### PR TITLE
Supply args to foreign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,40 @@ view! {
 
 (It's a shame `const` function are not allowed in traits, if that was the case the code outputed by `td!` would be entirly const, making it the same as directly pasting the locale)
 
+### Foreign keys
+
+Foreign keys let you re-use already declared translations, you declare them like variables but with a '@' before the path:
+
+```json
+{
+  "hello_world": "Hello World!",
+  "reuse": "message: {{ @hello_world }}"
+}
+```
+
+This will replace `{{ @hello_world }}` by the value of the key `hello_world`, making `reuse` equal to `"message: Hello World!"`.
+
+#### Supply arguments
+
+You can also supply arguments to fill variables of the pointed key:
+
+```json
+{
+  "click_count": "You clicked {{ count }} times",
+  "clicked_twice": "{{ @click_count, count = 'two' }}"
+}
+```
+
+This will result to `clicked_twice` to have the value `"You clicked two times"`.
+
+Arguments must be string, delimited by either single quotes or double quotes.
+
+**Note**: Any argument with no matching variable are just discarded, they will not emit any warning/error.
+
+### Book
+
+A more in-depth doc is available on github, the [book](https://github.com/Baptistemontan/leptos_i18n/tree/master/docs/book)
+
 ### Examples
 
 If examples works better for you, you can look at the different examples available on the Github. If something is missing or not clear feel free to open a discussion on github!

--- a/docs/book/src/declare/05_foreign_keys.md
+++ b/docs/book/src/declare/05_foreign_keys.md
@@ -18,3 +18,20 @@ To point to subkeys you give the path by separating the the key by `.`: `{{ @key
 When using namespaces you _must_ specify the namespace of the key you are looking for, using `::`: `{{ @namespace::key }}`.
 
 You can point to explicitly defaulted keys, but not implictly defaulted ones.
+
+## Supply arguments
+
+You can also supply arguments to fill variables of the pointed key:
+
+```json
+{
+  "click_count": "You clicked {{ count }} times",
+  "clicked_twice": "{{ @click_count, count = 'two' }}"
+}
+```
+
+This will result to `clicked_twice` to have the value `"You clicked two times"`.
+
+Arguments must be string, delimited by either single quotes or double quotes.
+
+**Note**: Any argument with no matching variable are just discarded, they will not emit any warning/error.

--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -70,6 +70,11 @@ pub enum Error {
         locale: Rc<Key>,
         key_path: KeyPath,
     },
+    MissingForeignKey {
+        foreign_key: KeyPath,
+        locale: Rc<Key>,
+        key_path: KeyPath,
+    },
     InvalidForeignKey {
         foreign_key: KeyPath,
         locale: Rc<Key>,
@@ -153,8 +158,9 @@ impl Display for Error {
             Error::PluralNumberType { found, expected } => write!(f, "number type {} can't be used for plural type {}", found, expected),
             Error::ExplicitDefaultInDefault(key_path) => write!(f, "Explicit defaults (null) are not allowed in default locale, at key {}", key_path),
             Error::RecursiveForeignKey { locale, key_path } => write!(f, "Borrow Error while linking foreign key at key {} in locale {:?}, check for recursive foreign key.", key_path, locale),
-            Error::InvalidForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key at key {} in locale {:?}, key {} don't exist.", key_path, locale, foreign_key),
-            Error::Custom(s) => f.write_str(s)
+            Error::MissingForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key {} at key {} in locale {:?}, key don't exist.", foreign_key, key_path, locale),
+            Error::Custom(s) => f.write_str(s),
+            Error::InvalidForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key {} at key {} in locale {:?}, foreign key to plurals or subkeys are not allowed.", foreign_key, key_path, locale),
         }
     }
 }

--- a/leptos_i18n_macro/src/load_locales/plural.rs
+++ b/leptos_i18n_macro/src/load_locales/plural.rs
@@ -535,7 +535,6 @@ impl<T: PluralNumber> ToTokens for Plural<T> {
             } => {
                 quote!(#start..)
             }
-            // unreachable normally but mal
             Plural::Range {
                 start,
                 end: Bound::Excluded(end),

--- a/tests/json/locales/en.json
+++ b/tests/json/locales/en.json
@@ -75,5 +75,6 @@
     "foreign_key_to_string": "before {{ @click_to_inc }} after",
     "foreign_key_to_interpolation": "before {{ @click_count }} after",
     "foreign_key_to_subkey": "before {{ @subkeys.subkey_1 }} after",
-    "foreign_key_to_explicit_default": "no explicit default in default locale"
+    "foreign_key_to_explicit_default": "no explicit default in default locale",
+    "populated_foreign_key": "before {{ @click_count, count = '45' }} after"
 }

--- a/tests/json/locales/fr.json
+++ b/tests/json/locales/fr.json
@@ -77,5 +77,6 @@
     "foreign_key_to_string": "before {{ @click_to_inc }} after",
     "foreign_key_to_interpolation": "before {{ @click_count }} after",
     "foreign_key_to_subkey": "before {{ @subkeys.subkey_1 }} after",
-    "foreign_key_to_explicit_default": "before {{ @defaulted_string }} after"
+    "foreign_key_to_explicit_default": "before {{ @defaulted_string }} after",
+    "populated_foreign_key": "before {{ @click_count, count = \"32\" }} after"
 }

--- a/tests/json/src/foreign.rs
+++ b/tests/json/src/foreign.rs
@@ -50,3 +50,11 @@ fn foreign_key_to_explicit_default() {
     let fr = td!(Locale::fr, foreign_key_to_explicit_default);
     assert_eq!(fr, "before this string is declared in locale en after");
 }
+
+#[test]
+fn populated_foreign_key() {
+    let en = td!(Locale::en, populated_foreign_key);
+    assert_eq!(en, "before You clicked 45 times after");
+    let fr = td!(Locale::fr, populated_foreign_key);
+    assert_eq!(fr, "before Vous avez cliqué 32 fois after");
+}


### PR DESCRIPTION
This PR add the possibility to supply args for foreign keys:

```json
{
    "click_count": "You clicked {{ count }} times",
    "clicked_twice": "{{ @click_count, count = 'two' }}"
}
```

```rust
load_locales!();

let clicked_twice = td!(Locale::en, clicked_twice);
assert_eq!(clicked_twice, "You clicked two times");
```

Arguments values must be string, delimited by either single quotes or double quotes.

Only arguments to variables can be supplied.