### PR TITLE
`td_string!` macro to create strings from translations

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -18,4 +18,5 @@
   - [`I18nContext`](./usage/02_context.md)
   - [`t!` Macro](./usage/03_t_macro.md)
   - [`td!` Macro](./usage/04_td_macro.md)
+  - [`td_string!` Macro](./usage/05_td_string_macro.md)
 - [Features](./06_features.md)

--- a/docs/book/src/usage/05_td_string_macro.md
+++ b/docs/book/src/usage/05_td_string_macro.md
@@ -1,0 +1,46 @@
+# The `td_string!` Macro
+
+The `td_string!` macro is to use interpolations outside the context of rendering views, it let you give a different kind of values such that the resulting value implement `Display` (and thus inherit the `ToString` impl).
+
+```rust
+// click_count = "You clicked {{ count }} times"
+assert_eq!(
+    td_string!(Locale::en, click_count, count = 10).to_string(),
+    "You clicked 10 times"
+)
+assert_eq!(
+    td_string!(Locale::en, click_count, count = "a lot of").to_string(),
+    "You clicked a lot of times"
+)
+```
+
+### Expected values
+
+Variables expect anything that implement `Display`.
+
+If the key use plurals it expect the type of the count, if you set the type to `f32`, it expect a `f32`.
+
+Components are a bit trickier, they expect this abomination:
+
+```rust
+Fn(&mut core::fmt::Formatter, &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result) -> core::fmt::Result
+```
+
+which basically let you do this:
+
+```rust
+use core::fmt::{Formatter, Result};
+
+fn render_b(f: &mut Formatter, child: &dyn Fn(&mut Formatter) -> Result) -> Result {
+    write!(f, "<div>")?;
+    child(f)?;
+    write!(f, "</div>")
+}
+
+// hello_world = "Hello <b>World</b> !"
+let hw = td_string!(Locale::en, hello_world, <b> = render_b);
+println!("{}", hw); // print "Hello <div>World</div> !"
+```
+
+If you look closely, there is no `Clone` or `'static` bounds for any arguments, but they are captured by the value returned by the macro,
+so the returned value as a lifetime bound to the "smallest" lifetime of the arguments.

--- a/docs/book/src/usage/05_td_string_macro.md
+++ b/docs/book/src/usage/05_td_string_macro.md
@@ -2,6 +2,10 @@
 
 The `td_string!` macro is to use interpolations outside the context of rendering views, it let you give a different kind of values such that the resulting value implement `Display` (and thus inherit the `ToString` impl).
 
+This requires the `interpolate_display` feature to be enabled.
+
+It enable you to do this:
+
 ```rust
 // click_count = "You clicked {{ count }} times"
 assert_eq!(

--- a/docs/book/src/usage/05_td_string_macro.md
+++ b/docs/book/src/usage/05_td_string_macro.md
@@ -1,6 +1,6 @@
 # The `td_string!` Macro
 
-The `td_string!` macro is to use interpolations outside the context of rendering views, it let you give a different kind of values such that the resulting value implement `Display` (and thus inherit the `ToString` impl).
+The `td_string!` macro is to use interpolations outside the context of rendering views, it let you give a different kind of values and return a `Cow<'static, str>`.
 
 This requires the `interpolate_display` feature to be enabled.
 
@@ -9,11 +9,11 @@ It enable you to do this:
 ```rust
 // click_count = "You clicked {{ count }} times"
 assert_eq!(
-    td_string!(Locale::en, click_count, count = 10).to_string(),
+    td_string!(Locale::en, click_count, count = 10),
     "You clicked 10 times"
 )
 assert_eq!(
-    td_string!(Locale::en, click_count, count = "a lot of").to_string(),
+    td_string!(Locale::en, click_count, count = "a lot of"),
     "You clicked a lot of times"
 )
 ```
@@ -24,7 +24,16 @@ Variables expect anything that implement `Display`.
 
 If the key use plurals it expect the type of the count, if you set the type to `f32`, it expect a `f32`.
 
-Components are a bit trickier, they expect this abomination:
+Components expect a value that implement `leptos_i18::display::DisplayComponent`, you can find some type made to help the formatting in the `display` module,
+such as `DisplayComp`.
+
+```rust
+// hello_world = "Hello <b>World</b> !"
+let hw = td_string!(Locale::en, hello_world, <b> = DisplayComp("div"));
+assert_eq!(hw, "Hello <div>World</div> !");
+```
+
+If you want finer control over the formatting, you can create your own types implementing the `DisplayComponent` trait, or you can pass this abomination of a function:
 
 ```rust
 Fn(&mut core::fmt::Formatter, &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result) -> core::fmt::Result
@@ -36,15 +45,33 @@ which basically let you do this:
 use core::fmt::{Formatter, Result};
 
 fn render_b(f: &mut Formatter, child: &dyn Fn(&mut Formatter) -> Result) -> Result {
-    write!(f, "<div>")?;
-    child(f)?;
+    write!(f, "<div id=\"some_id\">")?;
+    child(f)?; // format the children
     write!(f, "</div>")
 }
 
 // hello_world = "Hello <b>World</b> !"
 let hw = td_string!(Locale::en, hello_world, <b> = render_b);
-println!("{}", hw); // print "Hello <div>World</div> !"
+assert_eq!(hw, "Hello <div id=\"some_id\">World</div> !");
 ```
 
 If you look closely, there is no `Clone` or `'static` bounds for any arguments, but they are captured by the value returned by the macro,
 so the returned value as a lifetime bound to the "smallest" lifetime of the arguments.
+
+# The `td_display!` Macro
+
+Just like the `td_string!` macro but return either a struct implementing `Display` or a `&'static str` instead of a `Cow<'static, str>`.
+
+This is usefull if you will print the value or use it in any formatting operation, as it will avoid a temporary `String`.
+
+```rust
+use crate::i18n::Locale;
+use leptos_i18n::td_display;
+
+// click_count = "You clicked {{ count }} times"
+let t = td_display!(Locale::en, click_count, count = 10); // this only return the builder, no work has been done.
+assert_eq!(format!("before {t} after"), "before You clicked 10 times after");
+
+let t_str = t.to_string(); // can call `to_string` as the value impl `Display`
+assert_eq!(t_str, "You clicked 10 times");
+```

--- a/docs/book/src/usage/05_td_string_macro.md
+++ b/docs/book/src/usage/05_td_string_macro.md
@@ -27,10 +27,22 @@ If the key use plurals it expect the type of the count, if you set the type to `
 Components expect a value that implement `leptos_i18::display::DisplayComponent`, you can find some type made to help the formatting in the `display` module,
 such as `DisplayComp`.
 
+`String` and `&str` implement this trait such that
+
 ```rust
 // hello_world = "Hello <b>World</b> !"
-let hw = td_string!(Locale::en, hello_world, <b> = DisplayComp("div"));
-assert_eq!(hw, "Hello <div>World</div> !");
+
+let hw = td_string(Locale::en, hello_world, <b> = "span");
+assert_eq!(hw, "Hello <span>World</span> !");
+```
+
+The `DisplayComp` struct let you pass leptos attributes:
+
+```rust
+let attrs = [("id", leptos::Attribute::String("my_id".into()))];
+let b = DisplayComp::new("div", &attrs);
+let hw = td_string!(Locale::en, hello_world, <b>);
+assert_eq!(hw, "Hello <div id=\"my_id\">World</div> !");
 ```
 
 If you want finer control over the formatting, you can create your own types implementing the `DisplayComponent` trait, or you can pass this abomination of a function:

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -34,6 +34,7 @@ debug_interpolations = ["leptos_i18n_macro/debug_interpolations"]
 suppress_key_warnings = ["leptos_i18n_macro/suppress_key_warnings"]
 json_files = ["leptos_i18n_macro/json_files"]
 yaml_files = ["leptos_i18n_macro/yaml_files"]
+interpolate_display = ["leptos_i18n_macro/interpolate_display"]
 
 
 [package.metadata.cargo-all-features]

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -38,7 +38,14 @@ interpolate_display = ["leptos_i18n_macro/interpolate_display"]
 
 
 [package.metadata.cargo-all-features]
-denylist = ["ssr", "nightly", "yaml_files"]
+denylist = [
+    "ssr",
+    "nightly",
+    "yaml_files",
+    "serde",
+    "debug_interpolations",
+    "suppress_key_warnings",
+]
 skip_feature_sets = [
     [
         "actix",

--- a/leptos_i18n/src/display.rs
+++ b/leptos_i18n/src/display.rs
@@ -1,0 +1,52 @@
+//! This module contain some helpers to format component using the `td_string!` macro.
+
+use std::fmt;
+
+/// This trait is used when interpolating component with the `td_string!` macro
+pub trait DisplayComponent {
+    /// Takes as an input a formatter and a function to format the component children
+    fn fmt<T>(&self, f: &mut fmt::Formatter<'_>, children: T) -> fmt::Result
+    where
+        T: Fn(&mut fmt::Formatter<'_>) -> fmt::Result;
+}
+
+impl<F> DisplayComponent for F
+where
+    F: Fn(&mut fmt::Formatter<'_>, &dyn Fn(&mut fmt::Formatter<'_>) -> fmt::Result) -> fmt::Result,
+{
+    fn fmt<T>(&self, f: &mut fmt::Formatter<'_>, children: T) -> fmt::Result
+    where
+        T: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        self(f, &children)
+    }
+}
+
+/// This struct is made to be used with the `td_string!` macro when interpolating a component
+///
+/// ```rust,ignore
+/// /* key = "highlight <b>me</b>" */
+/// let t = td_string!(locale, key, <b> = DisplayComp("div"));
+/// assert_eq!(t.to_string(), "highlight <div>me</div>");
+/// ```
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct DisplayComp<'a>(pub &'a str);
+
+impl<'a> DisplayComp<'a> {
+    #[inline]
+    /// Create a new `DisplayComp`
+    pub fn new(component_name: &'a str) -> Self {
+        DisplayComp(component_name)
+    }
+}
+
+impl DisplayComponent for DisplayComp<'_> {
+    fn fmt<T>(&self, f: &mut fmt::Formatter<'_>, children: T) -> fmt::Result
+    where
+        T: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        write!(f, "<{}>", self.0)?;
+        children(f)?;
+        write!(f, "</{}>", self.0)
+    }
+}

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -139,7 +139,7 @@ pub use context::{provide_i18n_context, use_i18n_context, I18nContext};
 pub use leptos_i18n_macro::{load_locales, t, td};
 
 #[cfg(feature = "interpolate_display")]
-pub use leptos_i18n_macro::td_string;
+pub use leptos_i18n_macro::{td_display, td_string};
 
 #[doc(hidden)]
 pub mod __private {

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -129,7 +129,7 @@ mod locale_traits;
 #[cfg(feature = "ssr")]
 mod server;
 
-// #[cfg(feature = "interpolate_display")]
+#[cfg(feature = "interpolate_display")]
 pub mod display;
 
 pub use locale_traits::*;

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -135,6 +135,9 @@ pub use context::{provide_i18n_context, use_i18n_context, I18nContext};
 
 pub use leptos_i18n_macro::{load_locales, t, td};
 
+#[cfg(feature = "interpolate_display")]
+pub use leptos_i18n_macro::td_string;
+
 #[doc(hidden)]
 pub mod __private {
     pub use super::locale_traits::BuildStr;

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -129,6 +129,9 @@ mod locale_traits;
 #[cfg(feature = "ssr")]
 mod server;
 
+// #[cfg(feature = "interpolate_display")]
+pub mod display;
+
 pub use locale_traits::*;
 
 pub use context::{provide_i18n_context, use_i18n_context, I18nContext};

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 /// Trait implemented the enum representing the supported locales of the application
 ///
 /// Most functions of this crate are generic of type implementing this trait
@@ -52,9 +54,16 @@ pub trait BuildStr: Sized {
     }
 
     #[inline]
-    fn build_string(self) -> Self {
+    fn build_display(self) -> Self {
         self
     }
+
+    fn build_string(self) -> Cow<'static, str>;
 }
 
-impl<'a> BuildStr for &'a str {}
+impl BuildStr for &'static str {
+    #[inline]
+    fn build_string(self) -> Cow<'static, str> {
+        Cow::Borrowed(self)
+    }
+}

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -50,6 +50,11 @@ pub trait BuildStr: Sized {
     fn build(self) -> Self {
         self
     }
+
+    #[inline]
+    fn build_string(self) -> Self {
+        self
+    }
 }
 
 impl<'a> BuildStr for &'a str {}

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -30,6 +30,7 @@ nightly = []
 suppress_key_warnings = []
 json_files = ["serde_json"]
 yaml_files = ["serde_yaml"]
+interpolate_display = []
 
 [package.metadata.cargo-all-features]
 # cargo-all-features don't provide a way to always include one feature in a set, so CI will just do json...

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -59,7 +59,7 @@ pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream
 /// ```
 #[proc_macro]
 pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, false, false)
+    t_macro::t_macro(tokens, false, false, false)
 }
 
 /// Just like the `t!` macro but instead of taking `I18nContext` as the first argument it takes the desired locale.
@@ -79,30 +79,56 @@ pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// This let you use a specific locale regardless of the current one.
 #[proc_macro]
 pub fn td(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, true, false)
+    t_macro::t_macro(tokens, true, false, false)
 }
 
-/// Just like the `td!` macro but return a struct implementing `Display`
+/// Just like the `td_string!` macro but return either a struct implementing `Display` or a `&'static str` instead of a `Cow<'static, str>`,
+/// This allow finer formatting of the value.
 ///
 /// Usage:
 ///
 /// ```rust, ignore
 /// use crate::i18n::Locale;
-/// use leptos_i18n::td_string;
+/// use leptos_i18n::td_display;
 ///
 /// // click_count = "You clicked {{ count }} times"
 /// assert_eq!(
-///     td_string!(Locale::en, click_count, count = 10).to_string(),
+///     td_display!(Locale::en, click_count, count = 10).to_string(),
 ///     "You clicked 10 times"
 /// )
 ///
 /// assert_eq!(
-///     td_string!(Locale::en, click_count, count = "a lot of").to_string(),
+///     td_display!(Locale::en, click_count, count = "a lot of").to_string(),
+///     "You clicked a lot of times"
+/// )
+///```
+#[cfg(feature = "interpolate_display")]
+#[proc_macro]
+pub fn td_display(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t_macro::t_macro(tokens, true, true, false)
+}
+
+/// Just like the `td!` macro but return a `Cow<'static, str>`
+///
+/// Usage:
+///
+/// ```rust, ignore
+/// use crate::i18n::Locale;
+/// use leptos_i18n::td_display;
+///
+/// // click_count = "You clicked {{ count }} times"
+/// assert_eq!(
+///     td_string!(Locale::en, click_count, count = 10),
+///     "You clicked 10 times"
+/// )
+///
+/// assert_eq!(
+///     td_string!(Locale::en, click_count, count = "a lot of"),
 ///     "You clicked a lot of times"
 /// )
 ///```
 #[cfg(feature = "interpolate_display")]
 #[proc_macro]
 pub fn td_string(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, true, true)
+    t_macro::t_macro(tokens, true, true, true)
 }

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -59,7 +59,7 @@ pub fn load_locales(_tokens: proc_macro::TokenStream) -> proc_macro::TokenStream
 /// ```
 #[proc_macro]
 pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, false)
+    t_macro::t_macro(tokens, false, false)
 }
 
 /// Just like the `t!` macro but instead of taking `I18nContext` as the first argument it takes the desired locale.
@@ -79,5 +79,30 @@ pub fn t(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// This let you use a specific locale regardless of the current one.
 #[proc_macro]
 pub fn td(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, true)
+    t_macro::t_macro(tokens, true, false)
+}
+
+/// Just like the `td!` macro but return a struct implementing `Display`
+///
+/// Usage:
+///
+/// ```rust, ignore
+/// use crate::i18n::Locale;
+/// use leptos_i18n::td_string;
+///
+/// // click_count = "You clicked {{ count }} times"
+/// assert_eq!(
+///     td_string!(Locale::en, click_count, count = 10),
+///     "You clicked 10 times"
+/// )
+///
+/// assert_eq!(
+///     td_string!(Locale::en, click_count, count = "a lot of"),
+///     "You clicked a lot of times"
+/// )
+///```
+#[cfg(feature = "interpolate_display")]
+#[proc_macro]
+pub fn td_string(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t_macro::t_macro(tokens, true, true)
 }

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -82,32 +82,6 @@ pub fn td(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     t_macro::t_macro(tokens, true, false, false)
 }
 
-/// Just like the `td_string!` macro but return either a struct implementing `Display` or a `&'static str` instead of a `Cow<'static, str>`,
-/// This allow finer formatting of the value.
-///
-/// Usage:
-///
-/// ```rust, ignore
-/// use crate::i18n::Locale;
-/// use leptos_i18n::td_display;
-///
-/// // click_count = "You clicked {{ count }} times"
-/// assert_eq!(
-///     td_display!(Locale::en, click_count, count = 10).to_string(),
-///     "You clicked 10 times"
-/// )
-///
-/// assert_eq!(
-///     td_display!(Locale::en, click_count, count = "a lot of").to_string(),
-///     "You clicked a lot of times"
-/// )
-///```
-#[cfg(feature = "interpolate_display")]
-#[proc_macro]
-pub fn td_display(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    t_macro::t_macro(tokens, true, true, false)
-}
-
 /// Just like the `td!` macro but return a `Cow<'static, str>`
 ///
 /// Usage:
@@ -131,4 +105,29 @@ pub fn td_display(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[proc_macro]
 pub fn td_string(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     t_macro::t_macro(tokens, true, true, true)
+}
+
+/// Just like the `td_string!` macro but return either a struct implementing `Display` or a `&'static str` instead of a `Cow<'static, str>`.
+///
+/// This is usefull if you will print the value or use it in any formatting operation, as it will avoid a temporary `String`.
+///
+/// Usage:
+///
+/// ```rust, ignore
+/// use crate::i18n::Locale;
+/// use leptos_i18n::td_display;
+///
+/// // click_count = "You clicked {{ count }} times"
+/// let t = td_display!(Locale::en, click_count, count = 10); // this only return the builder, no work has been done.
+///
+/// assert_eq!(format!("before {t} after"), "before You clicked 10 times after");
+///
+/// let t_str = t.to_string(); // can call `to_string` as the value impl `Display`
+///
+/// assert_eq!(t_str, "You clicked 10 times");
+///```
+#[cfg(feature = "interpolate_display")]
+#[proc_macro]
+pub fn td_display(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    t_macro::t_macro(tokens, true, true, false)
 }

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -92,12 +92,12 @@ pub fn td(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// // click_count = "You clicked {{ count }} times"
 /// assert_eq!(
-///     td_string!(Locale::en, click_count, count = 10),
+///     td_string!(Locale::en, click_count, count = 10).to_string(),
 ///     "You clicked 10 times"
 /// )
 ///
 /// assert_eq!(
-///     td_string!(Locale::en, click_count, count = "a lot of"),
+///     td_string!(Locale::en, click_count, count = "a lot of").to_string(),
 ///     "You clicked a lot of times"
 /// )
 ///```

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -584,7 +584,7 @@ impl Interpolation {
         quote! {
             #[allow(non_camel_case_types)]
             impl<#(#left_generics,)*> core::fmt::Display for #ident<#(#right_generics,)*> {
-                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                fn fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     #destructure
                     match #locale_field {
                         #(

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -171,8 +171,12 @@ impl Interpolation {
             #[allow(non_camel_case_types)]
             impl<#(#left_generics_string,)*> #ident<#(#right_generics_string,)*> {
                 #[inline]
-                pub fn build_string(self) -> Self {
+                pub fn build_display(self) -> Self {
                     self
+                }
+
+                pub fn build_string(self) -> std::borrow::Cow<'static, str> {
+                    self.to_string().into()
                 }
             }
         }

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -3,6 +3,9 @@ use std::collections::HashSet;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
+#[cfg(feature = "interpolate_display")]
+use quote::format_ident;
+
 use super::{
     key::Key,
     locale::Locale,
@@ -33,7 +36,9 @@ impl Interpolation {
         locales: &[Locale],
         default_match: &TokenStream,
     ) -> Self {
-        let ident = syn::Ident::new(&format!("{}_builder", key.name), Span::call_site());
+        let builder_name = format!("{}_builder", key.name);
+
+        let ident = syn::Ident::new(&builder_name, Span::call_site());
 
         let locale_field = Key::new("_locale").unwrap();
 
@@ -62,6 +67,14 @@ impl Interpolation {
         let builder_impl = Self::builder_impl(&ident, &locale_field, &fields);
         let into_view_impl =
             Self::into_view_impl(key, &ident, &locale_field, &fields, locales, default_match);
+        let debug_impl = Self::debug_impl(&builder_name, &ident, &fields);
+
+        #[cfg(feature = "interpolate_display")]
+        let display_impl =
+            Self::display_impl(key, &ident, &locale_field, &fields, locales, default_match);
+        #[cfg(not(feature = "interpolate_display"))]
+        let display_impl = quote!();
+
         let new_impl = Self::new_impl(&ident, &locale_field, &fields);
         let default_generics = fields
             .iter()
@@ -74,6 +87,10 @@ impl Interpolation {
             #new_impl
 
             #into_view_impl
+
+            #debug_impl
+
+            #display_impl
 
             #builder_impl
         };
@@ -133,7 +150,34 @@ impl Interpolation {
             #success_build
         }
     }
-    // #[cfg(not(feature = "debug_interpolations"))]
+
+    #[cfg(feature = "interpolate_display")]
+    fn generate_string_build(ident: &syn::Ident, fields: &[Field]) -> TokenStream {
+        let left_generics_string = fields.iter().filter_map(|field| {
+            let ident = &field.generic;
+            let generic = field.kind.get_string_generic().ok()?;
+            Some(quote!(#ident: #generic))
+        });
+
+        let right_generics_string = fields.iter().map(|field| match field.kind {
+            InterpolateKey::Count(t) => quote!(#t),
+            _ => {
+                let ident = &field.generic;
+                quote!(#ident)
+            }
+        });
+
+        quote! {
+            #[allow(non_camel_case_types)]
+            impl<#(#left_generics_string,)*> #ident<#(#right_generics_string,)*> {
+                #[inline]
+                pub fn build_string(self) -> Self {
+                    self
+                }
+            }
+        }
+    }
+
     fn generate_success_build_fn(ident: &syn::Ident, fields: &[Field]) -> TokenStream {
         let left_generics = fields.iter().map(|field| {
             let ident = &field.generic;
@@ -146,6 +190,12 @@ impl Interpolation {
             quote!(#ident)
         });
 
+        #[cfg(feature = "interpolate_display")]
+        let string_build = Self::generate_string_build(ident, fields);
+
+        #[cfg(not(feature = "interpolate_display"))]
+        let string_build = quote!();
+
         quote! {
 
             #[allow(non_camel_case_types)]
@@ -155,6 +205,9 @@ impl Interpolation {
                     self
                 }
             }
+
+            #string_build
+
         }
     }
 
@@ -182,7 +235,7 @@ impl Interpolation {
 
         quote! {
             #[allow(non_camel_case_types, non_snake_case)]
-            #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+            #[derive(Clone, Copy, Hash, PartialEq, Eq)]
             pub struct #ident<#(#generics,)*> {
                 _locale: Locale,
                 #(#fields,)*
@@ -317,6 +370,19 @@ impl Interpolation {
             right_fields,
             quoted_gen,
         );
+
+        #[cfg(feature = "interpolate_display")]
+        let output_field_generic_string = match field.kind.get_string_generic() {
+            Ok(bounds) => quote!(impl #bounds),
+            Err(t) => quote!(#t),
+        };
+        #[cfg(feature = "interpolate_display")]
+        let output_generics_string = Self::generate_generics(
+            left_fields,
+            Some(output_field_generic_string.clone()),
+            right_fields,
+            quoted_gen,
+        );
         let other_fields = Self::generate_generics(left_fields, None, right_fields, |field| {
             if let Some(key) = field.kind.as_key() {
                 quote!(#key)
@@ -334,8 +400,8 @@ impl Interpolation {
         };
         let restructure = quote!(#ident { #(#other_fields,)* #kind });
 
-        let set_function = match kind {
-            InterpolateKey::Variable(key) => {
+        let fns = match kind {
+            InterpolateKey::Variable(key) => (
                 quote! {
                     #[inline]
                     pub fn #key<__T>(self, #key: __T) -> #ident<#(#output_generics,)*>
@@ -344,9 +410,21 @@ impl Interpolation {
                         #destructure
                         #restructure
                     }
-                }
-            }
-            InterpolateKey::Component(key) => {
+                },
+                #[cfg(feature = "interpolate_display")]
+                {
+                    let string_key = format_ident!("{}_string", key.ident);
+                    quote! {
+                        #[inline]
+                        pub fn #string_key(self, #key: #output_field_generic_string) -> #ident<#(#output_generics_string,)*>
+                        {
+                            #destructure
+                            #restructure
+                        }
+                    }
+                },
+            ),
+            InterpolateKey::Component(key) => (
                 quote! {
                     #[inline]
                     pub fn #key<__O, __T>(self, #key: __T) -> #ident<#(#output_generics,)*>
@@ -358,9 +436,21 @@ impl Interpolation {
                         let #key = move |children| leptos::IntoView::into_view(#key(children));
                         #restructure
                     }
-                }
-            }
-            InterpolateKey::Count(plural_type) => {
+                },
+                #[cfg(feature = "interpolate_display")]
+                {
+                    let string_key = format_ident!("{}_string", key.ident);
+                    quote! {
+                        #[inline]
+                        pub fn #string_key(self, #key: #output_field_generic_string) -> #ident<#(#output_generics_string,)*>
+                        {
+                            #destructure
+                            #restructure
+                        }
+                    }
+                },
+            ),
+            InterpolateKey::Count(plural_type) => (
                 quote! {
                     #[inline]
                     pub fn var_count<__T>(self, var_count: __T) -> #ident<#(#output_generics,)*>
@@ -369,9 +459,23 @@ impl Interpolation {
                         #destructure
                         #restructure
                     }
-                }
-            }
+                },
+                #[cfg(feature = "interpolate_display")]
+                quote! {
+                    #[inline]
+                    pub fn var_count_string(self, var_count: #plural_type) -> #ident<#(#output_generics_string,)*>
+                    {
+                        #destructure
+                        #restructure
+                    }
+                },
+            ),
         };
+
+        #[cfg(feature = "interpolate_display")]
+        let (set_function, set_str_function) = fns;
+        #[cfg(not(feature = "interpolate_display"))]
+        let (set_function, set_str_function) = (fns.0, quote!());
 
         if cfg!(feature = "debug_interpolations") {
             let left_generics_empty =
@@ -426,6 +530,67 @@ impl Interpolation {
                 #[allow(non_camel_case_types)]
                 impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
                     #set_function
+
+                    #set_str_function
+                }
+            }
+        }
+    }
+
+    fn debug_impl(builder_name: &str, ident: &syn::Ident, fields: &[Field]) -> TokenStream {
+        let left_generics = fields.iter().map(|field| &field.generic);
+
+        let right_generics = left_generics.clone();
+
+        quote! {
+            #[allow(non_camel_case_types)]
+            impl<#(#left_generics,)*> core::fmt::Debug for #ident<#(#right_generics,)*> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct(#builder_name).finish()
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "interpolate_display")]
+    fn display_impl(
+        key: &Key,
+        ident: &syn::Ident,
+        locale_field: &Key,
+        fields: &[Field],
+        locales: &[Locale],
+        default_match: &TokenStream,
+    ) -> TokenStream {
+        let left_generics = fields.iter().filter_map(|field| {
+            let ident = &field.generic;
+            let generic = field.kind.get_string_generic().ok()?;
+            Some(quote!(#ident: #generic))
+        });
+
+        let right_generics = fields.iter().map(|field| match field.kind {
+            InterpolateKey::Count(t) => quote!(#t),
+            _ => {
+                let ident = &field.generic;
+                quote!(#ident)
+            }
+        });
+
+        let fields_key = fields.iter().map(|f| f.kind);
+
+        let destructure = quote!(let Self { #(#fields_key,)* #locale_field } = self;);
+
+        let locales_impls = Self::create_locale_string_impl(key, locales, default_match);
+
+        quote! {
+            #[allow(non_camel_case_types)]
+            impl<#(#left_generics,)*> core::fmt::Display for #ident<#(#right_generics,)*> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    #destructure
+                    match #locale_field {
+                        #(
+                            #locales_impls,
+                        )*
+                    }
                 }
             }
         }
@@ -491,6 +656,38 @@ impl Interpolation {
                     }
                     Some(value) => value,
                 };
+
+                let ts = match i == 0 {
+                    true => quote!(#default_match => { #value }),
+                    false => quote!(Locale::#locale_key => { #value }),
+                };
+                Some(ts)
+            })
+    }
+
+    #[cfg(feature = "interpolate_display")]
+    fn create_locale_string_impl<'a>(
+        key: &'a Key,
+        locales: &'a [Locale],
+        default_match: &TokenStream,
+    ) -> impl Iterator<Item = TokenStream> + 'a {
+        let mut default_match = default_match.clone();
+        locales
+            .iter()
+            .enumerate()
+            .rev()
+            .filter_map(move |(i, locale)| {
+                let locale_key = &locale.top_locale_name;
+
+                let value = match locale.keys.get(key) {
+                    None | Some(ParsedValue::Default) => {
+                        default_match.extend(quote!(| Locale::#locale_key));
+                        return None;
+                    }
+                    Some(value) => value,
+                };
+
+                let value = value.as_string_impl();
 
                 let ts = match i == 0 {
                     true => quote!(#default_match => { #value }),

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -48,7 +48,7 @@ pub fn load_locales() -> Result<TokenStream> {
 
     let macros_reexport = if cfg!(feature = "interpolate_display") {
         quote!(
-            pub use leptos_i18n::{t, td, td_string};
+            pub use leptos_i18n::{t, td, td_string, td_display};
         )
     } else {
         quote!(

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -46,6 +46,16 @@ pub fn load_locales() -> Result<TokenStream> {
 
     let warnings = generate_warnings();
 
+    let macros_reexport = if cfg!(feature = "interpolate_display") {
+        quote!(
+            pub use leptos_i18n::{t, td, td_string};
+        )
+    } else {
+        quote!(
+            pub use leptos_i18n::{t, td};
+        )
+    };
+
     Ok(quote! {
         pub mod i18n {
             #locale_enum
@@ -62,7 +72,7 @@ pub fn load_locales() -> Result<TokenStream> {
                 leptos_i18n::provide_i18n_context()
             }
 
-            pub use leptos_i18n::{t, td};
+            #macros_reexport
 
             #warnings
         }

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -574,6 +574,44 @@ impl ParsedValue {
             },
         }
     }
+
+    #[cfg(feature = "interpolate_display")]
+    fn flatten_string(&self, tokens: &mut Vec<TokenStream>) {
+        match self {
+            ParsedValue::Subkeys(_) | ParsedValue::Default => {}
+            ParsedValue::String(s) if s.is_empty() => {}
+            ParsedValue::String(s) => tokens.push(quote!(core::fmt::Display::fmt(#s, f))),
+            ParsedValue::Plural(plurals) => tokens.push(plurals.as_string_impl()),
+            ParsedValue::Variable(key) => {
+                tokens.push(quote!(core::fmt::Display::fmt(#key, f)))
+            }
+            ParsedValue::Component { key, inner } => {
+                let inner = inner.as_string_impl();
+                tokens.push(quote!((#key)(f, &|f| #inner)))
+            }
+            ParsedValue::Bloc(values) => {
+                for value in values {
+                    value.flatten_string(tokens)
+                }
+            }
+            ParsedValue::ForeignKey(foreign_key) => match &*foreign_key.borrow() {
+                ForeignKey::Set(inner) => inner.flatten_string(tokens),
+                ForeignKey::NotSet(_, _) => unreachable!("called flatten_string on an unresolved foreign key, if you got this error please open a issue on github."),
+            },
+        }
+    }
+
+    #[cfg(feature = "interpolate_display")]
+    pub fn as_string_impl(&self) -> TokenStream {
+        let mut tokens = Vec::new();
+        self.flatten_string(&mut tokens);
+
+        match &tokens[..] {
+            [] => quote!(Ok(())),
+            [value] => value.clone(),
+            values => quote!({ #(#values?;)* Ok(()) }),
+        }
+    }
 }
 
 impl InterpolateKey {
@@ -613,6 +651,20 @@ impl InterpolateKey {
                     + core::clone::Clone
                     + 'static
             ),
+        }
+    }
+
+    #[cfg(feature = "interpolate_display")]
+    pub fn get_string_generic(&self) -> Result<TokenStream, PluralType> {
+        match self {
+            InterpolateKey::Count(t) => Err(*t),
+            InterpolateKey::Variable(_) => Ok(quote!(core::fmt::Display)),
+            InterpolateKey::Component(_) => Ok(quote!(
+                Fn(
+                    &mut core::fmt::Formatter<'_>,
+                    &dyn Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result,
+                ) -> core::fmt::Result
+            )),
         }
     }
 

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -580,14 +580,14 @@ impl ParsedValue {
         match self {
             ParsedValue::Subkeys(_) | ParsedValue::Default => {}
             ParsedValue::String(s) if s.is_empty() => {}
-            ParsedValue::String(s) => tokens.push(quote!(core::fmt::Display::fmt(#s, f))),
+            ParsedValue::String(s) => tokens.push(quote!(core::fmt::Display::fmt(#s, __formatter))),
             ParsedValue::Plural(plurals) => tokens.push(plurals.as_string_impl()),
             ParsedValue::Variable(key) => {
-                tokens.push(quote!(core::fmt::Display::fmt(#key, f)))
+                tokens.push(quote!(core::fmt::Display::fmt(#key, __formatter)))
             }
             ParsedValue::Component { key, inner } => {
                 let inner = inner.as_string_impl();
-                tokens.push(quote!((#key)(f, &|f| #inner)))
+                tokens.push(quote!(leptos_i18n::display::DisplayComponent::fmt(#key, __formatter, |__formatter| #inner)))
             }
             ParsedValue::Bloc(values) => {
                 for value in values {
@@ -659,12 +659,7 @@ impl InterpolateKey {
         match self {
             InterpolateKey::Count(t) => Err(*t),
             InterpolateKey::Variable(_) => Ok(quote!(core::fmt::Display)),
-            InterpolateKey::Component(_) => Ok(quote!(
-                Fn(
-                    &mut core::fmt::Formatter<'_>,
-                    &dyn Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result,
-                ) -> core::fmt::Result
-            )),
+            InterpolateKey::Component(_) => Ok(quote!(leptos_i18n::display::DisplayComponent)),
         }
     }
 

--- a/leptos_i18n_macro/src/t_macro/interpolate.rs
+++ b/leptos_i18n_macro/src/t_macro/interpolate.rs
@@ -1,3 +1,4 @@
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{Expr, Ident, Token};
 
@@ -39,26 +40,52 @@ impl syn::parse::Parse for InterpolatedValue {
     }
 }
 
-impl ToTokens for InterpolatedValue {
-    fn to_token_stream(&self) -> proc_macro2::TokenStream {
+impl InterpolatedValue {
+    fn to_token_stream(&self, string: bool) -> TokenStream {
+        fn format_ident(ident: &Ident, variable: bool, string: bool) -> Ident {
+            match (variable, string) {
+                (true, true) => format_ident!("var_{}_string", ident),
+                (true, false) => format_ident!("var_{}", ident),
+                (false, true) => format_ident!("comp_{}_string", ident),
+                (false, false) => format_ident!("comp_{}", ident),
+            }
+        }
+
         match self {
             InterpolatedValue::Var(ident) => {
-                let var_ident = format_ident!("var_{}", ident);
+                let var_ident = format_ident(ident, true, string);
                 quote!(#var_ident(#ident))
             }
             InterpolatedValue::Comp(ident) => {
-                let comp_ident = format_ident!("comp_{}", ident);
+                let comp_ident = format_ident(ident, false, string);
                 quote!(#comp_ident(#ident))
             }
             InterpolatedValue::AssignedVar { key, value } => {
-                let var_ident = format_ident!("var_{}", key);
+                let var_ident = format_ident(key, true, string);
                 quote!(#var_ident(#value))
             }
             InterpolatedValue::AssignedComp { key, value } => {
-                let comp_ident = format_ident!("comp_{}", key);
+                let comp_ident = format_ident(key, false, string);
                 quote!(#comp_ident(#value))
             }
         }
+    }
+}
+
+pub struct InterpolatedValueTokenizer<'a> {
+    string: bool,
+    value: &'a InterpolatedValue,
+}
+
+impl<'a> InterpolatedValueTokenizer<'a> {
+    pub fn new(value: &'a InterpolatedValue, string: bool) -> Self {
+        Self { string, value }
+    }
+}
+
+impl ToTokens for InterpolatedValueTokenizer<'_> {
+    fn to_token_stream(&self) -> proc_macro2::TokenStream {
+        self.value.to_token_stream(self.string)
     }
 
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -1,17 +1,23 @@
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::t_macro::interpolate::InterpolatedValueTokenizer;
+
 use self::parsed_input::{Keys, ParsedInput};
 
 pub mod interpolate;
 pub mod parsed_input;
 
-pub fn t_macro(tokens: proc_macro::TokenStream, direct: bool) -> proc_macro::TokenStream {
+pub fn t_macro(
+    tokens: proc_macro::TokenStream,
+    direct: bool,
+    string: bool,
+) -> proc_macro::TokenStream {
     let input = parse_macro_input!(tokens as ParsedInput);
-    t_macro_inner(input, direct).into()
+    t_macro_inner(input, direct, string).into()
 }
 
-pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStream {
+pub fn t_macro_inner(input: ParsedInput, direct: bool, string: bool) -> proc_macro2::TokenStream {
     let ParsedInput {
         context,
         keys,
@@ -30,7 +36,18 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
             quote!(#get_keys.#namespace #(.#keys)*)
         }
     };
+
+    let build = if string {
+        quote!(build_string)
+    } else {
+        quote!(build)
+    };
+
     let inner = if let Some(interpolations) = interpolations {
+        let interpolations = interpolations
+            .iter()
+            .map(|inter| InterpolatedValueTokenizer::new(inter, string));
+
         quote! {
             {
                 let _key = #get_key;
@@ -38,7 +55,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
                     let _key = _key.#interpolations;
                 )*
                 #[deny(deprecated)]
-                _key.build()
+                _key.#build()
             }
         }
     } else {
@@ -47,7 +64,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool) -> proc_macro2::TokenStre
                 #[allow(unused)]
                 use leptos_i18n::__private::BuildStr;
                 let _key = #get_key;
-                _key.build()
+                _key.#build()
             }
         }
     };

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -11,13 +11,19 @@ pub mod parsed_input;
 pub fn t_macro(
     tokens: proc_macro::TokenStream,
     direct: bool,
-    string: bool,
+    display: bool,
+    to_string: bool,
 ) -> proc_macro::TokenStream {
     let input = parse_macro_input!(tokens as ParsedInput);
-    t_macro_inner(input, direct, string).into()
+    t_macro_inner(input, direct, display, to_string).into()
 }
 
-pub fn t_macro_inner(input: ParsedInput, direct: bool, string: bool) -> proc_macro2::TokenStream {
+pub fn t_macro_inner(
+    input: ParsedInput,
+    direct: bool,
+    display: bool,
+    to_string: bool,
+) -> proc_macro2::TokenStream {
     let ParsedInput {
         context,
         keys,
@@ -37,8 +43,12 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool, string: bool) -> proc_mac
         }
     };
 
-    let build = if string {
-        quote!(build_string)
+    let build = if display {
+        if to_string {
+            quote!(build_string)
+        } else {
+            quote!(build_display)
+        }
     } else {
         quote!(build)
     };
@@ -46,7 +56,7 @@ pub fn t_macro_inner(input: ParsedInput, direct: bool, string: bool) -> proc_mac
     let inner = if let Some(interpolations) = interpolations {
         let interpolations = interpolations
             .iter()
-            .map(|inter| InterpolatedValueTokenizer::new(inter, string));
+            .map(|inter| InterpolatedValueTokenizer::new(inter, display));
 
         quote! {
             {

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -65,3 +65,10 @@ macro_rules! assert_eq_rendered {
         assert_eq!(render_to_string($left), $($right)*)
     };
 }
+
+#[macro_export]
+macro_rules! assert_eq_string {
+    ($left:expr, $($right:tt)*) => {
+        assert_eq!($left.to_string(), $($right)*)
+    };
+}

--- a/tests/json/Cargo.toml
+++ b/tests/json/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 leptos = "0.5.0"
 common = { path = "../common" }
-leptos_i18n = { path = "../../leptos_i18n" }
+leptos_i18n = { path = "../../leptos_i18n", features = ["interpolate_display"] }
 
 
 [package.metadata.leptos-i18n]

--- a/tests/json/src/plurals.rs
+++ b/tests/json/src/plurals.rs
@@ -149,32 +149,32 @@ fn f32_or_plural_string() {
     // count = 0 | 5
     for count in [0.0, 5.0] {
         let en = td_string!(Locale::en, f32_OR_plural, count);
-        assert_eq_string!(en, "0 or 5");
+        assert_eq!(en, "0 or 5");
         let fr = td_string!(Locale::fr, f32_OR_plural, count);
-        assert_eq_string!(fr, "0 or 5");
+        assert_eq!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for count in [1.0, 4.0, 6.0, 9.0] {
         let en = td_string!(Locale::en, f32_OR_plural, count);
-        assert_eq_string!(en, "1..5 | 6..10");
+        assert_eq!(en, "1..5 | 6..10");
         let fr = td_string!(Locale::fr, f32_OR_plural, count);
-        assert_eq_string!(fr, "1..5 | 6..10");
+        assert_eq!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for count in [10.0, 12.0, 14.0, 20.0] {
         let en = td_string!(Locale::en, f32_OR_plural, count);
-        assert_eq_string!(en, "10..15 | 20");
+        assert_eq!(en, "10..15 | 20");
         let fr = td_string!(Locale::fr, f32_OR_plural, count);
-        assert_eq_string!(fr, "10..15 | 20");
+        assert_eq!(fr, "10..15 | 20");
     }
 
     // count = _
     for count in [15.0, 17.0, 21.0, 56.0] {
         let en = td_string!(Locale::en, f32_OR_plural, count);
-        assert_eq_string!(en, "fallback with no count");
+        assert_eq!(en, "fallback with no count");
         let fr = td_string!(Locale::fr, f32_OR_plural, count);
-        assert_eq_string!(fr, "fallback avec tuple vide");
+        assert_eq!(fr, "fallback avec tuple vide");
     }
 }

--- a/tests/json/src/plurals.rs
+++ b/tests/json/src/plurals.rs
@@ -49,6 +49,24 @@ fn u32_plural() {
 }
 
 #[test]
+fn u32_plural_string() {
+    // count = 0
+    let count = 0;
+    let en = td_string!(Locale::en, u32_plural, count);
+    assert_eq!(en.to_string(), "0");
+    let fr = td_string!(Locale::fr, u32_plural, count);
+    assert_eq!(fr.to_string(), "0");
+
+    // count = 1..
+    for count in [1, 45, 72] {
+        let en = td_string!(Locale::en, u32_plural, count);
+        assert_eq!(en.to_string(), "1..");
+        let fr = td_string!(Locale::fr, u32_plural, count);
+        assert_eq!(fr.to_string(), "1..");
+    }
+}
+
+#[test]
 fn or_plural() {
     // count = 0 | 5
     for i in [0, 5] {
@@ -123,5 +141,40 @@ fn f32_or_plural() {
         assert_eq_rendered!(en, "fallback with no count");
         let fr = td!(Locale::fr, f32_OR_plural, count);
         assert_eq_rendered!(fr, "fallback avec tuple vide");
+    }
+}
+
+#[test]
+fn f32_or_plural_string() {
+    // count = 0 | 5
+    for count in [0.0, 5.0] {
+        let en = td_string!(Locale::en, f32_OR_plural, count);
+        assert_eq_string!(en, "0 or 5");
+        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        assert_eq_string!(fr, "0 or 5");
+    }
+
+    // count = 1..5 | 6..10
+    for count in [1.0, 4.0, 6.0, 9.0] {
+        let en = td_string!(Locale::en, f32_OR_plural, count);
+        assert_eq_string!(en, "1..5 | 6..10");
+        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        assert_eq_string!(fr, "1..5 | 6..10");
+    }
+
+    // count = 10..15 | 20
+    for count in [10.0, 12.0, 14.0, 20.0] {
+        let en = td_string!(Locale::en, f32_OR_plural, count);
+        assert_eq_string!(en, "10..15 | 20");
+        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        assert_eq_string!(fr, "10..15 | 20");
+    }
+
+    // count = _
+    for count in [15.0, 17.0, 21.0, 56.0] {
+        let en = td_string!(Locale::en, f32_OR_plural, count);
+        assert_eq_string!(en, "fallback with no count");
+        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        assert_eq_string!(fr, "fallback avec tuple vide");
     }
 }

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -29,26 +29,20 @@ fn subkey_2_string() {
     let b = |f: &mut core::fmt::Formatter,
              children: &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result|
      -> core::fmt::Result {
-        write!(f, "<b>")?;
+        write!(f, "<b>before ")?;
         children(f)?;
-        write!(f, "</b>")
+        write!(f, " after</b>")
     };
     let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
-    assert_eq_string!(en, "<b>subkey_2</b>");
+    assert_eq_string!(en, "<b>before subkey_2 after</b>");
     let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
-    assert_eq_string!(fr, "<b>subkey_2</b>");
+    assert_eq_string!(fr, "<b>before subkey_2 after</b>");
 
-    let b = |f: &mut core::fmt::Formatter,
-             children: &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result|
-     -> core::fmt::Result {
-        write!(f, "<div>before ")?;
-        children(f)?;
-        write!(f, " after</div>")
-    };
+    let b = leptos_i18n::display::DisplayComp("div");
     let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
-    assert_eq_string!(en, "<div>before subkey_2 after</div>");
+    assert_eq_string!(en, "<div>subkey_2</div>");
     let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
-    assert_eq_string!(fr, "<div>before subkey_2 after</div>");
+    assert_eq_string!(fr, "<div>subkey_2</div>");
 }
 
 #[test]

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -25,6 +25,33 @@ fn subkey_2() {
 }
 
 #[test]
+fn subkey_2_string() {
+    let b = |f: &mut core::fmt::Formatter,
+             children: &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result|
+     -> core::fmt::Result {
+        write!(f, "<b>")?;
+        children(f)?;
+        write!(f, "</b>")
+    };
+    let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
+    assert_eq_string!(en, "<b>subkey_2</b>");
+    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
+    assert_eq_string!(fr, "<b>subkey_2</b>");
+
+    let b = |f: &mut core::fmt::Formatter,
+             children: &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result|
+     -> core::fmt::Result {
+        write!(f, "<div>before ")?;
+        children(f)?;
+        write!(f, " after</div>")
+    };
+    let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
+    assert_eq_string!(en, "<div>before subkey_2 after</div>");
+    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
+    assert_eq_string!(fr, "<div>before subkey_2 after</div>");
+}
+
+#[test]
 fn subkey_3() {
     let count = || 0;
     let en = td!(Locale::en, subkeys.subkey_3, count);

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -33,16 +33,16 @@ fn subkey_2_string() {
         children(f)?;
         write!(f, " after</b>")
     };
-    let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
+    let en = td_display!(Locale::en, subkeys.subkey_2, <b>);
     assert_eq_string!(en, "<b>before subkey_2 after</b>");
-    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
+    let fr = td_display!(Locale::fr, subkeys.subkey_2, <b>);
     assert_eq_string!(fr, "<b>before subkey_2 after</b>");
 
     let b = leptos_i18n::display::DisplayComp("div");
     let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
-    assert_eq_string!(en, "<div>subkey_2</div>");
+    assert_eq!(en, "<div>subkey_2</div>");
     let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
-    assert_eq_string!(fr, "<div>subkey_2</div>");
+    assert_eq!(fr, "<div>subkey_2</div>");
 }
 
 #[test]

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -38,11 +38,19 @@ fn subkey_2_string() {
     let fr = td_display!(Locale::fr, subkeys.subkey_2, <b>);
     assert_eq_string!(fr, "<b>before subkey_2 after</b>");
 
-    let b = leptos_i18n::display::DisplayComp("div");
-    let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
+    let en = td_string!(Locale::en, subkeys.subkey_2, <b> = "div");
     assert_eq!(en, "<div>subkey_2</div>");
-    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
+    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b> = "div");
     assert_eq!(fr, "<div>subkey_2</div>");
+
+    let attrs = [("id", Attribute::String("my_id".into()))];
+
+    let b = leptos_i18n::display::DisplayComp::new("span", &attrs);
+
+    let en = td_string!(Locale::en, subkeys.subkey_2, <b>);
+    assert_eq!(en, "<span id=\"my_id\">subkey_2</span>");
+    let fr = td_string!(Locale::fr, subkeys.subkey_2, <b>);
+    assert_eq!(fr, "<span id=\"my_id\">subkey_2</span>");
 }
 
 #[test]

--- a/tests/json/src/tests.rs
+++ b/tests/json/src/tests.rs
@@ -35,15 +35,15 @@ fn click_count() {
 fn click_count_string() {
     for count in -5..5 {
         let en = td_string!(Locale::en, click_count, count);
-        assert_eq_string!(en, format!("You clicked {} times", count));
+        assert_eq!(en, format!("You clicked {} times", count));
         let fr = td_string!(Locale::fr, click_count, count);
-        assert_eq_string!(fr, format!("Vous avez cliqué {} fois", count));
+        assert_eq!(fr, format!("Vous avez cliqué {} fois", count));
     }
 
     let en = td_string!(Locale::en, click_count, count = "a lot of");
-    assert_eq_string!(en, "You clicked a lot of times");
+    assert_eq!(en, "You clicked a lot of times");
     let fr = td_string!(Locale::fr, click_count, count = "beaucoups de");
-    assert_eq_string!(fr, "Vous avez cliqué beaucoups de fois");
+    assert_eq!(fr, "Vous avez cliqué beaucoups de fois");
 }
 
 #[test]

--- a/tests/json/src/tests.rs
+++ b/tests/json/src/tests.rs
@@ -32,6 +32,21 @@ fn click_count() {
 }
 
 #[test]
+fn click_count_string() {
+    for count in -5..5 {
+        let en = td_string!(Locale::en, click_count, count);
+        assert_eq_string!(en, format!("You clicked {} times", count));
+        let fr = td_string!(Locale::fr, click_count, count);
+        assert_eq_string!(fr, format!("Vous avez cliqué {} fois", count));
+    }
+
+    let en = td_string!(Locale::en, click_count, count = "a lot of");
+    assert_eq_string!(en, "You clicked a lot of times");
+    let fr = td_string!(Locale::fr, click_count, count = "beaucoups de");
+    assert_eq_string!(fr, "Vous avez cliqué beaucoups de fois");
+}
+
+#[test]
 fn subkey_3() {
     let count = || 0;
     let en = td!(Locale::en, subkeys.subkey_3, count);


### PR DESCRIPTION
Enabling the `interpolate_display` feature generate code to implement `Display` for the builders.

You can now do

```rust
// click_count = "You clicked {{ count }} times"
assert_eq!(
    td_string!(Locale::en, click_count, count = 10).to_string(),
    "You clicked 10 times"
)
assert_eq!(
    td_string!(Locale::en, click_count, count = "a lot of").to_string(),
    "You clicked a lot of times"
)
```

Variables expect a value `T: Display`, Plural count expect the plural type and components expect.. brace for it ...
```rust
Fn(&mut fmt::Formatter, &dyn Fn(&mut fmt::Formatter) -> fmt::Result) -> fmt::Result
```
Type inference seams wanky with this one, so requires to manually type those unfortunately...
But basically you use it like this:
```rust
let b = |f: &mut core::fmt::Formatter,
    children: &dyn Fn(&mut core::fmt::Formatter) -> core::fmt::Result
    | -> core::fmt::Result {
    write!(f, "<b>")?;
    children(f)?;
    write!(f, "</b>")
};
```

The returned value don't directly implement `IntoString`, it implements `Display`, so you can use any formatters you want and can totally do

```rust
let click_count = td_string!(Locale::en, click_count, count = "a lot of");
println!("{}", click_count); // "You clicked a lot of times"
```
Without creating a temporary string
