### PR TITLE
Update leptos dep to 0.6

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/counter_plurals/Cargo.toml
+++ b/examples/counter_plurals/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/csr/Cargo.toml
+++ b/examples/csr/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/hello_world_actix/Cargo.toml
+++ b/examples/hello_world_actix/Cargo.toml
@@ -9,17 +9,17 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-files = { version = "0.6.2", optional = true }
-actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
-leptos = "0.5.0"
-leptos_meta = "0.5.0"
-leptos_actix = { version = "0.5.0", optional = true }
+actix-files = { version = "0.6", optional = true }
+actix-web = { version = "4.4", optional = true, features = ["macros"] }
+leptos = "0.6"
+leptos_meta = "0.6"
+leptos_actix = { version = "0.6.0", optional = true }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
-wasm-bindgen = { version = "=0.2.87", optional = true }
+wasm-bindgen = { version = "=0.2.90", optional = true }
 
 [features]
 hydrate = [

--- a/examples/hello_world_actix/src/main.rs
+++ b/examples/hello_world_actix/src/main.rs
@@ -30,7 +30,6 @@ async fn main() -> std::io::Result<()> {
         let site_root = &leptos_options.site_root;
 
         App::new()
-            .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
             // serve JS/WASM/CSS from `pkg`
             .service(Files::new("/pkg", format!("{site_root}/pkg")))
             // serve other assets from the `assets` directory

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 simple_logger = "4"
-tokio = { version = "1.35", optional = true }
+tokio = { version = "1.35", features = ["rt-multi-thread"], optional = true }
 log = "0.4"
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.6", optional = true }
-leptos = "0.5.0"
-leptos_meta = "0.5.0"
-leptos_axum = { version = "0.5.0", optional = true }
+axum = { version = "0.7", optional = true }
+leptos = "0.6"
+leptos_meta = "0.6"
+leptos_axum = { version = "0.6", optional = true }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
 ] }
@@ -20,10 +20,10 @@ serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 simple_logger = "4"
-tokio = { version = "1.25.0", optional = true }
+tokio = { version = "1.35", optional = true }
 log = "0.4"
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.4", features = ["fs"], optional = true }
+tower-http = { version = "0.5", features = ["fs"], optional = true }
 
 [features]
 hydrate = [

--- a/examples/hello_world_axum/src/fileserv.rs
+++ b/examples/hello_world_axum/src/fileserv.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use leptos::*;
 use tower::ServiceExt;
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, fs::ServeFileSystemResponseBody};
 
 pub async fn file_and_error_handler(
     uri: Uri,
@@ -22,23 +22,19 @@ pub async fn file_and_error_handler(
         res.into_response()
     } else {
         let handler =
-            leptos_axum::render_app_to_stream(options.to_owned(), move || view! {<App/>});
+            leptos_axum::render_app_to_stream(options.to_owned(), App);
         handler(req).await.into_response()
     }
 }
 
-async fn get_static_file(uri: Uri, root: &str) -> Result<Response<BoxBody>, (StatusCode, String)> {
+async fn get_static_file(uri: Uri, root: &str) -> Result<Response<ServeFileSystemResponseBody>, (StatusCode, String)> {
     let req = Request::builder()
         .uri(uri.clone())
         .body(Body::empty())
         .unwrap();
     // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
     // This path is relative to the cargo root
-    match ServeDir::new(root).oneshot(req).await {
-        Ok(res) => Ok(res.map(boxed)),
-        Err(err) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Something went wrong: {err}"),
-        )),
-    }
+    ServeDir::new(root)
+        .oneshot(req).await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, format!("Something went wrong: {err}")))
 }

--- a/examples/hello_world_axum/src/fileserv.rs
+++ b/examples/hello_world_axum/src/fileserv.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use axum::response::Response as AxumResponse;
 use axum::{
-    body::{boxed, Body, BoxBody},
+    body::Body,
     extract::State,
     http::{Request, Response, StatusCode, Uri},
     response::IntoResponse,

--- a/examples/hello_world_axum/src/main.rs
+++ b/examples/hello_world_axum/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`
     logging::log!("listening on http://{}", &addr);
-    let listener TcpListener::bind(&addr).await.unwrap();
+    let listener = TcpListener::bind(&addr).await.unwrap();
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();

--- a/examples/hello_world_axum/src/main.rs
+++ b/examples/hello_world_axum/src/main.rs
@@ -8,6 +8,7 @@ async fn main() {
     use hello_world_axum::fileserv::file_and_error_handler;
     use leptos::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
+    use tokio::net::TcpListener;
 
     simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
@@ -19,20 +20,20 @@ async fn main() {
     let conf = get_configuration(None).await.unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
-    let routes = generate_route_list(|| view! {  <App/> });
+    let routes = generate_route_list(App);
 
     // build our application with a route
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-        .leptos_routes(&leptos_options, routes, || view! {  <App/> })
+        .leptos_routes(&leptos_options, routes, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`
     logging::log!("listening on http://{}", &addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }

--- a/examples/interpolation/Cargo.toml
+++ b/examples/interpolation/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/namespaces/Cargo.toml
+++ b/examples/namespaces/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/subkeys/Cargo.toml
+++ b/examples/subkeys/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
     "csr",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/examples/workspace/counter/Cargo.toml
+++ b/examples/workspace/counter/Cargo.toml
@@ -9,15 +9,15 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-files = { version = "0.6.2", optional = true }
-actix-web = { version = "4.3.1", optional = true, features = ["macros"] }
-leptos = "0.5.0"
-leptos_meta = "0.5.0"
-leptos_actix = { version = "0.5.0", optional = true }
+actix-files = { version = "0.6", optional = true }
+actix-web = { version = "4.4", optional = true, features = ["macros"] }
+leptos = "0.6"
+leptos_meta = "0.6"
+leptos_actix = { version = "0.6", optional = true }
 leptos_i18n = { workspace = true, features = ["debug_interpolations"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
-wasm-bindgen = { version = "=0.2.87", optional = true }
+wasm-bindgen = { version = "=0.2.90", optional = true }
 
 [features]
 hydrate = [

--- a/examples/yaml/Cargo.toml
+++ b/examples/yaml/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.5.0", features = ["csr"] }
-leptos_meta = { version = "0.5.0", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
+leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_i18n = { path = "../../leptos_i18n", default-features = false, features = [
     "debug_interpolations",
     "csr",
@@ -16,7 +16,7 @@ leptos_i18n = { path = "../../leptos_i18n", default-features = false, features =
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "=0.2.90" }
 
 [package.metadata.leptos-i18n]
 default = "en"

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -13,13 +13,14 @@ readme = "../README.md"
 [dependencies]
 cfg-if = "1.0.0"
 leptos_i18n_macro = { workspace = true }
-leptos = "0.5"
-leptos_meta = "0.5"
+leptos = "0.6"
+leptos_meta = "0.6"
 actix-web = { version = "4", optional = true }
-axum = { version = "0.6", optional = true }
-leptos_axum = { version = "0.5", optional = true }
+axum = { version = "0.7", optional = true }
+leptos_axum = { version = "0.6", optional = true }
 web-sys = { version = "0.3", optional = true, features = ["HtmlDocument"] }
 wasm-bindgen = { version = "0.2", optional = true }
+http = { version = "1", optional = true }
 
 [features]
 default = ["cookie", "json_files"]
@@ -28,7 +29,7 @@ cookie = ["dep:web-sys", "dep:wasm-bindgen"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate"]
 ssr = ["leptos/ssr", "leptos_meta/ssr"]
 actix = ["ssr", "dep:actix-web"]
-axum = ["ssr", "dep:axum", "dep:leptos_axum"]
+axum = ["ssr", "dep:axum", "dep:leptos_axum", "dep:http"]
 csr = ["leptos/csr", "leptos_meta/csr"]
 serde = ["leptos_i18n_macro/serde"]
 debug_interpolations = ["leptos_i18n_macro/debug_interpolations"]

--- a/leptos_i18n/src/server/axum.rs
+++ b/leptos_i18n/src/server/axum.rs
@@ -1,15 +1,16 @@
 use crate::locale_traits::*;
 use axum::http::header;
+use http::request::Parts;
 
 pub fn fetch_locale_server<T: Locale>() -> T {
     // when leptos_router inspect the routes it execute the code once but don't set a RequestParts in the context,
     // so we can't expect it to be present.
-    leptos::use_context::<leptos_axum::RequestParts>()
+    leptos::use_context::<Parts>()
         .map(|req| from_req(&req))
         .unwrap_or_default()
 }
 
-fn from_req<T: Locale>(req: &leptos_axum::RequestParts) -> T {
+fn from_req<T: Locale>(req: &Parts) -> T {
     #[cfg(feature = "cookie")]
     if let Some(pref_lang_cookie) = get_prefered_lang_cookie::<T>(req) {
         return pref_lang_cookie;
@@ -29,7 +30,7 @@ fn from_req<T: Locale>(req: &leptos_axum::RequestParts) -> T {
 }
 
 #[cfg(feature = "cookie")]
-fn get_prefered_lang_cookie<T: Locale>(req: &leptos_axum::RequestParts) -> Option<T> {
+fn get_prefered_lang_cookie<T: Locale>(req: &Parts) -> Option<T> {
     req.headers
         .get_all(header::COOKIE)
         .into_iter()

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -20,7 +20,7 @@ serde_yaml = { version = "0.9", optional = true }
 proc-macro2 = "1"
 quote = "1"
 syn = "2.0"
-toml = "0.7"
+toml = "0.8"
 
 [features]
 default = ["json_files"]

--- a/leptos_i18n_macro/src/t_macro/parsed_input.rs
+++ b/leptos_i18n_macro/src/t_macro/parsed_input.rs
@@ -1,7 +1,9 @@
 use proc_macro2::Ident;
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::token::Comma;
-use syn::{Expr, Token};
+use syn::{
+    token::Comma,
+    {Expr, Token},
+};
 
 use super::interpolate::InterpolatedValue;
 

--- a/tests/common/Cargo.toml
+++ b/tests/common/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.5.0"
+leptos = "0.6"

--- a/tests/json/Cargo.toml
+++ b/tests/json/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.5.0"
+leptos = "0.6"
 common = { path = "../common" }
 leptos_i18n = { path = "../../leptos_i18n", features = ["interpolate_display"] }
 

--- a/tests/namespaces/Cargo.toml
+++ b/tests/namespaces/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.5.0"
+leptos = "0.6"
 common = { path = "../common" }
 leptos_i18n = { path = "../../leptos_i18n" }
 

--- a/tests/yaml/Cargo.toml
+++ b/tests/yaml/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.5.0"
+leptos = "0.6"
 common = { path = "../common" }
 leptos_i18n = { path = "../../leptos_i18n", default-features = false, features = [
     "yaml_files",


### PR DESCRIPTION
Leptos released it;s 0.6.x version a few days ago. Since I'm using this library as a dependency, I figured I'd take the liberty to update the leptos version depended on.