### PR TITLE
Explicit default

### DIFF
--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -57,6 +57,7 @@ pub enum Error {
         found: PluralType,
         expected: PluralType,
     },
+    ExplicitDefaultInDefault(KeyPath),
 }
 
 impl Display for Error {
@@ -133,6 +134,7 @@ impl Display for Error {
                 write!(f, "Missmatch value type beetween locale {:?} and default at key {}: one has subkeys and the other has direct value.", locale, key_path)
             },
             Error::PluralNumberType { found, expected } => write!(f, "number type {} can't be used for plural type {}", found, expected),
+            Error::ExplicitDefaultInDefault(key_path) => write!(f, "Explicit default (null) are not allowed in the default locale, at key {}.", key_path),
         }
     }
 }

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -175,12 +175,21 @@ impl Locale {
         let mut locales = locales.iter();
         let default_locale = locales.next().unwrap();
         let default_locale_ref = default_locale.borrow();
+        let mut key_path = KeyPath::new(namespace);
+
+        for (key, value) in &default_locale_ref.keys {
+            match value {
+                ParsedValue::Default => {
+                    key_path.push_key(Rc::clone(key));
+                    return Err(Error::ExplicitDefaultInDefault(key_path));
+                }
+                _ => continue,
+            }
+        }
 
         let mut default_keys = default_locale_ref.to_builder_keys();
 
         let default_locale_name = &default_locale_ref.name.name;
-
-        let mut key_path = KeyPath::new(namespace);
 
         for locale in locales {
             let top_locale = locale.borrow().name.clone();

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -134,12 +134,10 @@ impl Locale {
         &mut self,
         keys: &mut BuildersKeysInner,
         default_locale: &str,
-        default_values: &Self,
         top_locale: Rc<Key>,
         key_path: &mut KeyPath,
     ) -> Result<()> {
         for (key, keys) in &mut keys.0 {
-            let default_value = default_values.keys.get(key).unwrap();
             key_path.push_key(Rc::clone(key));
             let locale = self.name.clone();
             let value_entry = self.keys.entry(Rc::clone(key));
@@ -150,7 +148,7 @@ impl Locale {
                 });
                 ParsedValue::Default
             });
-            value.merge(keys, default_locale, default_value, locale, key_path)?;
+            value.merge(keys, default_locale, locale, key_path)?;
             key_path.pop_key();
         }
 
@@ -196,7 +194,6 @@ impl Locale {
             locale.borrow_mut().merge(
                 &mut default_keys,
                 default_locale_name,
-                &default_locale.borrow(),
                 top_locale,
                 &mut key_path,
             )?;
@@ -230,6 +227,7 @@ pub enum LocaleValue {
     Value(Option<HashSet<InterpolateKey>>),
     Subkeys {
         locales: Vec<Rc<RefCell<Locale>>>,
+        defaulted_locales: Vec<Rc<Key>>,
         keys: BuildersKeysInner,
     },
 }

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -96,7 +96,7 @@ impl LocalesOrNamespaces {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Locale {
     pub name: Rc<Key>,
-    pub keys: HashMap<Rc<Key>, Rc<ParsedValue>>,
+    pub keys: HashMap<Rc<Key>, ParsedValue>,
 }
 
 impl Locale {
@@ -148,7 +148,7 @@ impl Locale {
                     locale: top_locale.clone(),
                     key_path: key_path.clone(),
                 });
-                Rc::clone(default_value)
+                ParsedValue::Default
             });
             value.merge(keys, default_locale, default_value, locale, key_path)?;
             key_path.pop_key();
@@ -229,7 +229,7 @@ pub enum LocaleValue {
 pub struct LocaleSeed(pub Rc<Key>);
 
 impl<'de> serde::de::Visitor<'de> for LocaleSeed {
-    type Value = HashMap<Rc<Key>, Rc<ParsedValue>>;
+    type Value = HashMap<Rc<Key>, ParsedValue>;
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
@@ -242,7 +242,7 @@ impl<'de> serde::de::Visitor<'de> for LocaleSeed {
                 key: &locale_key,
                 in_plural: false,
             })?;
-            keys.insert(locale_key, Rc::new(value));
+            keys.insert(locale_key, value);
         }
 
         Ok(keys)


### PR DESCRIPTION
With #48 missing keys don't hard errors anymore, but generate a warning and default to whatever value the default locale has for this key.
But maybe you don't want the warning and want this to be the intended behavior, there is the `suppress_key_warnings` feature for that, but it completly disable the warnings for all keys, and you would want to very specifically select the keys and the locales where the warnings are removed.

This PR adress this, you can now explicitly declare that the value for this key is defaulted, you can do that by giving the value `null` to the key in the json file of the locale:


`en.json`:
```json
{
    "my_key": "whatever value"
}
```
`fr.json`:
```json
{
    "my_key": null
}
```
(with `en`being the default locale)

This will give to `my_key` the value in `en` for the locale `fr`, and will not emit a warning.

You can do this with string, interpolations, plurals and subkeys (so every value type).

Explicit defaults are not allowed in the default locale, for obvious reasons.