### PR TITLE
Direct component for interpolation

### DIFF
--- a/tests/json/locales/en.json
+++ b/tests/json/locales/en.json
@@ -76,5 +76,6 @@
     "foreign_key_to_interpolation": "before {{ @click_count }} after",
     "foreign_key_to_subkey": "before {{ @subkeys.subkey_1 }} after",
     "foreign_key_to_explicit_default": "no explicit default in default locale",
-    "populated_foreign_key": "before {{ @click_count, count = '45' }} after"
+    "populated_foreign_key": "before {{ @click_count, count = '45' }} after",
+    "interpolate_variable_and_comp": "<b>{{ count }}</b>"
 }

--- a/tests/json/locales/fr.json
+++ b/tests/json/locales/fr.json
@@ -78,5 +78,6 @@
     "foreign_key_to_interpolation": "before {{ @click_count }} after",
     "foreign_key_to_subkey": "before {{ @subkeys.subkey_1 }} after",
     "foreign_key_to_explicit_default": "before {{ @defaulted_string }} after",
-    "populated_foreign_key": "before {{ @click_count, count = \"32\" }} after"
+    "populated_foreign_key": "before {{ @click_count, count = \"32\" }} after",
+    "interpolate_variable_and_comp": "<b>{{ count }}</b>"
 }

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -1,17 +1,9 @@
+#![cfg(test)]
 #![deny(warnings)]
 leptos_i18n::load_locales!();
 
-#[cfg(test)]
-mod plurals;
-
-#[cfg(test)]
-mod subkeys;
-
-#[cfg(test)]
-mod tests;
-
-#[cfg(test)]
 mod defaulted;
-
-#[cfg(test)]
 mod foreign;
+mod plurals;
+mod subkeys;
+mod tests;

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -22,6 +22,11 @@ fn subkey_2() {
     assert_eq_rendered!(en, "<div>before subkey_2 after</div>");
     let fr = td!(Locale::fr, subkeys.subkey_2, <b>);
     assert_eq_rendered!(fr, "<div>before subkey_2 after</div>");
+
+    let en = td!(Locale::en, subkeys.subkey_2, <b> = <span attr:id="test"/>);
+    assert_eq_rendered!(en, "<span id=\"test\">subkey_2</span>");
+    let fr = td!(Locale::fr, subkeys.subkey_2, <b> = <span/>);
+    assert_eq_rendered!(fr, "<span>subkey_2</span>");
 }
 
 #[test]

--- a/tests/json/src/tests.rs
+++ b/tests/json/src/tests.rs
@@ -64,3 +64,12 @@ fn subkey_3() {
     let fr = td!(Locale::fr, subkeys.subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }
+
+#[test]
+fn interpolate_variable_and_comp() {
+    let en =
+        td!(Locale::en, interpolate_variable_and_comp, <b> = <span attr:id="test"/>, count = 12);
+    assert_eq_rendered!(en, "<span id=\"test\">12</span>");
+    let fr = td!(Locale::fr, interpolate_variable_and_comp, <b> = <span/>, count = 34);
+    assert_eq_rendered!(fr, "<span>34</span>");
+}


### PR DESCRIPTION
This PR add this syntax to `t!` and `td!` for components:

```rust
// key = "<b>{{ count }}</b>"
t!(i18n, key, <b> = <span />, count = 32);
```

This will render `<span>32</span>`.

You can set attributes, event handlers, props ect:

```rust
t!(i18n, key, <b> = <span attr:id="my_id" on:click=|_| { /* do stuff */} />, count = 0);
```

Basically `<name .../>` expand to `move |children| view! { <name ...>{move || children()}</name> }`