### PR TITLE
Move from `i18n.json` to `Cargo.toml` metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ And the files must look like this:
 
 All locales files need to have exactly the same keys.
 
+If you need your locales to be in a different folders than `./locales` you can specify the path in the configuration:
+
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+locales-dir = "./path/to/locales"
+```
+
 ### Loading the locales
 
 You can then use the `load_locales!()` macro in a module of the project, this will load _at compile time_ the locales, and create a struct that describe your locales:

--- a/README.md
+++ b/README.md
@@ -21,22 +21,21 @@ view! { cx,
 }
 ```
 
-You just need a configuration file named `i18n.json` and one file per locale name `{locale}.json` in the `/locales` folder of your application.
+You just need to declare the locales in you `Cargo.toml` and one file per locale named `{locale}.json` in the `/locales` folder of your application.
 
 ## How to use
 
 ### Configuration files
 
-There are files that need to exist, the first one is the `i18n.json` file that describe the default locale and supported locales, it need to be at the root of the project and look like this:
+First You need to declare your locales in your cargo manifest `Cargo.toml`:
 
-```json
-{
-  "default": "en",
-  "locales": ["en", "fr"]
-}
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
 ```
 
-The other ones are the files containing the translation, they are key-value pairs and need to be situated in the `/locales` directory at root of the project, they should be named `{locale}.json`, one per locale defined in the `i18n.json` file.
+You can then put your translations files in the `/locales` directory at root of the project, they should be named `{locale}.json`, one per locale declared in the configuration.
 
 The file structure must look like this:
 
@@ -385,14 +384,13 @@ You can also have multiple conditions:
 
 ### Namespaces
 
-Being constrained to put every translation in one unique file can make the locale file overly big, and keys must be unique making things even more complex. To avoid this situation you can introduce namespaces in the config file (i18n.json):
+Being constrained to put every translation in one unique file can make the locale file overly big, and keys must be unique making things even more complex. To avoid this situation you can introduce namespaces in the configuration:
 
-```json
-{
-  "default": "en",
-  "locales": ["en", "fr"],
-  "namespaces": ["common", "home"]
-}
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+namespaces = ["common", "home"]
 ```
 
 Then your file structures must look like this int the `/locales` directory:

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -36,6 +36,10 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "counter"

--- a/examples/counter/i18n.json
+++ b/examples/counter/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}

--- a/examples/counter_plurals/Cargo.toml
+++ b/examples/counter_plurals/Cargo.toml
@@ -36,6 +36,10 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "counter"

--- a/examples/counter_plurals/i18n.json
+++ b/examples/counter_plurals/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}

--- a/examples/hello_world_actix/Cargo.toml
+++ b/examples/hello_world_actix/Cargo.toml
@@ -36,6 +36,10 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "hello_world_actix"

--- a/examples/hello_world_actix/i18n.json
+++ b/examples/hello_world_actix/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -42,6 +42,10 @@ ssr = [
     "leptos_i18n/axum",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "hello_world_axum"

--- a/examples/hello_world_axum/i18n.json
+++ b/examples/hello_world_axum/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}

--- a/examples/interpolation/Cargo.toml
+++ b/examples/interpolation/Cargo.toml
@@ -36,6 +36,10 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "interpolation"

--- a/examples/interpolation/i18n.json
+++ b/examples/interpolation/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}

--- a/examples/namespaces/Cargo.toml
+++ b/examples/namespaces/Cargo.toml
@@ -36,6 +36,11 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+namespaces = ["change_locale", "counter"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "namespaces"

--- a/examples/namespaces/i18n.json
+++ b/examples/namespaces/i18n.json
@@ -1,5 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"],
-    "namespaces": ["change_locale", "counter"]
-}

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -39,13 +39,12 @@
 //!
 //! # A Simple Counter
 //!
-//! `i18n.json`:
+//! `Cargo.toml`:
 //!
-//! ```json
-//! {
-//!     "default": "en",
-//!     "locales": ["en", "fr"]
-//! }
+//! ```toml
+//! [package.metadata.leptos-i18n]
+//! default = "en"
+//! locales = ["en", "fr"]
 //! ```
 //!
 //! `./locales/en.json`:

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = "2.0"
+toml = "0.7"
 
 [features]
 serde = []

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) mod t_macro;
 // this is to use serde::de::DeserializeSeed to pass information on what locale or key we are currently at
 // and give better information on what went wrong when an error is emitted.
 
-/// Look at the `i18n.json` configuration file at the root of the project and load the given locales.
+/// Look for the configuration in the cargo manifest `Cargo.toml` at the root of the project and load the given locales.
 ///
 /// It creates multiple types allowing to easily incorporate translations in you application such as:
 ///
@@ -23,7 +23,7 @@ pub(crate) mod t_macro;
 /// - `Locales`: an empty type that serves as a bridge beetween the two types.
 #[proc_macro]
 pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    match load_locales::load_locales(None::<String>) {
+    match load_locales::load_locales() {
         Ok(ts) => ts.into(),
         Err(err) => err.into(),
     }

--- a/leptos_i18n_macro/src/load_locales/cfg_file.rs
+++ b/leptos_i18n_macro/src/load_locales/cfg_file.rs
@@ -1,8 +1,10 @@
+use serde::de::DeserializeSeed;
+
 use super::{
     error::{Error, Result},
     key::{Key, KeySeed, KeyVecSeed},
 };
-use std::{collections::HashSet, fs::File, path::Path};
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub struct ConfigFile {
@@ -30,14 +32,24 @@ impl ConfigFile {
         duplicates
     }
 
-    pub fn new<T: AsRef<Path>>(path: Option<T>) -> Result<ConfigFile> {
-        let path = path
-            .as_ref()
-            .map(|path| path.as_ref())
-            .unwrap_or("./i18n.json".as_ref());
-        let cfg_file = File::open(path).map_err(Error::ConfigFileNotFound)?;
+    pub fn new() -> Result<ConfigFile> {
+        let cfg_file_str =
+            std::fs::read_to_string("./Cargo.toml").map_err(Error::ManifestNotFound)?;
 
-        let cfg: ConfigFile = serde_json::from_reader(cfg_file).map_err(Error::ConfigFileDeser)?;
+        let Some((before, i18n_cfg)) = cfg_file_str.split_once("[package.metadata.leptos-i18n]")
+        else {
+            return Err(Error::ConfigNotPresent);
+        };
+
+        // this is to have the correct line number in the reported error.
+        let cfg_file_whitespaced = before
+            .chars()
+            .filter(|c| *c == '\n')
+            .chain(i18n_cfg.chars())
+            .collect::<String>();
+
+        let cfg: ConfigFile =
+            toml::de::from_str(&cfg_file_whitespaced).map_err(Error::ConfigFileDeser)?;
 
         if !cfg.locales.contains(&cfg.default) {
             Err(Error::ConfigFileDefaultMissing(cfg))
@@ -55,6 +67,10 @@ impl ConfigFile {
     }
 }
 
+/// -----------------------------------------
+/// Deserialization
+/// -----------------------------------------
+
 struct CfgFileVisitor;
 
 impl<'de> serde::Deserialize<'de> for ConfigFile {
@@ -62,7 +78,7 @@ impl<'de> serde::Deserialize<'de> for ConfigFile {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_struct("ConfigFile", &["default", "locales"], CfgFileVisitor)
+        deserializer.deserialize_struct("ConfigFile", Field::FIELDS, CfgFileVisitor)
     }
 }
 
@@ -70,6 +86,11 @@ enum Field {
     Default,
     Locales,
     Namespaces,
+    Unknown,
+}
+
+impl Field {
+    const FIELDS: &'static [&'static str] = &["default", "locales, namespaces"];
 }
 
 struct FieldVisitor;
@@ -89,7 +110,8 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             formatter,
-            "an identifier for the field \"default\" or the field \"locales\""
+            "an identifier for the fields {:?}",
+            Field::FIELDS
         )
     }
 
@@ -101,7 +123,7 @@ impl<'de> serde::de::Visitor<'de> for FieldVisitor {
             "default" => Ok(Field::Default),
             "locales" => Ok(Field::Locales),
             "namespaces" => Ok(Field::Namespaces),
-            _ => Err(E::unknown_field(v, &["default", "locales"])),
+            _ => Ok(Field::Unknown), // skip unknown fields
         }
     }
 }
@@ -113,35 +135,43 @@ impl<'de> serde::de::Visitor<'de> for CfgFileVisitor {
     where
         A: serde::de::MapAccess<'de>,
     {
+        fn deser_field<'de, A, S, T>(
+            option: &mut Option<T>,
+            map: &mut A,
+            seed: S,
+            field_name: &'static str,
+        ) -> Result<(), A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+            S: DeserializeSeed<'de, Value = T>,
+        {
+            if option.replace(map.next_value_seed(seed)?).is_some() {
+                Err(serde::de::Error::duplicate_field(field_name))
+            } else {
+                Ok(())
+            }
+        }
         let mut default = None;
         let mut locales = None;
         let mut name_spaces = None;
         while let Some(field) = map.next_key::<Field>()? {
             match field {
                 Field::Default => {
-                    if default
-                        .replace(map.next_value_seed(KeySeed::LocaleName)?)
-                        .is_some()
-                    {
-                        return Err(serde::de::Error::duplicate_field("default"));
-                    }
+                    deser_field(&mut default, &mut map, KeySeed::LocaleName, "default")?
                 }
-                Field::Locales => {
-                    if locales
-                        .replace(map.next_value_seed(KeyVecSeed(KeySeed::LocaleName))?)
-                        .is_some()
-                    {
-                        return Err(serde::de::Error::duplicate_field("locales"));
-                    }
-                }
-                Field::Namespaces => {
-                    if name_spaces
-                        .replace(map.next_value_seed(KeyVecSeed(KeySeed::Namespace))?)
-                        .is_some()
-                    {
-                        return Err(serde::de::Error::duplicate_field("locales"));
-                    }
-                }
+                Field::Locales => deser_field(
+                    &mut locales,
+                    &mut map,
+                    KeyVecSeed(KeySeed::LocaleName),
+                    "locales",
+                )?,
+                Field::Namespaces => deser_field(
+                    &mut name_spaces,
+                    &mut map,
+                    KeyVecSeed(KeySeed::Namespace),
+                    "namespaces",
+                )?,
+                Field::Unknown => continue,
             }
         }
         let Some(default) = default else {

--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     ManifestNotFound(std::io::Error),
     ConfigNotPresent,
     ConfigFileDeser(toml::de::Error),
-    ConfigFileDefaultMissing(ConfigFile),
+    ConfigFileDefaultMissing(Box<ConfigFile>),
     LocaleFileNotFound {
         locale: String,
         namespace: Option<String>, 

--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -5,8 +5,9 @@ use quote::quote;
 
 #[derive(Debug)]
 pub enum Error {
-    ConfigFileNotFound(std::io::Error),
-    ConfigFileDeser(serde_json::Error),
+    ManifestNotFound(std::io::Error),
+    ConfigNotPresent,
+    ConfigFileDeser(toml::de::Error),
     ConfigFileDefaultMissing(ConfigFile),
     LocaleFileNotFound {
         locale: String,
@@ -61,11 +62,14 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::ConfigFileNotFound(err) => {
-                write!(f, "Could not found configuration file (i18n.json) : {}", err)
+            Error::ManifestNotFound(err) => {
+                write!(f, "Error accessing cargo manifest (Cargo.toml) : {}", err)
+            },
+            Error::ConfigNotPresent => {
+                write!(f, "Could not found \"[package.metadata.leptos-i18n]\" in cargo manifest (Cargo.toml)")
             }
             Error::ConfigFileDeser(err) => {
-                write!(f, "Parsing of configuration file (i18n.json) failed: {}", err)
+                write!(f, "Parsing of cargo manifest (Cargo.toml) failed: {}", err)
             }
             Error::ConfigFileDefaultMissing(cfg_file) => write!(f,
                 "{:?} is set as default locale but is not in the locales list: {:?}",
@@ -139,7 +143,7 @@ impl Display for Error {
                 locale_name, namespace, locale_key, plural, plural_type
             ),
             Error::DuplicateLocalesInConfig(duplicates) => write!(f,
-                "Found duplicates locales in configuration file (i18n.json): {:?}", 
+                "Found duplicates locales in configuration (Cargo.toml): {:?}", 
                 duplicates
             ),
             Error::InvalidBoundEnd {
@@ -203,7 +207,7 @@ impl Display for Error {
                 name
             ),
             Error::DuplicateNamespacesInConfig(duplicates) => write!(f,
-                "Found duplicates namespaces in configuration file (i18n.json): {:?}", 
+                "Found duplicates namespaces in configuration (Cargo.toml): {:?}", 
                 duplicates
             ),
             Error::PluralTypeMissmatch { locale_key, namespace: Some(namespace) } => write!(f, "In namespace {:?} at key {:?} the plurals types don't match across locales", namespace, locale_key),

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -31,10 +31,10 @@ pub enum BuildersKeys<'a> {
 }
 
 impl Namespace {
-    pub fn new(key: &Key, locale_keys: &[Key]) -> Result<Self> {
+    pub fn new(locales_dir: &str, key: &Key, locale_keys: &[Key]) -> Result<Self> {
         let mut locales = Vec::with_capacity(locale_keys.len());
         for locale in locale_keys {
-            let path = format!("./locales/{}/{}.json", locale.name, key.name);
+            let path = format!("{}/{}/{}.json", locales_dir, locale.name, key.name);
             locales.push(Locale::new(path, locale, Some(&key.name))?);
         }
         Ok(Namespace {
@@ -47,16 +47,17 @@ impl Namespace {
 impl LocalesOrNamespaces {
     pub fn new(cfg_file: &ConfigFile) -> Result<Self> {
         let locale_keys = &cfg_file.locales;
+        let locales_dir = cfg_file.locales_dir.as_ref();
         if let Some(namespace_keys) = &cfg_file.name_spaces {
             let mut namespaces = Vec::with_capacity(namespace_keys.len());
             for namespace in namespace_keys {
-                namespaces.push(Namespace::new(namespace, locale_keys)?);
+                namespaces.push(Namespace::new(locales_dir, namespace, locale_keys)?);
             }
             Ok(LocalesOrNamespaces::NameSpaces(namespaces))
         } else {
             let mut locales = Vec::with_capacity(locale_keys.len());
             for locale in locale_keys {
-                let path = format!("./locales/{}.json", locale.name);
+                let path = format!("{}/{}.json", locales_dir, locale.name);
                 locales.push(Locale::new(path, locale, None)?);
             }
             Ok(LocalesOrNamespaces::Locales(locales))

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Not, path::Path};
+use std::{collections::HashMap, ops::Not};
 
 pub mod cfg_file;
 pub mod error;
@@ -18,8 +18,8 @@ use quote::{format_ident, quote};
 
 use self::locale::{BuildersKeys, BuildersKeysInner, LocalesOrNamespaces, Namespace};
 
-pub fn load_locales(cfg_file_path: Option<impl AsRef<Path>>) -> Result<TokenStream> {
-    let cfg_file = ConfigFile::new(cfg_file_path)?;
+pub fn load_locales() -> Result<TokenStream> {
+    let cfg_file = ConfigFile::new()?;
 
     let locales = LocalesOrNamespaces::new(&cfg_file)?;
 

--- a/tests/namespaces/Cargo.toml
+++ b/tests/namespaces/Cargo.toml
@@ -36,6 +36,11 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+namespaces = ["first_namespace", "second_namespace"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "namespaces"

--- a/tests/namespaces/i18n.json
+++ b/tests/namespaces/i18n.json
@@ -1,5 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"],
-    "namespaces": ["first_namespace", "second_namespace"]
-}

--- a/tests/no_namespaces/Cargo.toml
+++ b/tests/no_namespaces/Cargo.toml
@@ -36,6 +36,10 @@ ssr = [
     "leptos_i18n/actix",
 ]
 
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
 output-name = "no_namespaces"

--- a/tests/no_namespaces/i18n.json
+++ b/tests/no_namespaces/i18n.json
@@ -1,4 +1,0 @@
-{
-    "default": "en",
-    "locales": ["en", "fr"]
-}


### PR DESCRIPTION
Configuration will now be situated in the cargo manifest instead of it's own file.

close #25 