### PR TITLE
Fix explicit default in default locale

### DIFF
--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -29,6 +29,17 @@ use self::{
     warning::generate_warnings,
 };
 
+/// Steps:
+///
+/// 1: Locate and parse the manifest (`ConfigFile::new`)
+/// 2: parse each locales/namespaces files (`LocalesOrNamespaces::new`)
+/// 3: Resolve foreign keys (`ParsedValue::resolve_foreign_keys`)
+/// 4: check the locales: (`Locale::check_locales`)
+/// 4.1: get interpolations keys of the default, meaning all variables/components/plurals of the default locale (`Locale::make_builder_keys`)
+/// 4.2: in the process reduce all values and check for default in the default locale
+/// 4.3: then merge all other locales in the default locale keys, reducing all values in the process (`Locale::merge`)
+/// 4.4: discard any surplus key and emit a warning
+/// 5: generate code (and warnings)
 pub fn load_locales() -> Result<TokenStream> {
     let mut cargo_manifest_dir: PathBuf = std::env::var("CARGO_MANIFEST_DIR")
         .map_err(Error::CargoDirEnvNotPresent)?


### PR DESCRIPTION
Previously the check for explicit default in the default locale was only done at depth 1, so it was still possible to put explicit defaults in subkeys for the default locale, which would cause the generation of bad code.

This also fix an edge case where you could have a foreign key to an explicit default in the default locale, entering an infinite loop as foreign key to a default would then resolve the default, entering an infinite loop and causing a rustc stack overflow.