### PR TITLE
Flatten blocs of parsed value

### DIFF
--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -151,7 +151,10 @@ impl Locale {
                 let ParsedValue::Subkeys(subkeys) = value else {
                     return None;
                 };
-                subkeys.get_value_at(path)
+                match subkeys {
+                    None => unreachable!("called get_value_at on empty subkeys. If you got this error please open an issue on github."),
+                    Some(subkeys) => subkeys.get_value_at(path)
+                }
             }
         }
     }


### PR DESCRIPTION
This make `Bloc(String, Bloc(String, Variable, String), String)` turn into `Bloc(String, Variable, String)` where strings are merged together even at different depth, this takes a bit more computation but can avoid some unecessary overhead at runtime.