### PR TITLE
Generate warnings on missing keys instead of hard error

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ Better compilation errors are generated for interpolations with 4 keys or less.
 This is a feature as this code is not "necessary" and could slow compile times,
 advice is to enable it for debug builds but disable it for release builds.
 
+The `supress_key_warnings` feature remove the warning emission of the `load_locales!()` macro when some keys are missing or ignored.
+
 ## Contributing
 
 Errors are a bit clunky or obscure for now, there is a lot of edge cases and I did not had time to track every failing scenario, feel free to open an issue on github so I can improve those.

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -22,7 +22,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 
 [features]
 default = ["cookie"]
-nightly = ["leptos/nightly", "leptos_meta/nightly"]
+nightly = ["leptos/nightly", "leptos_meta/nightly", "leptos_i18n_macro/nightly"]
 cookie = []
 hydrate = [
     "leptos/hydrate",

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -35,7 +35,7 @@ actix = ["ssr", "dep:actix-web"]
 axum = ["ssr", "dep:axum", "dep:leptos_axum"]
 serde = ["leptos_i18n_macro/serde"]
 debug_interpolations = ["leptos_i18n_macro/debug_interpolations"]
-supress_warnings = ["leptos_i18n_macro/supress_warnings"]
+supress_key_warnings = ["leptos_i18n_macro/supress_key_warnings"]
 
 
 [package.metadata.cargo-all-features]

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -35,6 +35,7 @@ actix = ["ssr", "dep:actix-web"]
 axum = ["ssr", "dep:axum", "dep:leptos_axum"]
 serde = ["leptos_i18n_macro/serde"]
 debug_interpolations = ["leptos_i18n_macro/debug_interpolations"]
+supress_warnings = ["leptos_i18n_macro/supress_warnings"]
 
 
 [package.metadata.cargo-all-features]

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `axum` feature).
 //! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 //! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
+//! - `supress_key_warnings`: Disable the warning emission of the `load_locales!()` macro when some keys are missing or ignored.
 //!
 //! # A Simple Counter
 //!

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -25,3 +25,6 @@ toml = "0.7"
 serde = []
 debug_interpolations = []
 nightly = []
+
+[package.metadata.cargo-all-features]
+denylist = ["nightly"]

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -22,9 +22,11 @@ syn = "2.0"
 toml = "0.7"
 
 [features]
+# default = ["supress_warnings"]
 serde = []
 debug_interpolations = []
 nightly = []
+supress_warnings = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly"]

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -22,11 +22,11 @@ syn = "2.0"
 toml = "0.7"
 
 [features]
-# default = ["supress_warnings"]
+# default = ["supress_key_warnings"]
 serde = []
 debug_interpolations = []
 nightly = []
-supress_warnings = []
+supress_key_warnings = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly"]

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -24,3 +24,4 @@ toml = "0.7"
 [features]
 serde = []
 debug_interpolations = []
+nightly = []

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(warnings)]
+#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
 //! # About Leptos i18n macro
 //!
 //! This crate expose the utility macro for `leptos_i18n`

--- a/leptos_i18n_macro/src/load_locales/cfg_file.rs
+++ b/leptos_i18n_macro/src/load_locales/cfg_file.rs
@@ -56,7 +56,9 @@ impl ConfigFile {
             // put default as first locale
             cfg.locales.swap(0, i);
         } else {
-            return Err(Error::ConfigFileDefaultMissing(Box::new(cfg)));
+            let len = cfg.locales.len();
+            cfg.locales.push(Rc::clone(&cfg.default));
+            cfg.locales.swap(0, len);
         }
 
         if let Some(duplicates) = Self::contain_duplicates(&cfg.locales) {

--- a/leptos_i18n_macro/src/load_locales/cfg_file.rs
+++ b/leptos_i18n_macro/src/load_locales/cfg_file.rs
@@ -49,12 +49,17 @@ impl ConfigFile {
             .chain(i18n_cfg.chars())
             .collect::<String>();
 
-        let cfg: ConfigFile =
+        let mut cfg: ConfigFile =
             toml::de::from_str(&cfg_file_whitespaced).map_err(Error::ConfigFileDeser)?;
 
-        if !cfg.locales.contains(&cfg.default) {
-            Err(Error::ConfigFileDefaultMissing(Box::new(cfg)))
-        } else if let Some(duplicates) = Self::contain_duplicates(&cfg.locales) {
+        if let Some(i) = cfg.locales.iter().position(|l| l == &cfg.default) {
+            // put default as first locale
+            cfg.locales.swap(0, i);
+        } else {
+            return Err(Error::ConfigFileDefaultMissing(Box::new(cfg)));
+        }
+
+        if let Some(duplicates) = Self::contain_duplicates(&cfg.locales) {
             Err(Error::DuplicateLocalesInConfig(duplicates))
         } else if let Some(duplicates) = cfg
             .name_spaces

--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, fmt::Display, rc::Rc};
 
 use super::{
-    cfg_file::ConfigFile,
     key::{Key, KeyPath},
     plural::PluralType,
 };
@@ -12,7 +11,6 @@ pub enum Error {
     ManifestNotFound(std::io::Error),
     ConfigNotPresent,
     ConfigFileDeser(toml::de::Error),
-    ConfigFileDefaultMissing(Box<ConfigFile>),
     LocaleFileNotFound {
         path: String,
         err: std::io::Error,
@@ -72,10 +70,6 @@ impl Display for Error {
             Error::ConfigFileDeser(err) => {
                 write!(f, "Parsing of cargo manifest (Cargo.toml) failed: {}", err)
             }
-            Error::ConfigFileDefaultMissing(cfg_file) => write!(f,
-                "{:?} is set as default locale but is not in the locales list: {:?}",
-                cfg_file.default, cfg_file.locales
-            ),
             Error::LocaleFileNotFound { path, err} => {
                 write!(f,
                     "Could not found file {:?} : {}",

--- a/leptos_i18n_macro/src/load_locales/key.rs
+++ b/leptos_i18n_macro/src/load_locales/key.rs
@@ -53,23 +53,36 @@ impl quote::ToTokens for Key {
     }
 }
 
-#[derive(Default, Debug)]
-pub struct KeyPath(Vec<Rc<Key>>);
+#[derive(Debug, Clone, Default)]
+pub struct KeyPath {
+    namespace: Option<Rc<Key>>,
+    path: Vec<Rc<Key>>,
+}
 
 impl KeyPath {
+    pub fn new(namespace: Option<Rc<Key>>) -> Self {
+        KeyPath {
+            namespace,
+            path: vec![],
+        }
+    }
+
     pub fn push_key(&mut self, key: Rc<Key>) {
-        self.0.push(key);
+        self.path.push(key);
     }
 
     pub fn pop_key(&mut self) {
-        self.0.pop();
+        self.path.pop();
     }
 }
 
 impl Display for KeyPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("\"")?;
-        let mut iter = self.0.iter();
+        if let Some(namespace) = &self.namespace {
+            write!(f, "{}::", namespace.name)?;
+        }
+        let mut iter = self.path.iter();
         if let Some(first) = iter.next() {
             f.write_str(&first.name)?;
             for key in iter {

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -1,0 +1,79 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use super::key::{Key, KeyPath};
+use std::{cell::RefCell, fmt::Display, rc::Rc};
+
+#[derive(Debug)]
+pub enum Warning {
+    MissingKey { locale: Rc<Key>, key_path: KeyPath },
+    SurplusKey { locale: Rc<Key>, key_path: KeyPath },
+}
+
+thread_local! {
+    pub static WARNINGS: RefCell<Vec<Warning>> = const { RefCell::new(Vec::new()) };
+}
+
+pub fn emit_warning(warning: Warning) {
+    WARNINGS.with_borrow_mut(|warnings| warnings.push(warning));
+}
+
+impl Display for Warning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Warning::MissingKey { locale, key_path } => {
+                write!(f, "Missing key {} in locale {:?}", key_path, locale)
+            }
+            Warning::SurplusKey { locale, key_path } => write!(
+                f,
+                "Key {} is present in locale {:?} but not in default locale, it is ignored",
+                key_path, locale
+            ),
+        }
+    }
+}
+
+impl Warning {
+    fn to_fn(&self, index: usize) -> TokenStream {
+        let msg = self.to_string();
+        let fn_name = format_ident!("w{}", index);
+        quote! {
+            #[deprecated(note = #msg)]
+            fn #fn_name() {
+                unimplemented!()
+            }
+        }
+    }
+}
+
+fn generate_warnings_inner(warnings: &[Warning]) -> TokenStream {
+    let warning_fns = warnings.iter().enumerate().map(|(i, w)| w.to_fn(i));
+
+    let fn_calls = (0..warnings.len()).map(|i| {
+        let fn_name = format_ident!("w{}", i);
+        quote!(#fn_name();)
+    });
+
+    quote! {
+        #[allow(unused)]
+        fn emit_warnings() {
+            #(
+                #warning_fns
+            )*
+
+            #(
+                #fn_calls
+            )*
+        }
+    }
+}
+
+pub fn generate_warnings() -> Option<TokenStream> {
+    WARNINGS.with_borrow(|ws| {
+        if ws.is_empty() {
+            None
+        } else {
+            Some(generate_warnings_inner(ws))
+        }
+    })
+}

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -16,7 +16,9 @@ thread_local! {
 }
 
 pub fn emit_warning(warning: Warning) {
-    WARNINGS.with(|warnings| warnings.borrow_mut().push(warning));
+    if !cfg!(feature = "supress_warnings") {
+        WARNINGS.with(|warnings| warnings.borrow_mut().push(warning));
+    }
 }
 
 impl Display for Warning {

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -16,7 +16,7 @@ thread_local! {
 }
 
 pub fn emit_warning(warning: Warning) {
-    if !cfg!(feature = "supress_warnings") {
+    if !cfg!(feature = "supress_key_warnings") {
         WARNINGS.with(|warnings| warnings.borrow_mut().push(warning));
     }
 }

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -85,19 +85,20 @@ fn generate_warnings_inner(warnings: &[Warning]) -> TokenStream {
 
 #[cfg(not(feature = "nightly"))]
 pub fn generate_warnings() -> Option<TokenStream> {
-    WARNINGS.with_borrow(|ws| {
+    WARNINGS.with(|cell| {
+        let ws = cell.borrow();
         if ws.is_empty() {
             None
         } else {
-            Some(generate_warnings_inner(ws))
+            Some(generate_warnings_inner(&ws))
         }
     })
 }
 
 #[cfg(feature = "nightly")]
 pub fn generate_warnings() -> Option<TokenStream> {
-    WARNINGS.with_borrow(|ws| {
-        for warning in ws {
+    WARNINGS.with(|ws| {
+        for warning in ws.borrow().iter() {
             warning.emit();
         }
         None

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -71,7 +71,7 @@ fn generate_warnings_inner(warnings: &[Warning]) -> TokenStream {
 
     quote! {
         #[allow(unused)]
-        fn emit_warnings() {
+        fn warnings() {
             #(
                 #warning_fns
             )*


### PR DESCRIPTION
When anything goes wrong with the locales declaration the macro hard error and no code is generated, this can be frustrating when you have multiple locales and just want to iterate with one locale as the code won't compile.

To mitigate this issue this PR change the behavior for 2 cases: missing key and surplus key. The macro will now concider the default locale to be the source of truth, so if a key is in the default, but not in another locale, the other locale has a missing key, if a key is present in another locale but not in the default, the other locale has a surplus key.

When a missing key is encounter, it will default to the value given to the default locale, and a warning be emitted:
```bash
warning: use of deprecated function `i18n::warnings::w0`: Missing key "click_to_inc" in locale "fr"
 --> src\lib.rs:4:1
  |
4 | leptos_i18n::load_locales!();
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
  = note: this warning originates in the macro `leptos_i18n::load_locales` (in Nightly builds, run with -Z macro-backtrace for more info)
```
When a surplus key is encounter, that key will be discarded and a warning will be emitted:
```bash
warning: use of deprecated function `i18n::warnings::w0`: Key "click_to_inc" is present in locale "fr" but not in default locale, it is ignored
 --> src\lib.rs:4:1
  |
4 | leptos_i18n::load_locales!();
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
  = note: this warning originates in the macro `leptos_i18n::load_locales` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The reason the warning comes from a deprecated fn is because it is the only way (for now) to generate warnings with custom message on the stable release: calling a function annotated with `#[deprecated(note = "custom warning")]`.

You can activate the "nigthly" feature to get  rid of the noise generated by such method:
```bash
warning: Missing key "click_to_inc" in locale "fr"
 --> src\lib.rs:4:1
  |
4 | leptos_i18n::load_locales!();
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this warning originates in the macro `leptos_i18n::load_locales` (in Nightly builds, run with -Z macro-backtrace for more info)
```
```bash
warning: Key "click_to_inc" is present in locale "fr" but not in default locale, it is ignored
 --> src\lib.rs:4:1
  |
4 | leptos_i18n::load_locales!();
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this warning originates in the macro `leptos_i18n::load_locales` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Project with `#![deny(warnings)]` will still have hard error, but only from the macro, not from all the bad import and missing keys ect...
This should overall allow a way better DX then the previous hard errors.

For those who want this behavior but without the warnings, you can enable the `supress_key_warnings` feature.

All other errors stay as error, if someone think an error should be turned into a warning, feel free to open an issue.

close #45 