### PR TITLE
Expand locales in mod

### DIFF
--- a/examples/counter/src/app.rs
+++ b/examples/counter/src/app.rs
@@ -1,12 +1,11 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -24,7 +23,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 

--- a/examples/counter/src/i18n.rs
+++ b/examples/counter/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/examples/counter_plurals/src/app.rs
+++ b/examples/counter_plurals/src/app.rs
@@ -1,12 +1,11 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -24,7 +23,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 

--- a/examples/counter_plurals/src/i18n.rs
+++ b/examples/counter_plurals/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/counter_plurals/src/lib.rs
+++ b/examples/counter_plurals/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/examples/hello_world_actix/src/app.rs
+++ b/examples/hello_world_actix/src/app.rs
@@ -1,14 +1,13 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    leptos_i18n::provide_i18n_context::<Locales>();
+    provide_i18n_context();
 
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {

--- a/examples/hello_world_actix/src/i18n.rs
+++ b/examples/hello_world_actix/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/hello_world_actix/src/lib.rs
+++ b/examples/hello_world_actix/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/examples/hello_world_axum/src/app.rs
+++ b/examples/hello_world_axum/src/app.rs
@@ -1,14 +1,13 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    leptos_i18n::provide_i18n_context::<Locales>();
+    provide_i18n_context();
 
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 

--- a/examples/hello_world_axum/src/i18n.rs
+++ b/examples/hello_world_axum/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/hello_world_axum/src/lib.rs
+++ b/examples/hello_world_axum/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod app;
 #[cfg(feature = "ssr")]
 pub mod fileserv;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/examples/interpolation/src/app.rs
+++ b/examples/interpolation/src/app.rs
@@ -1,12 +1,11 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -24,7 +23,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 

--- a/examples/interpolation/src/i18n.rs
+++ b/examples/interpolation/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/interpolation/src/lib.rs
+++ b/examples/interpolation/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/examples/namespaces/src/app.rs
+++ b/examples/namespaces/src/app.rs
@@ -1,12 +1,11 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -24,7 +23,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 

--- a/examples/namespaces/src/i18n.rs
+++ b/examples/namespaces/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/examples/namespaces/src/lib.rs
+++ b/examples/namespaces/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -98,7 +98,7 @@ pub fn provide_i18n_context<T: Locales>() -> I18nContext<T> {
 /// ## Panic
 ///
 /// Panics if the context is missing.
-pub fn get_context<T: Locales>() -> I18nContext<T> {
+pub fn use_i18n_context<T: Locales>() -> I18nContext<T> {
     use_context().expect("I18nContext is missing, use provide_i18n_context() to provide it.")
 }
 

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -71,14 +71,14 @@
 //!
 //! ```rust,ignore
 //! leptos_i18n::load_locales!();
+//! use i18n::*; // `i18n` module created by the macro above
 //! use leptos::*;
-//! use leptos_i18n::t;
 //!
 //! #[component]
 //! pub fn App() -> impl IntoView {
 //!     leptos_meta::provide_meta_context();
 //!
-//!     let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+//!     let i18n = provide_i18n_context();
 //!
 //!     let on_switch = move |_| {
 //!         let new_lang = match i18n.get_locale() {
@@ -96,7 +96,7 @@
 //!
 //! #[component]
 //! fn Counter() -> impl IntoView {
-//!     let i18n = i18n_context();
+//!     let i18n = use_i18n();
 //!
 //!     let (counter, set_counter) = create_signal( 0);
 //!
@@ -106,6 +106,9 @@
 //!
 //!     view! {
 //!         <p>{t!(i18n, click_count, count)}</p>
+//!         // Equivalent to:
+//!         // <p>{t!(i18n, click_count, count = count)}</p>
+//!         // Could also be wrote:
 //!         // <p>{t!(i18n, click_count, count = move || counter.get())}</p>
 //!         <button on:click=inc>{t!(i18n, click_to_inc)}</button>
 //!     }
@@ -123,7 +126,7 @@ pub(crate) const COOKIE_PREFERED_LANG: &str = "i18n_pref_locale";
 
 pub use locale_traits::*;
 
-pub use context::{get_context, provide_i18n_context, I18nContext};
+pub use context::{provide_i18n_context, use_i18n_context, I18nContext};
 
 pub use leptos_i18n_macro::{load_locales, t};
 

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -43,10 +43,12 @@ pub fn load_locales() -> Result<TokenStream> {
 
             #locale_type
 
+            #[inline]
             pub fn use_i18n() -> leptos_i18n::I18nContext<Locales> {
                 leptos_i18n::use_i18n_context()
             }
 
+            #[inline]
             pub fn provide_i18n_context() -> leptos_i18n::I18nContext<Locales> {
                 leptos_i18n::provide_i18n_context()
             }

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -36,11 +36,23 @@ pub fn load_locales() -> Result<TokenStream> {
     let locales = create_locales_type(&cfg_file);
 
     Ok(quote! {
-        #locales
+        pub mod i18n {
+            #locales
 
-        #locale_variants
+            #locale_variants
 
-        #locale_type
+            #locale_type
+
+            pub fn use_i18n() -> leptos_i18n::I18nContext<Locales> {
+                leptos_i18n::use_i18n_context()
+            }
+
+            pub fn provide_i18n_context() -> leptos_i18n::I18nContext<Locales> {
+                leptos_i18n::provide_i18n_context()
+            }
+
+            pub use leptos_i18n::t;
+        }
     })
 }
 

--- a/tests/namespaces/src/app.rs
+++ b/tests/namespaces/src/app.rs
@@ -1,4 +1,4 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::{provide_i18n_context, use_i18n, LocaleEnum, Locales};
 use leptos::*;
 use leptos_i18n::t;
 
@@ -6,7 +6,7 @@ use leptos_i18n::t;
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -24,7 +24,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 
@@ -41,7 +41,7 @@ fn Counter() -> impl IntoView {
 
 #[component]
 fn Tests() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     view! {
         <p>{t!(i18n, first_namespace.common_key)}</p>

--- a/tests/namespaces/src/app.rs
+++ b/tests/namespaces/src/app.rs
@@ -1,6 +1,5 @@
-use crate::i18n::{provide_i18n_context, use_i18n, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {

--- a/tests/namespaces/src/i18n.rs
+++ b/tests/namespaces/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/tests/namespaces/src/lib.rs
+++ b/tests/namespaces/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/tests/no_namespaces/src/app.rs
+++ b/tests/no_namespaces/src/app.rs
@@ -1,6 +1,5 @@
-use crate::i18n::{provide_i18n_context, use_i18n, LocaleEnum, Locales};
+use crate::i18n::*;
 use leptos::*;
-use leptos_i18n::t;
 
 #[component]
 pub fn App() -> impl IntoView {

--- a/tests/no_namespaces/src/app.rs
+++ b/tests/no_namespaces/src/app.rs
@@ -1,4 +1,4 @@
-use crate::i18n::{i18n_context, LocaleEnum, Locales};
+use crate::i18n::{provide_i18n_context, use_i18n, LocaleEnum, Locales};
 use leptos::*;
 use leptos_i18n::t;
 
@@ -6,7 +6,7 @@ use leptos_i18n::t;
 pub fn App() -> impl IntoView {
     leptos_meta::provide_meta_context();
 
-    let i18n = leptos_i18n::provide_i18n_context::<Locales>();
+    let i18n = provide_i18n_context();
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
@@ -25,7 +25,7 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Counter() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     let (counter, set_counter) = create_signal(0);
 
@@ -42,7 +42,7 @@ fn Counter() -> impl IntoView {
 
 #[component]
 fn Tests() -> impl IntoView {
-    let i18n = i18n_context();
+    let i18n = use_i18n();
 
     view! {
         <p>{t!(i18n, f32_plural, count = || 42f32)}</p>

--- a/tests/no_namespaces/src/i18n.rs
+++ b/tests/no_namespaces/src/i18n.rs
@@ -1,5 +1,0 @@
-leptos_i18n::load_locales!();
-
-pub fn i18n_context() -> leptos_i18n::I18nContext<Locales> {
-    leptos_i18n::get_context()
-}

--- a/tests/no_namespaces/src/lib.rs
+++ b/tests/no_namespaces/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 pub mod app;
-pub mod i18n;
+leptos_i18n::load_locales!();
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]


### PR DESCRIPTION
Instead of expanding the macro elements in the current module, create module that contain all elements.

Also expose a wrapper for `provide_i18n_context` and `use_i18n_context` using the created `Locales` type.

And re-export the `t!` macro for commodity.

```rust
pub mod i18n {
    pub struct I18nKeys {
        // ...
    }
    
    pub enum LocaleEnum {
        // ...
    }
    
    pub struct Locales;

    pub fn provide_i18n_context();

    pub fn use_i18n();

    pub use leptos_i18n::t;
}
```