### PR TITLE
Explicit default

### DIFF
--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -57,6 +57,7 @@ pub enum Error {
         found: PluralType,
         expected: PluralType,
     },
+    ExplicitDefaultInDefault(KeyPath),
 }
 
 impl Display for Error {
@@ -133,6 +134,7 @@ impl Display for Error {
                 write!(f, "Missmatch value type beetween locale {:?} and default at key {}: one has subkeys and the other has direct value.", locale, key_path)
             },
             Error::PluralNumberType { found, expected } => write!(f, "number type {} can't be used for plural type {}", found, expected),
+            Error::ExplicitDefaultInDefault(key_path) => write!(f, "Explicit defaults (null) are not allowed in default locale, at key {}", key_path)
         }
     }
 }


### PR DESCRIPTION
With #48 missing keys don't hard errors anymore, but generate a warning and default to whatever value the default locale has for this key.
But maybe you don't want the warning and want this to be the intended behavior, there is the `suppress_key_warnings` feature for that, but it completly disable the warnings for all keys, and you would want to very specifically select the keys and the locales where the warnings are removed.

This PR adress this, you can now explicitly declare that the value for this key is defaulted, you can do that by giving the value `null` to the key in the json file of the locale:


`en.json`:
```json
{
    "my_key": "whatever value"
}
```
`fr.json`:
```json
{
    "my_key": null
}
```
(with `en`being the default locale)

This will give to `my_key` the value in `en` for the locale `fr`, and will not emit a warning.

You can do this with string, interpolations, plurals and subkeys (so every value type).

Explicit defaults are not allowed in the default locale, for obvious reasons.