### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Leptos i18n
 
-This crate is made to simplify internalisation in a [Leptos](https://crates.io/crates/leptos) application, that load locales at **_compile time_** and provide compile time check for keys and selected locale.
+This crate is made to simplify internationalization in a [Leptos](https://crates.io/crates/leptos) application, that loads locales at **_compile time_** and provides compile time checks for translation keys, interpolation keys and the selected locale.
 
 The main focus is ease of use with leptos, a typical component using this crate will look like this:
 
@@ -269,7 +269,7 @@ view! {
 
 You can pass anything that implement `leptos::IntoView + Clone + 'static` as your variable. If a variable is not supplied it will not compile, same for an unknown variable key.
 
-You may also need to interpolate components, to highlight some part of a text for exemple, you can define them with html tags:
+You may also need to interpolate components, to highlight some part of a text for example, you can define them with html tags:
 
 ```json
 {
@@ -340,7 +340,7 @@ t!(i18n, key, count, <b>, other_key = ..)
 
 ### Plurals
 
-You may need to display different messages depending on a count, for exemple one when there is 0 elements, another when there is only one, and a last one when the count is anything else.
+You may need to display different messages depending on a count, for example one when there is 0 elements, another when there is only one, and a last one when the count is anything else.
 
 You declare them in a sequence of plurals, there is 2 syntax for the plurals, first is being a map with the `count` and the `value`:
 

--- a/docs/book/src/01_introduction.md
+++ b/docs/book/src/01_introduction.md
@@ -2,7 +2,7 @@
 
 This book is intended as an introduction to the [Leptos_i18n](https://github.com/Baptistemontan/leptos_i18n) crate.
 
-This crate is made to simplify internalisation in a [Leptos](https://crates.io/crates/leptos) application, that load locales at **_compile time_** and provide compile time check for keys and selected locale.
+This crate is made to simplify Internationalization in a [Leptos](https://crates.io/crates/leptos) application, that loads locales at **_compile time_** and provides compile time checks for translation keys, interpolation keys and the selected locale.
 
 This guide does assume you know some basics about `Leptos`, but the majority of the guide is about declaring the translations and how to use them, you can find the `Leptos` book [here](https://leptos-rs.github.io/leptos/).
 

--- a/docs/book/src/02_getting_started.md
+++ b/docs/book/src/02_getting_started.md
@@ -21,7 +21,7 @@ ssr = [
 ]
 ```
 
-You can see an exemple using `actix-web` [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_actix)
+You can see an example using `actix-web` [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_actix)
 
 ## `axum` Backend
 
@@ -36,7 +36,7 @@ ssr = [
 ]
 ```
 
-You can see an exemple using `axum` [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_axum)
+You can see an example using `axum` [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_axum)
 
 ## Hydrate
 
@@ -51,7 +51,7 @@ hydrate = [
 ]
 ```
 
-There exist 3 exemples using hydratation:
+There exist 3 examples using hydratation:
 
 - [Hello World Actix](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_actix)
 - [Hello World Axum](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_axum)
@@ -68,6 +68,6 @@ When compiling for the client, enable the `csr` feature:
 features = ["csr"]
 ```
 
-You can find an exemple using CSR [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/csr)
+You can find an  using CSR [here](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/csr)
 
-> **Note**: This version of the book and the linked exemples reflects the upcoming `Leptos_i18n` `v0.2.0` release, using upcoming `Leptos` `v0.5.0`.
+> **Note**: This version of the book and the linked examples reflects the upcoming `Leptos_i18n` `v0.2.0` release, using upcoming `Leptos` `v0.5.0`.

--- a/docs/book/src/declare/01_key_value.md
+++ b/docs/book/src/declare/01_key_value.md
@@ -8,7 +8,7 @@ As expected, you declare your translations a key-value pairs:
 }
 ```
 
-But there are additionnal rules you must follow in addition to those of the format you use.
+But there are additional rules you must follow in addition to those of the format you use.
 
 ## Keys
 
@@ -44,4 +44,4 @@ You can specify multiple kinds of values:
 - Interpolated String
 - Plurals
 
-The next chapters of this section will cover them, appart for strings, those are self explanatory.
+The next chapters of this section will cover them, apart for strings, those are self explanatory.

--- a/docs/book/src/declare/02_interpolation.md
+++ b/docs/book/src/declare/02_interpolation.md
@@ -2,7 +2,7 @@
 
 ## Interpolate Values
 
-There may be situations where you must interpolate a value inside your translations, for exemple a dynamic number.
+There may be situations where you must interpolate a value inside your translations, for example a dynamic number.
 You could declare 2 translations and use them around that number, but this is not an elegant solution.
 
 To declare a value that will be interpolated in your translations, simply give it a name around `{{ }}`:
@@ -15,13 +15,13 @@ To declare a value that will be interpolated in your translations, simply give i
 
 ## Interpolate Components
 
-There may also be situations where you want to use wrapp a part of your translation into a component, for exemple to highlight it.
+There may also be situations where you want to use wrap a part of your translation into a component, for example to highlight it.
 
 You can declare a component with html-like syntax:
 
 ```json
 {
-  "highlight_me": "highligh <b>me</b>"
+  "highlight_me": "highlight <b>me</b>"
 }
 ```
 
@@ -37,4 +37,4 @@ You can mix them both without problem:
 
 ## Names
 
-Just like keys, names of variable/components must be valid Rust identifier, appart from `-` which will be converted to `_`
+Just like keys, names of variable/components must be valid Rust identifier, apart from `-` which will be converted to `_`

--- a/docs/book/src/declare/03_plurals.md
+++ b/docs/book/src/declare/03_plurals.md
@@ -2,9 +2,9 @@
 
 What if your translation display a count, and thus you must handle the case where the count is zero, one, or multiple ? You could declare multiple translations and use some kind of switch-case, but again this is not elegant.
 
-To simplify this process you can declare plurals, they are based around a count and display different tranlsations based on this count.
+To simplify this process you can declare plurals, they are based around a count and display different translations based on this count.
 
-To declare them the key take a sequence where each element is a sequence with the first element being the value, and the other element the count to match against:
+To declare them the key takes a sequence where each element is a sequence with the first element being the value, and the other element the count to match against:
 
 ```json
 {
@@ -44,10 +44,11 @@ You can also declare a range where the translations is used:
 }
 ```
 
-You can use all Rust ranges syntax: `s..e`, `..e`, `s..`, `s..=e`, `..=e` or even `..` ( `..` will considered fallback `_`)
+You can use all Rust ranges syntax: `s..e`, `..e`, `s..`, `s..=e`, `..=e` or even `..` ( `..` will be considered fallback `_`)
 
 ## Number type
 
+// TODO: here its `i64` in usage/03_t_macro.html#plurals it says '(default is `i32`)'
 By default the count is expected to be an `i64`, but you can change that by specifying the type as the first element of the sequence:
 
 ```json
@@ -67,7 +68,7 @@ The supported types are `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f
 
 ## Fallback
 
-If all the given counts don't fill the range of the number type, you can use a fallback (`"_"` or `".."`) as seen above, but it can be completly ommitted on the last element of the sequence:
+If all the given counts don't fill the range of the number type, you can use a fallback (`"_"` or `".."`) as seen above, but it can be completely omitted on the last element of the sequence:
 
 ```json
 {
@@ -96,7 +97,7 @@ Fallbacks are always required for `f32` and `f64`.
 
 ## Order
 
-The order of the plurals matter, for exemple:
+The order of the plurals matter, for example:
 
 ```json
 {
@@ -108,7 +109,7 @@ The order of the plurals matter, for exemple:
 }
 ```
 
-Here "second" will only be printed if count is 5, if `0 <= count > 5` then "first" will be printed.
+Here "second" will only be printed if count is 5, if `0 <= count < 5` then "first" will be printed.
 
 ## Mix ranges with exact values
 

--- a/docs/book/src/declare/03_plurals.md
+++ b/docs/book/src/declare/03_plurals.md
@@ -48,8 +48,7 @@ You can use all Rust ranges syntax: `s..e`, `..e`, `s..`, `s..=e`, `..=e` or eve
 
 ## Number type
 
-// TODO: here its `i64` in usage/03_t_macro.html#plurals it says '(default is `i32`)'
-By default the count is expected to be an `i64`, but you can change that by specifying the type as the first element of the sequence:
+By default the count is expected to be an `i32`, but you can change that by specifying the type as the first element of the sequence:
 
 ```json
 {

--- a/docs/book/src/declare/05_foreign_keys.md
+++ b/docs/book/src/declare/05_foreign_keys.md
@@ -11,10 +11,10 @@ Foreign keys let you re-use already declared translations, you declare them like
 
 This will replace `{{ @hello_world }}` by the value of the key `hello_world`, making `reuse` equal to `"message: Hello World!"`.
 
-You can point to any key other than plurals and key containing subkeys.
+You can point to any key other than plurals and keys containing subkeys.
 
 To point to subkeys you give the path by separating the the key by `.`: `{{ @key.subkey.subsubkey }}`.
 
 When using namespaces you _must_ specify the namespace of the key you are looking for, using `::`: `{{ @namespace::key }}`.
 
-You can point to explicitly defaulted keys, but not implictly defaulted ones.
+You can point to explicitly defaulted keys, but not implicitly defaulted ones.

--- a/docs/book/src/declare/06_mix_kinds.md
+++ b/docs/book/src/declare/06_mix_kinds.md
@@ -4,4 +4,4 @@ What happens if for a key you declare plurals in one locale, interpolation in an
 
 Well this is totally allowed, but you will still need to supply all values/components of every locale combined when using the translation, regardless of what the current locale is.
 
-What is not allowed to mix are subkeys, the key must be a subkey in all locales.
+What is not allowed to mix are subkeys. If a key has subkeys in one locale, the key must have subkeys in all locales.

--- a/docs/book/src/declare/06_mix_kinds.md
+++ b/docs/book/src/declare/06_mix_kinds.md
@@ -1,7 +1,7 @@
 # Mixing Kinds
 
-What happen if for a key you declare plurals in one locale, interpolation in another, and a simple string in a third ?
+What happens if for a key you declare plurals in one locale, interpolation in another, and a simple string in a third ?
 
-Well this is totally allowed, but you will still need to supply all values/component of every locales combined when using the translation, regardless of what the current locale is.
+Well this is totally allowed, but you will still need to supply all values/components of every locale combined when using the translation, regardless of what the current locale is.
 
-What is not allowed to mix is subkeys, the key must be subkeys in all locale.
+What is not allowed to mix are subkeys, the key must be a subkey in all locales.

--- a/docs/book/src/setting_up/01_configuration.md
+++ b/docs/book/src/setting_up/01_configuration.md
@@ -1,8 +1,8 @@
 # Configuration
 
-This crate in basically entirely based around one macro: the `load_locales!` macro. We will cover it in a later chapter, but for now just know it looks at your translations files and generate code for them.
+This crate in basically entirely based around one macro: the `load_locales!` macro. We will cover it in a later chapter, but for now just know that it looks at your translation files and generates code for them.
 
-To load those translations it first need to know what to look for, so you need to declare what locales you are supporting and which one is the default.
+To load those translations it first needs to know what to look for, so you need to declare what locales you are supporting and which one is the default.
 To do that you use the `[package.metadata.leptos-i18n]` section in your `Cargo.toml`.
 
 To declare `en` and `fr` as locales, with `en` being the default you would write:
@@ -13,9 +13,9 @@ default = "en"
 locales = ["en", "fr"]
 ```
 
-There is 2 more optionnal values you can supply:
+There is 2 more optional values you can supply:
 
 - `namespaces`: This is to split your translations in multiple files, we will cover it in a later chapter
 - `locales-dir`: This is to have a custom path to the directory containing the locales files, it default to `"./locales"`.
 
-Once this configuration done, you can start writing your translations.
+Once this configuration is done, you can start writing your translations.

--- a/docs/book/src/setting_up/02_file_structure.md
+++ b/docs/book/src/setting_up/02_file_structure.md
@@ -1,6 +1,6 @@
 # File Structure
 
-Now that you have configured your locales, you can start writing your translations, this chapter cover where to put your files, we will cover how to write them in another section.
+Now that you have configured your locales, you can start writing your translations, this chapter covers where to put your files. We will cover how to write them in another section.
 
 By default you must put your files in the `./locales` directory, and each file must be `%{locale}.json`:
 
@@ -12,7 +12,7 @@ By default you must put your files in the `./locales` directory, and each file m
 
 ## Custom Directory
 
-You can change the path to the directory containing the files with the `locales-dir` field in the configuration, for exemple
+You can change the path to the directory containing the files with the `locales-dir` field in the configuration, for example
 
 ```toml
 [package.metadata.leptos-i18n]

--- a/docs/book/src/setting_up/03_namespaces.md
+++ b/docs/book/src/setting_up/03_namespaces.md
@@ -22,5 +22,5 @@ Then your file structures must look like this in the `/locales` directory:
     └── home.json
 ```
 
-You can now make smaller files, with one for each sections of the website for exemple.
+You can now make smaller files, with one for each sections of the website for example.
 This also allow the `common` namespace to use keys that the `home` namespace also use, without colliding.

--- a/docs/book/src/usage/01_load.md
+++ b/docs/book/src/usage/01_load.md
@@ -14,7 +14,7 @@ The macro will generate a module called `i18n`, this module contain everything y
 
 ### The `Locale` enum
 
-You can found in this module the enum `Locale`, it represent all the locales you declared, for exemple this configuration:
+You can find the enum `Locale` in this module, it represent all the locales you declared, for example this configuration:
 
 ```toml
 [package.metadata.leptos-i18n]

--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -6,8 +6,8 @@ The context is a wrapper around a `RwSignal` of the current locale, every getter
 
 ## Provide the context
 
-The `load_locales!` macro generate the `provide_i18n_context` function in the `i18n` module,
-you can use this fonction in a component to make the context accessible to all child components.
+The `load_locales!` macro generates the `provide_i18n_context` function in the `i18n` module,
+you can use this function in a component to make the context accessible to all child components.
 
 ```rust
 use crate::i18n::*;
@@ -80,7 +80,7 @@ A non-reactive counterpart to `get_locale` exist: `get_locale_untracked`.
 
 ## Change the locale
 
-With the context you can change the current locale with the `set_locale` method, for exemple this component will switch beetween `en` and `fr` with a button:
+With the context you can change the current locale with the `set_locale` method, for example this component will switch between `en` and `fr` with a button:
 
 ```rust
 use crate::i18n::*;

--- a/docs/book/src/usage/03_t_macro.md
+++ b/docs/book/src/usage/03_t_macro.md
@@ -38,7 +38,7 @@ pub fn Foo() -> impl IntoView {
 }
 ```
 
-If your variable as the same name as the value, you can pass it directly:
+If your variable has the same name as the value, you can pass it directly:
 
 ```rust
 use crate::i18n::*;
@@ -140,7 +140,7 @@ Plurals expect a variable named `count`, that implement `Fn() -> N + Clone + 'st
 
 ## Access subkeys
 
-You can access subkeys by simply seperating the path with `.`:
+You can access subkeys by simply separating the path with `.`:
 
 ```rust
 use crate::i18n::*;
@@ -179,7 +179,7 @@ pub fn Foo() -> impl IntoView {
 }
 ```
 
-To avoid confusion with subkeys you can use `::` to seperate the namespace name from the rest of the path:
+To avoid confusion with subkeys you can use `::` to separate the namespace name from the rest of the path:
 
 ```rust
 t!(i18n, my_namespace::hello_world)

--- a/docs/book/src/usage/04_td_macro.md
+++ b/docs/book/src/usage/04_td_macro.md
@@ -6,7 +6,7 @@ The `td!` macro works just like the `t!` macro but instead of taking the context
 td!(Locale::fr, hello_world)
 ```
 
-This is usefull if for exemple you want the buttons to switch locale to always be in the language they switch to:
+This is useful if for example you want the buttons to switch locale to always be in the language they switch to:
 
 ```rust
 use crate::i18n::*;

--- a/docs/book/src/usage/README.md
+++ b/docs/book/src/usage/README.md
@@ -1,3 +1,3 @@
 # How to use in code
 
-Now that we know how to delclare our translations, we can incorporate them in the code, and this is what this chapter cover.
+Now that we know how to declare our translations, we can incorporate them in the code, and this is what this chapter cover.

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,6 +1,6 @@
 # Counter Example
 
-This exemple showcase how you can interpolate a variable in your translations and switch locale without loosing state.
+This example showcase how you can interpolate a variable in your translations and switch locale without loosing state.
 
 ## How to run
 

--- a/examples/counter_plurals/README.md
+++ b/examples/counter_plurals/README.md
@@ -1,6 +1,6 @@
 # Counter Plurals Example
 
-This exemple showcase how you can use plurals to display a different text based on a count.
+This example showcase how you can use plurals to display a different text based on a count.
 
 ## How to run
 

--- a/examples/csr/README.md
+++ b/examples/csr/README.md
@@ -1,6 +1,6 @@
 # CSR Example
 
-This exemple showcase how to use `leptos_i18n` with client side rendering
+This example showcase how to use `leptos_i18n` with client side rendering
 
 ## How to run
 

--- a/examples/hello_world_actix/README.md
+++ b/examples/hello_world_actix/README.md
@@ -1,10 +1,10 @@
 # Hello World Example
 
-This exemple showcase how to setup the files to use `leptos_i18n` and easily introduce translations in you application.
+This example showcase how to setup the files to use `leptos_i18n` and easily introduce translations in you application.
 
-This exemple use the `actix` backend, but all the code in relation to `leptos_i18n` would be the same using `axum`.
+This example use the `actix` backend, but all the code in relation to `leptos_i18n` would be the same using `axum`.
 
-Check the `axum` Hello World exemple to compare.
+Check the `axum` Hello World example to compare.
 
 ## How to run
 

--- a/examples/hello_world_axum/README.md
+++ b/examples/hello_world_axum/README.md
@@ -1,10 +1,10 @@
 # Hello World Example
 
-This exemple showcase how to setup the files to use `leptos_i18n` and easily introduce translations in you application.
+This example showcase how to setup the files to use `leptos_i18n` and easily introduce translations in you application.
 
-This exemple use the `axum` backend, but all the code in relation to `leptos_i18n` would be the same using `actix`.
+This example use the `axum` backend, but all the code in relation to `leptos_i18n` would be the same using `actix`.
 
-Check the `actix` Hello World exemple to compare.
+Check the `actix` Hello World example to compare.
 
 ## How to run
 

--- a/examples/interpolation/README.md
+++ b/examples/interpolation/README.md
@@ -1,6 +1,6 @@
 # Interpolation Example
 
-This exemple showcase how you can interpolate components/variable in your translations.
+This example showcase how you can interpolate components/variable in your translations.
 
 ## How to run
 

--- a/examples/namespaces/README.md
+++ b/examples/namespaces/README.md
@@ -1,6 +1,6 @@
 # Namespaces Example
 
-This exemple showcase how you can break down your translations in seperate files using namespaces.
+This example showcase how you can break down your translations in separate files using namespaces.
 
 ## How to run
 

--- a/examples/subkeys/README.md
+++ b/examples/subkeys/README.md
@@ -1,6 +1,6 @@
 # Subkeys Example
 
-This exemple showcase how you can use subkeys.
+This example showcase how you can use subkeys.
 
 ## How to run
 

--- a/examples/workspace/README.md
+++ b/examples/workspace/README.md
@@ -1,6 +1,6 @@
 # Counter Example
 
-This exemple showcase how you can interpolate a variable in your translations and switch locale without loosing state.
+This example showcase how you can interpolate a variable in your translations and switch locale without loosing state.
 
 ## How to run
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -1,6 +1,6 @@
 # YAML Example
 
-This exemple showcase how you can use the YAML format for declaring your locales
+This example showcase how you can use the YAML format for declaring your locales
 
 ## How to run
 

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! Leptos i18n is library to help with translations in a Leptos application
 //!
-//! It loads the translations at compile time and provide checks on translation keys and interpolations key.
+//! It loads the translations at compile time and provides checks on translation keys, interpolation keys and the selected locale.
 //!
 //!
 //! Explore our [Examples](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples) to see it in action.
@@ -18,8 +18,8 @@
 //! the [examples](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples):
 //! - [`hello_world_actix`](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_actix) is a simple example
 //!     to showcase the syntax and file structure to easily incorporate translations in you application using the actix backend
-//! - [`hello_world_axum`](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_axum) is like the actix hello world exemple
-//!     but use axum as the backend, it showcase that the code you will write with this library will be the same using actix or axum as a backend.
+//! - [`hello_world_axum`](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/hello_world_axum) is like the actix hello world example
+//!     but uses axum as the backend, it showcases that the code you will write with this library will be the same using actix or axum as a backend.
 //! - [`counter`](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/counter) is the classic
 //!     counter example, showing how you can interpolate values in the translations and switch locale without full reload.
 //! - [`counter_plurals`](https://github.com/Baptistemontan/leptos_i18n/tree/master/examples/counter_plurals) is like the `counter` example
@@ -34,7 +34,7 @@
 //! - `nightly`: On `nightly` Rust, enables the function-call syntax the i18n  context to get/set the locale.
 //! - `hydrate`: Enable this feature when building for the client.
 //! - `actix`: Enable this feature when building for the server with actix as the backend (can't be enabled with the `axum` feature).
-//! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `axum` feature).
+//! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `actix` feature).
 //! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 //! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
 //! - `suppress_key_warnings`: Disable the warning emission of the `load_locales!()` macro when some keys are missing or ignored.

--- a/tests/namespaces/locales/en/second_namespace.json
+++ b/tests/namespaces/locales/en/second_namespace.json
@@ -11,5 +11,6 @@
             ["{{ count }}", "_"]
         ]
     },
+    "foreign_key_to_same_namespace": "before {{ @second_namespace::common_key }} after",
     "foreign_key_to_another_namespace": "before {{ @first_namespace::common_key }} after"
 }

--- a/tests/namespaces/locales/fr/second_namespace.json
+++ b/tests/namespaces/locales/fr/second_namespace.json
@@ -10,5 +10,6 @@
             ["{{ count }}", "_"]
         ]
     },
+    "foreign_key_to_same_namespace": "before {{ @second_namespace::common_key }} after",
     "foreign_key_to_another_namespace": "before {{ @first_namespace::common_key }} after"
 }

--- a/tests/namespaces/src/second_ns.rs
+++ b/tests/namespaces/src/second_ns.rs
@@ -71,6 +71,14 @@ fn subkey_3() {
 }
 
 #[test]
+fn foreign_key_to_same_namespace() {
+    let en = td!(Locale::en, second_namespace::foreign_key_to_same_namespace);
+    assert_eq!(en, "before second namespace after");
+    let fr = td!(Locale::fr, second_namespace::foreign_key_to_same_namespace);
+    assert_eq!(fr, "before deuxième namespace after");
+}
+
+#[test]
 fn foreign_key_to_another_namespace() {
     let en = td!(
         Locale::en,


### PR DESCRIPTION
I just used your crate for my own project an corrected some typos while reading the docs and book.
I'm not a native english speaker myself so my edit may not be 100% correct.


If you are using VS Code i suggest using the extension `streetsidesoftware.code-spell-checker` & `streetsidesoftware.code-spell-checker-french`.
with the setting `cSpell.language` you can also set multiple languages like `en,fr`.

- [x] docs/book/src/declare/03_plurals.md:100 i think the comparison was the wrong way

I also added an extra test on top 😊