### PR TITLE
Better errors when missing/duplicate interpolation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The `serde` feature implement `serde::Serialize` and `serde::Deserialize` for th
 
 The `nightly` feature enable to do `i18n()` to get the locale instead of `i18n.get_locale()` and `i18n(new_locale)` instead of `i18n.set_locale(new_locale)`.
 
-The `debug_interpolations` feature enable the macros to generate code to emit a warning if a key is supplied twice in interpolations.
+The `debug_interpolations` feature enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 This is a feature as this code is not "necessary" and could slow compile times,
 advice is to enable it for debug builds but disable it for release builds.
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,10 @@ The `serde` feature implement `serde::Serialize` and `serde::Deserialize` for th
 
 The `nightly` feature enable to do `i18n()` to get the locale instead of `i18n.get_locale()` and `i18n(new_locale)` instead of `i18n.set_locale(new_locale)`.
 
+The `debug_interpolations` feature enable the macros to generate code to emit a warning if a key is supplied twice in interpolations.
+This is a feature as this code is not "necessary" and could slow compile times,
+advice is to enable it for debug builds but disable it for release builds.
+
 ## Contributing
 
 Errors are a bit clunky or obscure for now, there is a lot of edge cases and I did not had time to track every failing scenario, feel free to open an issue on github so I can improve those.

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/examples/counter_plurals/Cargo.toml
+++ b/examples/counter_plurals/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/examples/hello_world_actix/Cargo.toml
+++ b/examples/hello_world_actix/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -13,7 +13,9 @@ axum = { version = "0.6", optional = true }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_axum = { version = "0.4", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/interpolation/Cargo.toml
+++ b/examples/interpolation/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/examples/namespaces/Cargo.toml
+++ b/examples/namespaces/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -35,6 +35,7 @@ ssr = ["leptos/ssr", "leptos_meta/ssr"]
 actix = ["ssr", "dep:actix-web"]
 axum = ["ssr", "dep:axum", "dep:leptos_axum"]
 serde = ["leptos_i18n_macro/serde", "dep:serde"]
+debug_interpolations = ["leptos_i18n_macro/debug_interpolations"]
 
 
 [package.metadata.cargo-all-features]

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -35,7 +35,7 @@
 //! - `hydrate`: Enable this feature when building for the client.
 //! - `actix`: Enable this feature when building for the server with actix as the backend (can't be enabled with the `axum` feature).
 //! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `axum` feature).
-//! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations.
+//! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 //! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
 //!
 //! # A Simple Counter

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -35,6 +35,7 @@
 //! - `hydrate`: Enable this feature when building for the client.
 //! - `actix`: Enable this feature when building for the server with actix as the backend (can't be enabled with the `axum` feature).
 //! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `axum` feature).
+//! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations.
 //! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
 //!
 //! # A Simple Counter

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -22,3 +22,4 @@ syn = "2.0"
 
 [features]
 serde = []
+debug_interpolations = []

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -207,6 +207,31 @@ impl<'a> InterpolateKey<'a> {
             InterpolateKey::Count(_) => None,
         }
     }
+
+    #[cfg(feature = "debug_interpolations")]
+    pub fn get_real_name(self) -> &'a str {
+        match self {
+            InterpolateKey::Count(_) => "count",
+            InterpolateKey::Variable(key) => key.name.strip_prefix("var_").unwrap(),
+            InterpolateKey::Component(key) => key.name.strip_prefix("comp_").unwrap(),
+        }
+    }
+
+    pub fn get_generic(self) -> TokenStream {
+        match self {
+            InterpolateKey::Variable(_) => {
+                quote!(leptos::IntoView + core::clone::Clone + 'static)
+            }
+            InterpolateKey::Count(plural_type) => {
+                quote!(Fn() -> #plural_type + core::clone::Clone + 'static)
+            }
+            InterpolateKey::Component(_) => quote!(
+                Fn(leptos::Scope, leptos::ChildrenFn) -> leptos::View
+                    + core::clone::Clone
+                    + 'static
+            ),
+        }
+    }
 }
 
 impl<'a> ToTokens for InterpolateKey<'a> {

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -24,13 +24,26 @@ pub fn t_macro_inner(input: ParsedInput) -> proc_macro2::TokenStream {
         }
     };
     if let Some(interpolations) = interpolations {
-        quote! {
-            move || {
-                let _key = #get_key;
-                #(
-                    let _key = _key.#interpolations;
-                )*
-                _key
+        if cfg!(feature = "debug_interpolations") {
+            quote! {
+                move || {
+                    let _key = #get_key;
+                    #(
+                        let _key = _key.#interpolations;
+                    )*
+                    #[deny(deprecated)]
+                    _key.build()
+                }
+            }
+        } else {
+            quote! {
+                move || {
+                    let _key = #get_key;
+                    #(
+                        let _key = _key.#interpolations;
+                    )*
+                    _key
+                }
             }
         }
     } else {

--- a/tests/namespaces/Cargo.toml
+++ b/tests/namespaces/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }

--- a/tests/no_namespaces/Cargo.toml
+++ b/tests/no_namespaces/Cargo.toml
@@ -14,7 +14,9 @@ actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
 leptos = "0.4.8"
 leptos_meta = { version = "0.4" }
 leptos_actix = { version = "0.4.8", optional = true }
-leptos_i18n.path = "../../leptos_i18n"
+leptos_i18n = { path = "../../leptos_i18n", features = [
+    "debug_interpolations",
+] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "=0.2.87", optional = true }


### PR DESCRIPTION
It was before possible to supply twice the same value for interpolation without triggering any warning, this behavior is acceptable but not what you want.

This PR allow to create a warning when a key is supplied twice, this warning is emitted:

```bash
warning: use of deprecated method `i18n::builders::click_count_builder::<__count>::var_count`: variable `count` is already set
  --> src\app.rs:36:42
   |
36 |         <p>{t!(i18n, click_count, count, count)}</p>
   |                                          ^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

Usage of `#[deprecated]` does not output the best message but is the best solution provided by Rust to do this kind of thing for the moment.

See #30 