### PR TITLE
fix: allow the 'ssr' and 'hydrate' features to be enabled together

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,8 @@ If examples works better for you, you can look at the different examples availab
 
 ## Features
 
-You must enable the `hydrate` feature when building the client, either the `actix` or `axum` feature when building the server, and the `csr` feature when building with CSR.
+You must enable the `hydrate` feature when building the client, either the `actix` or `axum` feature when building the server, and the `csr` feature when building with CSR. Only one of these features
+should be enabled at a time.
 
 The `cookie` feature enable to set a cookie when a locale is chosen by the user, this feature is enabled by default.
 

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cfg-if = "1.0.0"
 leptos_i18n_macro = { workspace = true }
 leptos = "0.5"
 leptos_meta = "0.5"
@@ -39,14 +40,24 @@ interpolate_display = ["leptos_i18n_macro/interpolate_display"]
 
 [package.metadata.cargo-all-features]
 denylist = [
-    "ssr",
-    "nightly",
-    "yaml_files",
+    # Always exclude:
+    "ssr",        # Should always be enabled via a server integration rather than directly - see `./src/server/mod.rs`
+    "yaml_files", # See leptos_i18n_macro manifest to see why "yaml_files" and other formats are in deny list and JSON is always included
+    "nightly",    # Requires a nightly toolchain
+
+    # Only passed through to `leptos_i18n_macros`, exclude to save time:
     "serde",
     "debug_interpolations",
     "suppress_key_warnings",
 ]
 skip_feature_sets = [
+    # Axum and Actix features are incompatible with each other - see `./src/server/mod.rs`, always exclude:
+    [
+        "axum",
+        "actix",
+    ],
+
+    # Only one of `hydrate`, (`axum`, `actix`), `csr` should be enabled in a single crate, exclude to save time:
     [
         "actix",
         "hydrate",

--- a/leptos_i18n/src/fetch_locale.rs
+++ b/leptos_i18n/src/fetch_locale.rs
@@ -1,43 +1,39 @@
 use crate::Locale;
 
-#[cfg(feature = "ssr")]
-#[inline]
-pub fn fetch_locale<T: Locale>() -> T {
-    crate::server::fetch_locale_server_side::<T>()
-}
-
-#[cfg(feature = "hydrate")]
-pub fn fetch_locale<T: Locale>() -> T {
-    leptos::document()
-        .document_element()
-        .and_then(|el| el.get_attribute("lang"))
-        .and_then(|lang| T::from_str(&lang))
-        .unwrap_or_default()
-}
-
-#[cfg(not(any(
-    feature = "ssr",
-    feature = "hydrate",
-    all(feature = "csr", feature = "cookie")
-)))]
-#[inline]
-pub fn fetch_locale<T: Locale>() -> T {
-    Default::default()
-}
-
-#[cfg(all(feature = "csr", feature = "cookie"))]
-pub fn fetch_locale<T: Locale>() -> T {
-    fn inner<T: Locale>() -> Option<T> {
-        let document = super::get_html_document()?;
-        let cookies = document.cookie().ok()?;
-        cookies.split(';').find_map(|cookie| {
-            let (key, value) = cookie.split_once('=')?;
-            if key.trim() == super::COOKIE_PREFERED_LANG {
-                T::from_str(value)
-            } else {
-                None
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "ssr", not(any(feature = "hydrate", all(feature="csr", feature="cookie")))))] {
+        #[inline]
+        pub fn fetch_locale<T: Locale>() -> T {
+            crate::server::fetch_locale_server_side::<T>()
+        }
+    } else if #[cfg(all(feature = "hydrate", not(any(all(feature="csr", feature="cookie"), feature = "ssr"))))] {
+        pub fn fetch_locale<T: Locale>() -> T {
+            leptos::document()
+                .document_element()
+                .and_then(|el| el.get_attribute("lang"))
+                .and_then(|lang| T::from_str(&lang))
+                .unwrap_or_default()
+        }
+    } else if #[cfg(all(all(feature="csr", feature="cookie"), not(any(feature = "ssr", feature = "hydrate"))))] {
+        pub fn fetch_locale<T: Locale>() -> T {
+            fn inner<T: Locale>() -> Option<T> {
+                let document = super::get_html_document()?;
+                let cookies = document.cookie().ok()?;
+                cookies.split(';').find_map(|cookie| {
+                    let (key, value) = cookie.split_once('=')?;
+                    if key.trim() == super::COOKIE_PREFERED_LANG {
+                        T::from_str(value)
+                    } else {
+                        None
+                    }
+                })
             }
-        })
+            inner().unwrap_or_default()
+        }
+    } else {
+        #[inline]
+        pub fn fetch_locale<T: Locale>() -> T {
+            Default::default()
+        }
     }
-    inner().unwrap_or_default()
 }

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -126,7 +126,10 @@
 mod context;
 mod fetch_locale;
 mod locale_traits;
-#[cfg(feature = "ssr")]
+#[cfg(all(
+    feature = "ssr",
+    not(any(feature = "hydrate", all(feature = "csr", feature = "cookie")))
+))]
 mod server;
 
 #[cfg(feature = "interpolate_display")]


### PR DESCRIPTION
Refactor `fetch_locale.rs` to use a `cfg_if` case flow to determine which implementation of `fetch_locale` to enable. This ensures only one implementation will ever be enabled.

Add a dependency on https://github.com/rust-lang/cfg-if to `leptos_i18n`.

Fixes: #82