### PR TITLE
removed `Into<N>` for plurals and now default to `i32`

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,8 @@ You can mix them up as you want.
 
 The count can be a string `"0"` or a litteral `0`.
 
-When using plurals, variable name `count` is reserved and takes as a value `T: Fn() -> Into<N> + Clone + 'static` where `N` is the specified type.
-By default `N` is `i64` but you can change that by specifying the type as the **first** value in the sequence:
+When using plurals, variable name `count` is reserved and takes as a value `T: Fn() -> N + Clone + 'static` where `N` is the specified type.
+By default `N` is `i32` but you can change that by specifying the type as the **first** value in the sequence:
 
 ```json
 {

--- a/docs/book/src/usage/03_t_macro.md
+++ b/docs/book/src/usage/03_t_macro.md
@@ -136,7 +136,7 @@ Any missing components will generate an error.
 
 ## Plurals
 
-Plurals expect a variable named `count`, that implement `Fn() -> Into<N> + Clone + 'static` where `N` is the specified type of the plural (default is `i64`).
+Plurals expect a variable named `count`, that implement `Fn() -> N + Clone + 'static` where `N` is the specified type of the plural (default is `i32`).
 
 ## Access subkeys
 

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -363,12 +363,10 @@ impl Interpolation {
             InterpolateKey::Count(plural_type) => {
                 quote! {
                     #[inline]
-                    pub fn var_count<__T, __N>(self, var_count: __T) -> #ident<#(#output_generics,)*>
-                        where __T: Fn() -> __N + core::clone::Clone + 'static,
-                              __N: core::convert::Into<#plural_type>
+                    pub fn var_count<__T>(self, var_count: __T) -> #ident<#(#output_generics,)*>
+                        where __T: Fn() -> #plural_type + core::clone::Clone + 'static,
                     {
                         #destructure
-                        let var_count = move || core::convert::Into::into(var_count());
                         #restructure
                     }
                 }

--- a/leptos_i18n_macro/src/load_locales/plural.rs
+++ b/leptos_i18n_macro/src/load_locales/plural.rs
@@ -29,9 +29,11 @@ pub enum PluralType {
 
 impl Default for PluralType {
     fn default() -> Self {
-        Self::I64
+        Self::I32
     }
 }
+
+type DefaultPluralType = i32;
 
 impl core::fmt::Display for PluralType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -285,7 +287,7 @@ impl Plurals {
 
         let mut plurals = match type_or_plural {
             TypeOrPlural::Type(plural_type) => Self::from_type(plural_type),
-            TypeOrPlural::Plural(plural) => Plurals::I64(vec![plural]),
+            TypeOrPlural::Plural(plural) => Plurals::I32(vec![plural]),
         };
 
         plurals.deserialize_inner(seq, parsed_value_seed)?;
@@ -700,7 +702,7 @@ impl<'de> serde::de::Visitor<'de> for PluralFieldVisitor {
 
 enum TypeOrPlural {
     Type(PluralType),
-    Plural((Plural<i64>, ParsedValue)),
+    Plural((Plural<DefaultPluralType>, ParsedValue)),
 }
 
 struct TypeOrPluralSeed<'a>(pub ParsedValueSeed<'a>);
@@ -751,7 +753,7 @@ impl<'de> serde::de::Visitor<'de> for TypeOrPluralSeed<'_> {
     where
         A: serde::de::MapAccess<'de>,
     {
-        let plural_seed = PluralStructSeed::<i64>(self.0, PhantomData);
+        let plural_seed = PluralStructSeed::<DefaultPluralType>(self.0, PhantomData);
         plural_seed.visit_map(map).map(TypeOrPlural::Plural)
     }
 
@@ -759,7 +761,7 @@ impl<'de> serde::de::Visitor<'de> for TypeOrPluralSeed<'_> {
     where
         A: serde::de::SeqAccess<'de>,
     {
-        let plural_seed = PluralStructSeed::<i64>(self.0, PhantomData);
+        let plural_seed = PluralStructSeed::<DefaultPluralType>(self.0, PhantomData);
         plural_seed.visit_seq(seq).map(TypeOrPlural::Plural)
     }
 }

--- a/tests/json/src/plurals.rs
+++ b/tests/json/src/plurals.rs
@@ -32,14 +32,14 @@ fn f32_plural() {
 #[test]
 fn u32_plural() {
     // count = 0
-    let count = move || 0u32;
+    let count = move || 0;
     let en = td!(Locale::en, u32_plural, count);
     assert_eq_rendered!(en, "0");
     let fr = td!(Locale::fr, u32_plural, count);
     assert_eq_rendered!(fr, "0");
 
     // count = 1..
-    for i in [1u32, 45, 72] {
+    for i in [1, 45, 72] {
         let count = move || i;
         let en = td!(Locale::en, u32_plural, count);
         assert_eq_rendered!(en, "1..");
@@ -51,7 +51,7 @@ fn u32_plural() {
 #[test]
 fn or_plural() {
     // count = 0 | 5
-    for i in [0u8, 5] {
+    for i in [0, 5] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "0 or 5");
@@ -60,7 +60,7 @@ fn or_plural() {
     }
 
     // count = 1..5 | 6..10
-    for i in [1u8, 4, 6, 9] {
+    for i in [1, 4, 6, 9] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "1..5 | 6..10");
@@ -69,7 +69,7 @@ fn or_plural() {
     }
 
     // count = 10..15 | 20
-    for i in [10u8, 12, 14, 20] {
+    for i in [10, 12, 14, 20] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "10..15 | 20");
@@ -78,7 +78,7 @@ fn or_plural() {
     }
 
     // count = _
-    for i in [15u8, 17, 21, 56] {
+    for i in [15, 17, 21, 56] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "fallback with no count");

--- a/tests/yaml/src/plurals.rs
+++ b/tests/yaml/src/plurals.rs
@@ -32,14 +32,14 @@ fn f32_plural() {
 #[test]
 fn u32_plural() {
     // count = 0
-    let count = move || 0u32;
+    let count = move || 0;
     let en = td!(Locale::en, u32_plural, count);
     assert_eq_rendered!(en, "0");
     let fr = td!(Locale::fr, u32_plural, count);
     assert_eq_rendered!(fr, "0");
 
     // count = 1..
-    for i in [1u32, 45, 72] {
+    for i in [1, 45, 72] {
         let count = move || i;
         let en = td!(Locale::en, u32_plural, count);
         assert_eq_rendered!(en, "1..");
@@ -51,7 +51,7 @@ fn u32_plural() {
 #[test]
 fn or_plural() {
     // count = 0 | 5
-    for i in [0u8, 5] {
+    for i in [0, 5] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "0 or 5");
@@ -60,7 +60,7 @@ fn or_plural() {
     }
 
     // count = 1..5 | 6..10
-    for i in [1u8, 4, 6, 9] {
+    for i in [1, 4, 6, 9] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "1..5 | 6..10");
@@ -69,7 +69,7 @@ fn or_plural() {
     }
 
     // count = 10..15 | 20
-    for i in [10u8, 12, 14, 20] {
+    for i in [10, 12, 14, 20] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "10..15 | 20");
@@ -78,7 +78,7 @@ fn or_plural() {
     }
 
     // count = _
-    for i in [15u8, 17, 21, 56] {
+    for i in [15, 17, 21, 56] {
         let count = move || i;
         let en = td!(Locale::en, OR_plural, count);
         assert_eq_rendered!(en, "fallback with no count");


### PR DESCRIPTION
close #66 