### PR TITLE
Remove `Locales` type and `Locales` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,11 @@ struct I18nKeys {
 It also create an enum that describe the supported locales:
 
 ```rust
-enum LocaleEnum {
+enum Locale {
     en,
     fr
 }
 ```
-
-#### The glue
-
-It also declare a type `Locales` which unique pupose is to serves as a bridge beetween the two, most functions of the crate are generics over this type.
 
 #### Helper functions
 
@@ -185,7 +181,7 @@ The context implement 3 key functions: `.get_locale()`, `.get_keys()` and `.set_
 
 ### Accessing the current locale
 
-You may need to know what locale is currenly used, for that you can call `.get_locale` on the context, it will return the `LocaleEnum` defined by the `load_locales!()` macro. This function actually call `.get` on a signal, this means you should call it in a function like any signal.
+You may need to know what locale is currenly used, for that you can call `.get_locale` on the context, it will return the `Locale` defined by the `load_locales!()` macro. This function actually call `.get` on a signal, this means you should call it in a function like any signal.
 
 ### Accessing the keys
 
@@ -201,8 +197,8 @@ let i18n = use_i18n();
 let on_click = move |_| {
     let current_locale = i18n.get_locale();
     let new_locale = match current_locale {
-        LocaleEnum::en => LocaleEnum::fr,
-        LocaleEnum::fr => LocaleEnum::en,
+        Locale::en => Locale::fr,
+        Locale::fr => Locale::en,
     };
     i18n.set_locale(new_locale);
 };
@@ -522,7 +518,7 @@ You can have as many namespaces as you want, but the name should be a valid rust
 The `td!` macro works just like the `t!` macro but instead of taking the context as it first argument it directly take the locale:
 
 ```rust
-td!(LocaleEnum::fr, $key, ...)
+td!(Locale::fr, $key, ...)
 ```
 
 This let you use a translation regardless of the the current locale, enabling the use of multiple locales at the same time:
@@ -532,9 +528,9 @@ use crate::i18n::*;
 
 view! {
   <p>"In English:"</p>
-  <p>{td!(LocaleEnum::en, hello_world)}</p>
+  <p>{td!(Locale::en, hello_world)}</p>
   <p>"En Français:"</p>
-  <p>{td!(LocaleEnum::fr, hello_world)}</p>
+  <p>{td!(Locale::fr, hello_world)}</p>
 }
 ```
 

--- a/examples/counter/src/app.rs
+++ b/examples/counter/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/counter_plurals/src/app.rs
+++ b/examples/counter_plurals/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/hello_world_actix/src/app.rs
+++ b/examples/hello_world_actix/src/app.rs
@@ -11,8 +11,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/hello_world_axum/src/app.rs
+++ b/examples/hello_world_axum/src/app.rs
@@ -15,8 +15,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/interpolation/src/app.rs
+++ b/examples/interpolation/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/namespaces/src/app.rs
+++ b/examples/namespaces/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/subkeys/src/app.rs
+++ b/examples/subkeys/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/examples/workspace/counter/src/app.rs
+++ b/examples/workspace/counter/src/app.rs
@@ -9,8 +9,8 @@ pub fn App() -> impl IntoView {
 
     let on_switch = move |_| {
         let new_lang = match i18n.get_locale() {
-            LocaleEnum::en => LocaleEnum::fr,
-            LocaleEnum::fr => LocaleEnum::en,
+            Locale::en => Locale::fr,
+            Locale::fr => Locale::en,
         };
         i18n.set_locale(new_lang);
     };

--- a/leptos_i18n/src/fetch_locale.rs
+++ b/leptos_i18n/src/fetch_locale.rs
@@ -1,23 +1,22 @@
-use crate::Locales;
+use crate::Locale;
 
 #[cfg(feature = "ssr")]
 #[inline]
-pub fn fetch_locale<T: Locales>() -> T::Variants {
+pub fn fetch_locale<T: Locale>() -> T {
     crate::server::fetch_locale_server_side::<T>()
 }
 
 #[cfg(feature = "hydrate")]
-pub fn fetch_locale<T: Locales>() -> T::Variants {
-    use crate::LocaleVariant;
+pub fn fetch_locale<T: Locale>() -> T {
     leptos::document()
         .document_element()
         .and_then(|el| el.get_attribute("lang"))
-        .and_then(|lang| <T::Variants as LocaleVariant>::from_str(&lang))
+        .and_then(|lang| T::from_str(&lang))
         .unwrap_or_default()
 }
 
 #[cfg(not(any(feature = "ssr", feature = "hydrate")))]
 #[inline]
-pub fn fetch_locale<T: Locales>() -> T::Variants {
+pub fn fetch_locale<T: Locale>() -> T {
     Default::default()
 }

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -83,8 +83,8 @@
 //!
 //!     let on_switch = move |_| {
 //!         let new_lang = match i18n.get_locale() {
-//!             LocaleEnum::en => LocaleEnum::fr,
-//!             LocaleEnum::fr => LocaleEnum::en,
+//!             Locale::en => Locale::fr,
+//!             Locale::fr => Locale::en,
 //!         };
 //!         i18n.set_locale(new_lang);
 //!     };

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -1,9 +1,9 @@
 /// Trait implemented the enum representing the supported locales of the application
 ///
 /// Appart from maybe `as_str` you will probably never need to use it has it only serves the internals of the library.
-pub trait LocaleVariant: 'static + Default + Clone + Copy {
+pub trait Locale: 'static + Default + Clone + Copy {
     /// The associated struct containing the translations
-    type Keys: LocaleKeys<Variants = Self>;
+    type Keys: LocaleKeys<Locale = Self>;
 
     /// Try to match the given str to a locale and returns it.
     fn from_str(s: &str) -> Option<Self>;
@@ -31,24 +31,10 @@ pub trait LocaleVariant: 'static + Default + Clone + Copy {
 /// You will probably never need to use it has it only serves the internals of the library.
 pub trait LocaleKeys: 'static + Clone + Copy {
     /// The associated enum representing the supported locales
-    type Variants: LocaleVariant<Keys = Self>;
+    type Locale: Locale<Keys = Self>;
 
     /// Create self according to the given locale.
-    fn from_variant(variant: Self::Variants) -> &'static Self;
-}
-
-/// This trait servers as a bridge beetween the locale enum and the keys struct
-pub trait Locales: 'static + Clone + Copy {
-    /// The struct that represent the translations keys.
-    type LocaleKeys: LocaleKeys<Variants = Self::Variants>;
-    /// The enum that represent the different locales supported.
-    type Variants: LocaleVariant<Keys = Self::LocaleKeys>;
-
-    /// Create the keys according to the given locale.
-    #[inline]
-    fn get_keys(locale: Self::Variants) -> &'static Self::LocaleKeys {
-        locale.get_keys()
-    }
+    fn from_variant(variant: Self::Locale) -> &'static Self;
 }
 
 /// This is used to call `.build` on `&str` when building interpolations

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -1,6 +1,6 @@
 /// Trait implemented the enum representing the supported locales of the application
 ///
-/// Appart from maybe `as_str` you will probably never need to use it has it only serves the internals of the library.
+/// Most functions of this crate are generic of type implementing this trait
 pub trait Locale: 'static + Default + Clone + Copy {
     /// The associated struct containing the translations
     type Keys: LocaleKeys<Locale = Self>;

--- a/leptos_i18n/src/server/actix.rs
+++ b/leptos_i18n/src/server/actix.rs
@@ -1,7 +1,7 @@
 use crate::locale_traits::*;
 use actix_web::http::header;
 
-pub fn fetch_locale_server<T: Locales>() -> T::Variants {
+pub fn fetch_locale_server<T: Locale>() -> T {
     // when leptos_router inspect the routes it execute the code once but don't set an HttpRequest in the context,
     // so we can't expect it to be present.
     leptos::use_context::<actix_web::HttpRequest>()
@@ -9,7 +9,7 @@ pub fn fetch_locale_server<T: Locales>() -> T::Variants {
         .unwrap_or_default()
 }
 
-fn from_req<T: LocaleVariant>(req: &actix_web::HttpRequest) -> T {
+fn from_req<T: Locale>(req: &actix_web::HttpRequest) -> T {
     #[cfg(feature = "cookie")]
     if let Some(pref) = req
         .cookie(crate::COOKIE_PREFERED_LANG)
@@ -28,5 +28,5 @@ fn from_req<T: LocaleVariant>(req: &actix_web::HttpRequest) -> T {
 
     let langs = super::parse_header(header);
 
-    LocaleVariant::find_locale(&langs)
+    T::find_locale(&langs)
 }

--- a/leptos_i18n/src/server/axum.rs
+++ b/leptos_i18n/src/server/axum.rs
@@ -1,7 +1,7 @@
 use crate::locale_traits::*;
 use axum::http::header;
 
-pub fn fetch_locale_server<T: Locales>() -> T::Variants {
+pub fn fetch_locale_server<T: Locale>() -> T {
     // when leptos_router inspect the routes it execute the code once but don't set a RequestParts in the context,
     // so we can't expect it to be present.
     leptos::use_context::<leptos_axum::RequestParts>()
@@ -9,7 +9,7 @@ pub fn fetch_locale_server<T: Locales>() -> T::Variants {
         .unwrap_or_default()
 }
 
-fn from_req<T: LocaleVariant>(req: &leptos_axum::RequestParts) -> T {
+fn from_req<T: Locale>(req: &leptos_axum::RequestParts) -> T {
     #[cfg(feature = "cookie")]
     if let Some(pref_lang_cookie) = get_prefered_lang_cookie::<T>(req) {
         return pref_lang_cookie;
@@ -29,7 +29,7 @@ fn from_req<T: LocaleVariant>(req: &leptos_axum::RequestParts) -> T {
 }
 
 #[cfg(feature = "cookie")]
-fn get_prefered_lang_cookie<T: LocaleVariant>(req: &leptos_axum::RequestParts) -> Option<T> {
+fn get_prefered_lang_cookie<T: Locale>(req: &leptos_axum::RequestParts) -> Option<T> {
     req.headers
         .get_all(header::COOKIE)
         .into_iter()

--- a/leptos_i18n/src/server/mod.rs
+++ b/leptos_i18n/src/server/mod.rs
@@ -4,7 +4,7 @@ mod actix;
 #[cfg(all(feature = "axum", not(feature = "actix")))]
 mod axum;
 
-use crate::Locales;
+use crate::Locale;
 
 #[cfg(all(feature = "actix", not(feature = "axum")))]
 use actix as backend;
@@ -12,7 +12,7 @@ use actix as backend;
 use axum as backend;
 
 #[cfg(any(feature = "actix", feature = "axum"))]
-pub fn fetch_locale_server_side<T: Locales>() -> T::Variants {
+pub fn fetch_locale_server_side<T: Locale>() -> T {
     backend::fetch_locale_server::<T>()
 }
 
@@ -20,7 +20,7 @@ pub fn fetch_locale_server_side<T: Locales>() -> T::Variants {
 compile_error!("Can't enable \"actix\" and \"axum\" features together.");
 
 #[cfg(not(any(feature = "actix", feature = "axum")))]
-pub fn fetch_locale_server_side<T: Locales>() -> T::Variants {
+pub fn fetch_locale_server_side<T: Locale>() -> T {
     compile_error!("Need either \"actix\" or \"axum\" feature to be enabled in ssr. Don't use the \"ssr\" feature, it is directly enable by the \"actix\" or \"axum\" feature.")
 }
 

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -19,9 +19,8 @@ pub(crate) mod t_macro;
 ///
 /// It creates multiple types allowing to easily incorporate translations in you application such as:
 ///
-/// - `LocaleEnum`: an enum representing the available locales of the application.
+/// - `Locale`: an enum representing the available locales of the application.
 /// - `I18nKeys`: a struct representing the translation keys.
-/// - `Locales`: an empty type that serves as a bridge beetween the two types.
 #[proc_macro]
 pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match load_locales::load_locales() {
@@ -68,12 +67,12 @@ pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// Usage:
 ///
 /// ```rust, ignore
-/// use crate::i18n::LocaleEnum;
+/// use crate::i18n::Locale;
 /// use leptos_i18n::td;
 ///
 /// view! {
-///     <p>{td!(LocaleEnum::en, $key)}</p>
-///     <p>{td!(LocaleEnum::fr, $key, $variable = $value, <$component> = |child| ... )}</p>
+///     <p>{td!(Locale::en, $key)}</p>
+///     <p>{td!(Locale::fr, $key, $variable = $value, <$component> = |child| ... )}</p>
 /// }
 ///```
 ///

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -95,7 +95,7 @@ impl Interpolation {
 
         quote! {
             impl #ident<#(#generics,)*> {
-                pub const fn new(#locale_field: LocaleEnum) -> Self {
+                pub const fn new(#locale_field: Locale) -> Self {
                     Self {
                         #(#fields,)*
                         #locale_field
@@ -184,7 +184,7 @@ impl Interpolation {
             #[allow(non_camel_case_types, non_snake_case)]
             #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
             pub struct #ident<#(#generics,)*> {
-                __locale: LocaleEnum,
+                __locale: Locale,
                 #(#fields,)*
             }
         }
@@ -450,7 +450,7 @@ impl Interpolation {
 
                 let value = match locale.keys.get(key) {
                     None | Some(ParsedValue::Default) => {
-                        default_match.extend(quote!(| LocaleEnum::#locale_key));
+                        default_match.extend(quote!(| Locale::#locale_key));
                         return None;
                     }
                     Some(value) => value,
@@ -458,7 +458,7 @@ impl Interpolation {
 
                 let ts = match i == 0 {
                     true => quote!(#default_match => { #value }),
-                    false => quote!(LocaleEnum::#locale_key => { #value }),
+                    false => quote!(Locale::#locale_key => { #value }),
                 };
                 Some(ts)
             })

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -18,7 +18,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
         interpolations,
     } = input;
     let get_keys = if direct {
-        quote!(leptos_i18n::LocaleVariant::get_keys(#context))
+        quote!(leptos_i18n::Locale::get_keys(#context))
     } else {
         quote!(leptos_i18n::I18nContext::get_keys(#context))
     };

--- a/tests/namespaces/src/first_ns.rs
+++ b/tests/namespaces/src/first_ns.rs
@@ -3,50 +3,50 @@ use common::*;
 
 #[test]
 fn click_to_change_lang() {
-    let en = td!(LocaleEnum::en, first_namespace::click_to_change_lang);
+    let en = td!(Locale::en, first_namespace::click_to_change_lang);
     assert_eq!(en, "Click to change language");
-    let fr = td!(LocaleEnum::fr, first_namespace::click_to_change_lang);
+    let fr = td!(Locale::fr, first_namespace::click_to_change_lang);
     assert_eq!(fr, "Cliquez pour changez de langue");
 }
 
 #[test]
 fn common_key() {
-    let en = td!(LocaleEnum::en, first_namespace::common_key);
+    let en = td!(Locale::en, first_namespace::common_key);
     assert_eq!(en, "first namespace");
-    let fr = td!(LocaleEnum::fr, first_namespace::common_key);
+    let fr = td!(Locale::fr, first_namespace::common_key);
     assert_eq!(fr, "premier namespace");
 }
 
 #[test]
 fn plural_only_en() {
     let count = move || 0;
-    let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+    let en = td!(Locale::en, first_namespace::plural_only_en, count);
     assert_eq_rendered!(en, "exact");
     for i in -3..0 {
         let count = move || i;
-        let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+        let en = td!(Locale::en, first_namespace::plural_only_en, count);
         assert_eq_rendered!(en, "unbounded start");
     }
     for i in 99..103 {
         let count = move || i;
-        let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+        let en = td!(Locale::en, first_namespace::plural_only_en, count);
         assert_eq_rendered!(en, "unbounded end");
     }
     for i in 1..3 {
         let count = move || i;
-        let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+        let en = td!(Locale::en, first_namespace::plural_only_en, count);
         assert_eq_rendered!(en, "excluded end");
     }
     for i in 3..=8 {
         let count = move || i;
-        let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+        let en = td!(Locale::en, first_namespace::plural_only_en, count);
         assert_eq_rendered!(en, "included end");
     }
     for i in [30, 40, 55, 73] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, first_namespace::plural_only_en, count);
+        let en = td!(Locale::en, first_namespace::plural_only_en, count);
         assert_eq_rendered!(en, "fallback");
     }
-    let fr = td!(LocaleEnum::fr, first_namespace::plural_only_en, count);
+    let fr = td!(Locale::fr, first_namespace::plural_only_en, count);
     assert_eq_rendered!(fr, "pas de plurals en français");
 }

--- a/tests/namespaces/src/second_ns.rs
+++ b/tests/namespaces/src/second_ns.rs
@@ -3,9 +3,9 @@ use common::*;
 
 #[test]
 fn common_key() {
-    let en = td!(LocaleEnum::en, second_namespace::common_key);
+    let en = td!(Locale::en, second_namespace::common_key);
     assert_eq!(en, "second namespace");
-    let fr = td!(LocaleEnum::fr, second_namespace::common_key);
+    let fr = td!(Locale::fr, second_namespace::common_key);
     assert_eq!(fr, "deuxième namespace");
 }
 
@@ -13,59 +13,59 @@ fn common_key() {
 fn click_count() {
     for i in -5..=5 {
         let count = move || i;
-        let en = td!(LocaleEnum::en, second_namespace::click_count, count);
+        let en = td!(Locale::en, second_namespace::click_count, count);
         assert_eq_rendered!(en, format!("You clicked {} times", i));
-        let fr = td!(LocaleEnum::fr, second_namespace::click_count, count);
+        let fr = td!(Locale::fr, second_namespace::click_count, count);
         assert_eq_rendered!(fr, format!("Vous avez cliqué {} fois", i));
     }
 }
 
 #[test]
 fn click_to_inc() {
-    let en = td!(LocaleEnum::en, second_namespace::click_to_inc);
+    let en = td!(Locale::en, second_namespace::click_to_inc);
     assert_eq!(en, "Click to increment the counter");
-    let fr = td!(LocaleEnum::fr, second_namespace::click_to_inc);
+    let fr = td!(Locale::fr, second_namespace::click_to_inc);
     assert_eq!(fr, "Cliquez pour incrémenter le compteur");
 }
 
 #[test]
 fn subkey_1() {
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_1);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_1);
     assert_eq!(en, "subkey_1");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_1);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_1);
     assert_eq!(fr, "subkey_1");
 }
 
 #[test]
 fn subkey_2() {
     let b = |children: ChildrenFn| view! { <b>{children}</b> };
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_2, <b>);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_2, <b>);
     assert_eq_rendered!(en, "<b>subkey_2</b>");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_2, <b>);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_2, <b>);
     assert_eq_rendered!(fr, "<b>subkey_2</b>");
 
     let b = |children: ChildrenFn| view! { <div>"before "{children}" after"</div> };
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_2, <b>);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_2, <b>);
     assert_eq_rendered!(en, "<div>before subkey_2 after</div>");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_2, <b>);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_2, <b>);
     assert_eq_rendered!(fr, "<div>before subkey_2 after</div>");
 }
 
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_3, count);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(en, "zero");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "zero");
     let count = || 1;
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_3, count);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(en, "one");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = td!(LocaleEnum::en, second_namespace::subkeys.subkey_3, count);
+    let en = td!(Locale::en, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = td!(LocaleEnum::fr, second_namespace::subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, second_namespace::subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/no_namespaces/src/plurals.rs
+++ b/tests/no_namespaces/src/plurals.rs
@@ -5,26 +5,26 @@ use common::*;
 fn f32_plural() {
     // count = 0
     let count = move || 0.0;
-    let en = td!(LocaleEnum::en, f32_plural, count);
+    let en = td!(Locale::en, f32_plural, count);
     assert_eq_rendered!(en, "You are broke");
-    let fr = td!(LocaleEnum::fr, f32_plural, count);
+    let fr = td!(Locale::fr, f32_plural, count);
     assert_eq_rendered!(fr, "Vous êtes pauvre");
 
     // count = ..0
     for i in [-100.34, -57.69, 0.0 - 0.00001] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_plural, count);
+        let en = td!(Locale::en, f32_plural, count);
         assert_eq_rendered!(en, "You owe money");
-        let fr = td!(LocaleEnum::fr, f32_plural, count);
+        let fr = td!(Locale::fr, f32_plural, count);
         assert_eq_rendered!(fr, "Vous devez de l'argent");
     }
 
     // count = _
     for i in [100.34, 57.69, 0.0 + 0.00001] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_plural, count);
+        let en = td!(Locale::en, f32_plural, count);
         assert_eq_rendered!(en, format!("You have {}€", i));
-        let fr = td!(LocaleEnum::fr, f32_plural, count);
+        let fr = td!(Locale::fr, f32_plural, count);
         assert_eq_rendered!(fr, format!("Vous avez {}€", i));
     }
 }
@@ -33,17 +33,17 @@ fn f32_plural() {
 fn u32_plural() {
     // count = 0
     let count = move || 0u32;
-    let en = td!(LocaleEnum::en, u32_plural, count);
+    let en = td!(Locale::en, u32_plural, count);
     assert_eq_rendered!(en, "0");
-    let fr = td!(LocaleEnum::fr, u32_plural, count);
+    let fr = td!(Locale::fr, u32_plural, count);
     assert_eq_rendered!(fr, "0");
 
     // count = 1..
     for i in [1u32, 45, 72] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, u32_plural, count);
+        let en = td!(Locale::en, u32_plural, count);
         assert_eq_rendered!(en, "1..");
-        let fr = td!(LocaleEnum::fr, u32_plural, count);
+        let fr = td!(Locale::fr, u32_plural, count);
         assert_eq_rendered!(fr, "1..");
     }
 }
@@ -53,36 +53,36 @@ fn or_plural() {
     // count = 0 | 5
     for i in [0u8, 5] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, OR_plural, count);
+        let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = td!(LocaleEnum::fr, OR_plural, count);
+        let fr = td!(Locale::fr, OR_plural, count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1u8, 4, 6, 9] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, OR_plural, count);
+        let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = td!(LocaleEnum::fr, OR_plural, count);
+        let fr = td!(Locale::fr, OR_plural, count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10u8, 12, 14, 20] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, OR_plural, count);
+        let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = td!(LocaleEnum::fr, OR_plural, count);
+        let fr = td!(Locale::fr, OR_plural, count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15u8, 17, 21, 56] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, OR_plural, count);
+        let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = td!(LocaleEnum::fr, OR_plural, count);
+        let fr = td!(Locale::fr, OR_plural, count);
         assert_eq_rendered!(fr, "fallback sans count");
     }
 }
@@ -92,36 +92,36 @@ fn f32_or_plural() {
     // count = 0 | 5
     for i in [0.0, 5.0] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_OR_plural, count);
+        let en = td!(Locale::en, f32_OR_plural, count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = td!(LocaleEnum::fr, f32_OR_plural, count);
+        let fr = td!(Locale::fr, f32_OR_plural, count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1.0, 4.0, 6.0, 9.0] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_OR_plural, count);
+        let en = td!(Locale::en, f32_OR_plural, count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = td!(LocaleEnum::fr, f32_OR_plural, count);
+        let fr = td!(Locale::fr, f32_OR_plural, count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10.0, 12.0, 14.0, 20.0] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_OR_plural, count);
+        let en = td!(Locale::en, f32_OR_plural, count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = td!(LocaleEnum::fr, f32_OR_plural, count);
+        let fr = td!(Locale::fr, f32_OR_plural, count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15.0, 17.0, 21.0, 56.0] {
         let count = move || i;
-        let en = td!(LocaleEnum::en, f32_OR_plural, count);
+        let en = td!(Locale::en, f32_OR_plural, count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = td!(LocaleEnum::fr, f32_OR_plural, count);
+        let fr = td!(Locale::fr, f32_OR_plural, count);
         assert_eq_rendered!(fr, "fallback avec tuple vide");
     }
 }

--- a/tests/no_namespaces/src/subkeys.rs
+++ b/tests/no_namespaces/src/subkeys.rs
@@ -3,42 +3,42 @@ use common::*;
 
 #[test]
 fn subkey_1() {
-    let en = td!(LocaleEnum::en, subkeys.subkey_1);
+    let en = td!(Locale::en, subkeys.subkey_1);
     assert_eq!(en, "subkey_1");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_1);
+    let fr = td!(Locale::fr, subkeys.subkey_1);
     assert_eq!(fr, "subkey_1");
 }
 
 #[test]
 fn subkey_2() {
     let b = |children: ChildrenFn| view! { <b>{children}</b> };
-    let en = td!(LocaleEnum::en, subkeys.subkey_2, <b>);
+    let en = td!(Locale::en, subkeys.subkey_2, <b>);
     assert_eq_rendered!(en, "<b>subkey_2</b>");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_2, <b>);
+    let fr = td!(Locale::fr, subkeys.subkey_2, <b>);
     assert_eq_rendered!(fr, "<b>subkey_2</b>");
 
     let b = |children: ChildrenFn| view! { <div>"before "{children}" after"</div> };
-    let en = td!(LocaleEnum::en, subkeys.subkey_2, <b>);
+    let en = td!(Locale::en, subkeys.subkey_2, <b>);
     assert_eq_rendered!(en, "<div>before subkey_2 after</div>");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_2, <b>);
+    let fr = td!(Locale::fr, subkeys.subkey_2, <b>);
     assert_eq_rendered!(fr, "<div>before subkey_2 after</div>");
 }
 
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "zero");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "one");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/no_namespaces/src/tests.rs
+++ b/tests/no_namespaces/src/tests.rs
@@ -3,49 +3,49 @@ use common::*;
 
 #[test]
 fn click_to_change_lang() {
-    let en = td!(LocaleEnum::en, click_to_change_lang);
+    let en = td!(Locale::en, click_to_change_lang);
     assert_eq!(en, "Click to change language");
-    let fr = td!(LocaleEnum::fr, click_to_change_lang);
+    let fr = td!(Locale::fr, click_to_change_lang);
     assert_eq!(fr, "Cliquez pour changez de langue");
 }
 
 #[test]
 fn click_count() {
     for count in -5..5 {
-        let en = td!(LocaleEnum::en, click_count, count);
+        let en = td!(Locale::en, click_count, count);
         assert_eq_rendered!(en, format!("You clicked {} times", count));
-        let fr = td!(LocaleEnum::fr, click_count, count);
+        let fr = td!(Locale::fr, click_count, count);
         assert_eq_rendered!(fr, format!("Vous avez cliqué {} fois", count));
     }
 
     let count = "whatever impl into view";
-    let en = td!(LocaleEnum::en, click_count, count);
+    let en = td!(Locale::en, click_count, count);
     assert_eq_rendered!(en, format!("You clicked {} times", count));
-    let fr = td!(LocaleEnum::fr, click_count, count);
+    let fr = td!(Locale::fr, click_count, count);
     assert_eq_rendered!(fr, format!("Vous avez cliqué {} fois", count));
 
     let count = view! { <p>"even a view!"</p> };
-    let en = td!(LocaleEnum::en, click_count, count = count.clone());
+    let en = td!(Locale::en, click_count, count = count.clone());
     assert_eq_rendered!(en, "You clicked <p>even a view!</p> times");
-    let fr = td!(LocaleEnum::fr, click_count, count);
+    let fr = td!(Locale::fr, click_count, count);
     assert_eq_rendered!(fr, "Vous avez cliqué <p>even a view!</p> fois");
 }
 
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "zero");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "one");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = td!(LocaleEnum::en, subkeys.subkey_3, count);
+    let en = td!(Locale::en, subkeys.subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = td!(LocaleEnum::fr, subkeys.subkey_3, count);
+    let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }


### PR DESCRIPTION
For legacy reason and probably me not thinking enough there is this generated type that most of the crate is generic over: `Locales`.

It's just a type implementing a trait that declare the locale enum and the key struct, but now that things have moved around this type is not needed anymore, so this PR change those things:

- Remove the `Locales` trait
- Remove the generated `Locales` type
- Rename the `LocaleVariant` trait to `Locale`
- Rename the generated `LocaleEnum` enum to `Locale`
- Rename associated type `Variant` of trait `LocaleKeys` to `Locale`
- All functions generic over the deleted `Locales` trait are now generic over the `Locale` trait

This is technically a breaking change, but normally the only type/trait you should have used in any of those is `LocaleEnum`, so a quick globale search and replace to `Locale` should be good, all of the other are more internal, even if exposed, the `load_locales!` macro should have removed the need to use any of the others.