### PR TITLE
feat: New `td!` macro to directly use a locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,30 @@ t!(i18n, $namespace::$key.$subkey)
 
 You can have as many namespaces as you want, but the name should be a valid rust identifier (same as component/variable names, `-` are replaced by `_`).
 
+### The `td!` macro (`d` for direct)
+
+The `td!` macro works just like the `t!` macro but instead of taking the context as it first argument it directly take the locale:
+
+```rust
+td!(LocaleEnum::fr, $key, ...)
+```
+
+This let you use a translation regardless of the the current locale, enabling the use of multiple locales at the same time:
+
+```rust
+use crate::i18n::LocaleEnum;
+use leptos_i18n::td;
+
+view! {
+  <p>"In English:"</p>
+  <p>{td!(LocaleEnumm::en, hello_world)}</p>
+  <p>"En Français:"</p>
+  <p>{td!(LocaleEnumm::fr, hello_world)}</p>
+}
+```
+
+(It's a shame `const` function are not allowed in traits, if that was the case the code outputed by `td!` would be entirly const, making it the same as directly pasting the locale)
+
 ### Examples
 
 If examples works better for you, you can look at the different examples available on the Github.

--- a/README.md
+++ b/README.md
@@ -526,9 +526,9 @@ use leptos_i18n::td;
 
 view! {
   <p>"In English:"</p>
-  <p>{td!(LocaleEnumm::en, hello_world)}</p>
+  <p>{td!(LocaleEnum::en, hello_world)}</p>
   <p>"En Français:"</p>
-  <p>{td!(LocaleEnumm::fr, hello_world)}</p>
+  <p>{td!(LocaleEnum::fr, hello_world)}</p>
 }
 ```
 

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -27,15 +27,13 @@ impl<T: Locales> I18nContext<T> {
     /// Return the keys for the current locale subscribing to any changes
     #[inline]
     pub fn get_keys(self) -> &'static T::LocaleKeys {
-        let variant = self.get_locale();
-        LocaleKeys::from_variant(variant)
+        self.get_locale().get_keys()
     }
 
     /// Return the keys for the current locale but does not subscribe to changes
     #[inline]
     pub fn get_keys_untracked(self) -> &'static T::LocaleKeys {
-        let variant = self.get_locale_untracked();
-        LocaleKeys::from_variant(variant)
+        self.get_locale_untracked().get_keys()
     }
 
     /// Set the locale and notify all subscribers

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -129,7 +129,7 @@ pub use locale_traits::*;
 
 pub use context::{provide_i18n_context, use_i18n_context, I18nContext};
 
-pub use leptos_i18n_macro::{load_locales, t};
+pub use leptos_i18n_macro::{load_locales, t, td};
 
 #[doc(hidden)]
 pub mod __private {

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -1,9 +1,10 @@
-// use serde::{de::DeserializeOwned, Serialize};
-
 /// Trait implemented the enum representing the supported locales of the application
 ///
 /// Appart from maybe `as_str` you will probably never need to use it has it only serves the internals of the library.
 pub trait LocaleVariant: 'static + Default + Clone + Copy {
+    /// The associated struct containing the translations
+    type Keys: LocaleKeys<Variants = Self>;
+
     /// Try to match the given str to a locale and returns it.
     fn from_str(s: &str) -> Option<Self>;
 
@@ -17,30 +18,36 @@ pub trait LocaleVariant: 'static + Default + Clone + Copy {
             .find_map(|l| Self::from_str(l.as_ref()))
             .unwrap_or_default()
     }
+
+    /// Return the keys based on self
+    #[inline]
+    fn get_keys(self) -> &'static Self::Keys {
+        LocaleKeys::from_variant(self)
+    }
 }
 
 /// Trait implemented the struct representing the translation keys
 ///
 /// You will probably never need to use it has it only serves the internals of the library.
 pub trait LocaleKeys: 'static + Clone + Copy {
-    /// The associated `Locales` types that serves as a bridge beetween the locale enum and the keys.
-    type Locales: Locales;
+    /// The associated enum representing the supported locales
+    type Variants: LocaleVariant<Keys = Self>;
 
     /// Create self according to the given locale.
-    fn from_variant(variant: <Self::Locales as Locales>::Variants) -> &'static Self;
+    fn from_variant(variant: Self::Variants) -> &'static Self;
 }
 
 /// This trait servers as a bridge beetween the locale enum and the keys struct
 pub trait Locales: 'static + Clone + Copy {
-    /// The enum that represent the different locales supported.
-    type Variants: LocaleVariant;
     /// The struct that represent the translations keys.
-    type LocaleKeys: LocaleKeys<Locales = Self>;
+    type LocaleKeys: LocaleKeys<Variants = Self::Variants>;
+    /// The enum that represent the different locales supported.
+    type Variants: LocaleVariant<Keys = Self::LocaleKeys>;
 
     /// Create the keys according to the given locale.
     #[inline]
     fn get_keys(locale: Self::Variants) -> &'static Self::LocaleKeys {
-        <Self::LocaleKeys as LocaleKeys>::from_variant(locale)
+        locale.get_keys()
     }
 }
 

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -35,11 +35,13 @@ pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream
 /// Usage:
 ///
 /// ```rust, ignore
+/// use crate::i18n::*;
+///
 /// let i18n = use_i18n();
 ///
 /// view! {
 ///     <p>{t!(i18n, $key)}</p>
-///     <p>{t!(i18n, $key, $variable = $value, <$component> = |children| view! { <b>{children()}</b> })}</p>
+///     <p>{t!(i18n, $key, $variable = $value, <$component> = |child| ... )}</p>
 /// }
 ///```
 ///
@@ -58,5 +60,25 @@ pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream
 /// ```
 #[proc_macro]
 pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens)
+    t_macro::t_macro(tokens, false)
+}
+
+/// Just like the `t!` macro but instead of taking `I18nContext` as the first argument it takes the desired locale.
+///
+/// Usage:
+///
+/// ```rust, ignore
+/// use crate::i18n::LocaleEnum;
+/// use leptos_i18n::td;
+///
+/// view! {
+///     <p>{td!(LocaleEnum::en, $key)}</p>
+///     <p>{td!(LocaleEnum::fr, $key, $variable = $value, <$component> = |child| ... )}</p>
+/// }
+///```
+///
+/// This let you use a specific locale regardless of the current one.
+#[proc_macro]
+pub fn td(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t_macro::t_macro(tokens, true)
 }

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -96,6 +96,8 @@ fn create_locales_enum(cfg_file: &ConfigFile) -> TokenStream {
         }
 
         impl leptos_i18n::LocaleVariant for LocaleEnum {
+            type Keys = I18nKeys;
+
             fn as_str(self) -> &'static str {
                 match self {
                     #(#as_str_match_arms,)*
@@ -292,7 +294,7 @@ fn create_locale_type_inner(
 
         let from_variant = quote! {
             impl leptos_i18n::LocaleKeys for #type_ident {
-                type Locales = Locales;
+                type Variants = LocaleEnum;
                 fn from_variant(_variant: LocaleEnum) -> &'static Self {
                     match _variant {
                         #(
@@ -435,7 +437,7 @@ fn create_namespaces_types(
         }
 
         impl leptos_i18n::LocaleKeys for #i18n_keys_ident {
-            type Locales = Locales;
+            type Variants = LocaleEnum;
             fn from_variant(_variant: LocaleEnum) -> &'static Self {
                 match _variant {
                     #(

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -52,7 +52,7 @@ pub fn load_locales() -> Result<TokenStream> {
                 leptos_i18n::provide_i18n_context()
             }
 
-            pub use leptos_i18n::t;
+            pub use leptos_i18n::{t, td};
 
             #warnings
         }

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -31,29 +31,17 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
         }
     };
     let inner = if let Some(interpolations) = interpolations {
-        if cfg!(feature = "debug_interpolations") {
-            quote! {
-                {
-                    let _key = #get_key;
-                    #(
-                        let _key = _key.#interpolations;
-                    )*
-                    #[deny(deprecated)]
-                    _key.build()
-                }
-            }
-        } else {
-            quote! {
-                {
-                    let _key = #get_key;
-                    #(
-                        let _key = _key.#interpolations;
-                    )*
-                    _key
-                }
+        quote! {
+            {
+                let _key = #get_key;
+                #(
+                    let _key = _key.#interpolations;
+                )*
+                #[deny(deprecated)]
+                _key.build()
             }
         }
-    } else if cfg!(feature = "debug_interpolations") {
+    } else {
         quote! {
             {
                 #[allow(unused)]
@@ -62,8 +50,6 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
                 _key.build()
             }
         }
-    } else {
-        get_key
     };
 
     if direct {

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -30,10 +30,10 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
             quote!(#get_keys.#namespace #(.#keys)*)
         }
     };
-    if let Some(interpolations) = interpolations {
+    let inner = if let Some(interpolations) = interpolations {
         if cfg!(feature = "debug_interpolations") {
             quote! {
-                move || {
+                {
                     let _key = #get_key;
                     #(
                         let _key = _key.#interpolations;
@@ -44,7 +44,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
             }
         } else {
             quote! {
-                move || {
+                {
                     let _key = #get_key;
                     #(
                         let _key = _key.#interpolations;
@@ -55,7 +55,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
         }
     } else if cfg!(feature = "debug_interpolations") {
         quote! {
-            move || {
+            {
                 #[allow(unused)]
                 use leptos_i18n::__private::BuildStr;
                 let _key = #get_key;
@@ -63,6 +63,12 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
             }
         }
     } else {
-        quote!(move || #get_key)
+        get_key
+    };
+
+    if direct {
+        inner
+    } else {
+        quote!(move || #inner)
     }
 }

--- a/leptos_i18n_macro/src/t_macro/parsed_input.rs
+++ b/leptos_i18n_macro/src/t_macro/parsed_input.rs
@@ -1,6 +1,6 @@
 use proc_macro2::Ident;
 use syn::token::Comma;
-use syn::Token;
+use syn::{Expr, Token};
 
 use super::interpolate::InterpolatedValue;
 
@@ -11,7 +11,7 @@ pub enum Keys {
 }
 
 pub struct ParsedInput {
-    pub context: Ident,
+    pub context: Expr,
     pub keys: Keys,
     pub interpolations: Option<Vec<InterpolatedValue>>,
 }


### PR DESCRIPTION
New utility macro that works like the `t!` macro but instead of taking the context as argument, take the desired locale:

```rust
use crate::i18n::{LocaleEnum, td};

td!(LocaleEnum::fr, hello_world)
```

This let you use a translation regardless of the current locale, enabling the use of multiple locales together:

```rust
use crate::i18n::{LocaleEnum, td};

view! {
  <p>"In English:"</p>
  <p>{td!(LocaleEnum::en, hello_world)}</p>
  <p>"En Français:"</p>
  <p>{td!(LocaleEnum::fr, hello_world)}</p>
}
```

This macro is re-exported in the `i18n` generated module, just like the `t!` macro.

## Note

This macro can be used outside leptos reactive system without problems, the return type is the same type of `I18nKeys.$key`, so if `hello_world` is a plain string `td!(LocaleEnum::fr, hello_world)` would return `&'static str`. You can therefore do:

```rust
let fr_hello_world: &'static str = td!(LocaleEnum::fr, hello_world);
```

If `I18nKeys.$key` need interpolations it will return the populated builder. The only usefull thing the builder implements is the `IntoView` trait. (Builder types are located in `i18n::builders::*_builder`, with * being the key name)


This was already possible to do, the `td!` macro just makes it easier, if you need a const access to the value you can still access the const struct of the desired locale:
```rust
const FR_HELLO_WORLD: &str = crate::i18n::I18nKeys::fr.hello_world;
```


