### PR TITLE
Track locales files in proc macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ The `cookie` feature enable to set a cookie when a locale is chosen by the user,
 The `serde` feature implement `serde::Serialize` and `serde::Deserialize` for the locale enum.
 
 The `nightly` feature enable to do `i18n()` to get the locale instead of `i18n.get_locale()` and `i18n(new_locale)` instead of `i18n.set_locale(new_locale)`.
-It also allow macros to use unstable APIs for better warnings and to track the locales files as dependencies.
+It also allow macros to use unstable APIs for better warnings.
 
 The `debug_interpolations` feature enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 Better compilation errors are generated for interpolations with 4 keys or less.
@@ -612,7 +612,7 @@ The `track_locale_files` feature is to track files for rebuilds. The `load_local
 you may have noticed that if you use `cargo-leptos` with `watch-additional-files = ["locales"]` and running `cargo leptos watch`, even if the file changes and cargo-leptos triggers a rebuild nothing changes.
 This feature use a "trick" by using `include_bytes!()` to declare the use of a file, but I'm a bit sceptical of the impact on build time using this.
 I've already checked and it does not include the bytes in the final binary, even in debug, but it may slow down compilation time.
-If you use the `nighly` feature it already use the proc_macro tracking API so this feature is not used.
+If you use the `nighly` feature it use the [path tracking API](https://github.com/rust-lang/rust/issues/99515) so no trick using `include_bytes!` and the possible slowdown in compile times coming with it.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ The `cookie` feature enable to set a cookie when a locale is chosen by the user,
 The `serde` feature implement `serde::Serialize` and `serde::Deserialize` for the locale enum.
 
 The `nightly` feature enable to do `i18n()` to get the locale instead of `i18n.get_locale()` and `i18n(new_locale)` instead of `i18n.set_locale(new_locale)`.
+It also allow macros to use unstable APIs for better warnings and to track the locales files as dependencies.
 
 The `debug_interpolations` feature enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
 Better compilation errors are generated for interpolations with 4 keys or less.
@@ -606,6 +607,12 @@ The `suppress_key_warnings` feature remove the warning emission of the `load_loc
 The `json_files` feature tell the macro to expect JSON files for the locales, enabled by default
 
 The `yaml_files` feature tell the macro to expect YAML files for the locales
+
+The `track_locale_files` feature is to track files for rebuilds. The `load_locales!()` macro using external dependencies the build system is not aware that the macro should be rerun when those files changes,
+you may have noticed that if you use `cargo-leptos` with `watch-additional-files = ["locales"]` and running `cargo leptos watch`, even if the file changes and cargo-leptos triggers a rebuild nothing changes.
+This feature use a "trick" by using `include_bytes!()` to declare the use of a file, but I'm a bit sceptical of the impact on build time using this.
+I've already checked and it does not include the bytes in the final binary, even in debug, but it may slow down compilation time.
+If you use the `nighly` feature it already use the proc_macro tracking API so this feature is not used.
 
 ## Contributing
 

--- a/docs/book/src/06_features.md
+++ b/docs/book/src/06_features.md
@@ -46,7 +46,6 @@ Set a cookie to remember the last chosen locale.
 
 - Enable the use of some nighly features, like directly calling the context to get/set the current locale.
 - Allow the `load_locale!` macro to emit better warnings.
-- Allow tracking of locale files as dependencies for rebuilds.
 
 #### `track_locale_files`
 
@@ -55,4 +54,4 @@ The `load_locales!()` macro using external dependencies the build system is not 
 you may have noticed that if you use `cargo-leptos` with `watch-additional-files = ["locales"]` and running `cargo leptos watch`, even if the file changes and cargo-leptos triggers a rebuild nothing changes.
 This feature use a "trick" by using `include_bytes!()` to declare the use of a file, but I'm a bit sceptical of the impact on build time using this.
 I've already checked and it does not include the bytes in the final binary, even in debug, but it may slow down compilation time.
-If you use the `nighly` feature it already use the proc_macro tracking API so this feature is pointless.
+If you use the `nighly` feature it use the [path tracking API](https://github.com/rust-lang/rust/issues/99515) so no trick using `include_bytes!` and the possible slowdown in compile times coming with it.

--- a/docs/book/src/06_features.md
+++ b/docs/book/src/06_features.md
@@ -44,4 +44,15 @@ Set a cookie to remember the last chosen locale.
 
 #### `nightly`
 
-Enable the use of some nighly features, like directly calling the context to get/set the current locale, also allow the `load_locale!` macro to emit better warnings.
+- Enable the use of some nighly features, like directly calling the context to get/set the current locale.
+- Allow the `load_locale!` macro to emit better warnings.
+- Allow tracking of locale files as dependencies for rebuilds.
+
+#### `track_locale_files`
+
+Allow tracking of locale files as dependencies for rebuilds in stable.
+The `load_locales!()` macro using external dependencies the build system is not aware that the macro should be rerun when those files changes,
+you may have noticed that if you use `cargo-leptos` with `watch-additional-files = ["locales"]` and running `cargo leptos watch`, even if the file changes and cargo-leptos triggers a rebuild nothing changes.
+This feature use a "trick" by using `include_bytes!()` to declare the use of a file, but I'm a bit sceptical of the impact on build time using this.
+I've already checked and it does not include the bytes in the final binary, even in debug, but it may slow down compilation time.
+If you use the `nighly` feature it already use the proc_macro tracking API so this feature is pointless.

--- a/examples/hello_world_actix/Cargo.toml
+++ b/examples/hello_world_actix/Cargo.toml
@@ -16,6 +16,7 @@ leptos_meta = "0.6"
 leptos_actix = { version = "0.6.0", optional = true }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
+    "track_locale_files",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }

--- a/examples/hello_world_actix/Cargo.toml
+++ b/examples/hello_world_actix/Cargo.toml
@@ -87,5 +87,11 @@ lib-features = ["hydrate"]
 # Optional. Defaults to false.
 lib-default-features = false
 
+# Additional files your application could depends on.
+# A change to any file in those directories will trigger a rebuild.
+#
+# Optional.
+watch-additional-files = ["locales"]
+
 [package.metadata.cargo-all-features]
 skip_feature_sets = [["hydrate", "ssr"]]

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -93,5 +93,11 @@ lib-features = ["hydrate"]
 # Optional. Defaults to false.
 lib-default-features = false
 
+# Additional files your application could depends on.
+# A change to any file in those directories will trigger a rebuild.
+#
+# Optional.
+watch-additional-files = ["locales"]
+
 [package.metadata.cargo-all-features]
 skip_feature_sets = [["hydrate", "ssr"]]

--- a/examples/hello_world_axum/Cargo.toml
+++ b/examples/hello_world_axum/Cargo.toml
@@ -15,6 +15,7 @@ leptos_meta = "0.6"
 leptos_axum = { version = "0.6", optional = true }
 leptos_i18n = { path = "../../leptos_i18n", features = [
     "debug_interpolations",
+    "track_locale_files",
 ] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -37,6 +37,7 @@ suppress_key_warnings = ["leptos_i18n_macro/suppress_key_warnings"]
 json_files = ["leptos_i18n_macro/json_files"]
 yaml_files = ["leptos_i18n_macro/yaml_files"]
 interpolate_display = ["leptos_i18n_macro/interpolate_display"]
+track_locale_files = ["leptos_i18n_macro/track_locale_files"]
 
 
 [package.metadata.cargo-all-features]
@@ -50,6 +51,7 @@ denylist = [
     "serde",
     "debug_interpolations",
     "suppress_key_warnings",
+    "track_locale_files",
 ]
 skip_feature_sets = [
     # Axum and Actix features are incompatible with each other - see `./src/server/mod.rs`, always exclude:

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -45,6 +45,7 @@
 //! - `suppress_key_warnings`: Disable the warning emission of the `load_locales!()` macro when some keys are missing or ignored.
 //! - `yaml_files`: Enable this feature if you use YAML files for declaring your locales (can't be used with `json_files`).
 //! - `nightly`: On `nightly` Rust, enables the function-call syntax on the i18n context to get/set the locale.
+//! - `track_locale_files`: Enable the tracking of locale files as dependencies, usefull if you use some watcher. See the README for more infos.
 //!
 //! # A Simple Counter
 //!

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -31,6 +31,7 @@ suppress_key_warnings = []
 json_files = ["serde_json"]
 yaml_files = ["serde_yaml"]
 interpolate_display = []
+track_locale_files = []
 
 [package.metadata.cargo-all-features]
 # cargo-all-features don't provide a way to always include one feature in a set, so CI will just do json...

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![deny(warnings)]
-#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic))]
+#![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic, track_path))]
 //! # About Leptos i18n macro
 //!
 //! This crate expose the utility macro for `leptos_i18n`

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -10,6 +10,7 @@ use super::{
     error::{Error, Result},
     key::{Key, KeyPath},
     parsed_value::{InterpolateKey, ParsedValue, ParsedValueSeed},
+    tracking::track_file,
     warning::{emit_warning, Warning},
 };
 
@@ -190,16 +191,7 @@ impl Locale {
         locale: Rc<Key>,
         namespace: Option<Rc<Key>>,
     ) -> Result<Self> {
-        #[cfg(feature = "nightly")]
-        if let Some(path) = path.as_os_str().to_str() {
-            proc_macro::tracked_path::path(path);
-        } else {
-            emit_warning(Warning::NonUnicodePath {
-                locale: locale.clone(),
-                namespace: namespace.clone(),
-                path: path.clone(),
-            });
-        }
+        track_file(&locale, namespace.as_ref(), path);
 
         let seed = LocaleSeed {
             name: Rc::clone(&locale),

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -190,6 +190,17 @@ impl Locale {
         locale: Rc<Key>,
         namespace: Option<Rc<Key>>,
     ) -> Result<Self> {
+        #[cfg(feature = "nightly")]
+        if let Some(path) = path.as_os_str().to_str() {
+            proc_macro::tracked_path::path(path);
+        } else {
+            emit_warning(Warning::NonUnicodePath {
+                locale: locale.clone(),
+                namespace: namespace.clone(),
+                path: path.clone(),
+            });
+        }
+
         let seed = LocaleSeed {
             name: Rc::clone(&locale),
             top_locale_name: locale,

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -12,6 +12,7 @@ pub mod key;
 pub mod locale;
 pub mod parsed_value;
 pub mod plural;
+pub mod tracking;
 pub mod warning;
 
 use cfg_file::ConfigFile;
@@ -67,8 +68,12 @@ pub fn load_locales() -> Result<TokenStream> {
         )
     };
 
+    let file_tracking = tracking::generate_file_tracking();
+
     Ok(quote! {
         pub mod i18n {
+            #file_tracking
+
             #locale_enum
 
             #locale_type

--- a/leptos_i18n_macro/src/load_locales/tracking.rs
+++ b/leptos_i18n_macro/src/load_locales/tracking.rs
@@ -1,0 +1,41 @@
+use std::{path::PathBuf, rc::Rc};
+
+use super::key::Key;
+
+#[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
+thread_local! {
+    pub static LOCALES_PATH: std::cell::RefCell<Vec<String>>  = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
+pub fn generate_file_tracking() -> proc_macro2::TokenStream {
+    LOCALES_PATH
+        .with_borrow(|paths| quote::quote!(#(const _: &'static [u8] = include_bytes!(#paths);)*))
+}
+
+#[cfg(any(not(feature = "track_locale_files"), feature = "nightly"))]
+pub fn generate_file_tracking() -> proc_macro2::TokenStream {
+    proc_macro2::TokenStream::new()
+}
+
+#[cfg(any(feature = "nightly", feature = "track_locale_files"))]
+pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
+    use super::warning::Warning;
+    if let Some(path) = path.as_os_str().to_str() {
+        #[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
+        LOCALES_PATH.with_borrow_mut(|paths| paths.push(path.to_owned()));
+        #[cfg(feature = "nightly")]
+        proc_macro::tracked_path::path(path);
+    } else {
+        super::warning::emit_warning(Warning::NonUnicodePath {
+            locale: locale.clone(),
+            namespace: namespace.cloned(),
+            path: path.clone(),
+        });
+    }
+}
+
+#[cfg(not(any(feature = "nightly", feature = "track_locale_files")))]
+pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
+    let _ = (locale, namespace, path);
+}

--- a/leptos_i18n_macro/src/load_locales/tracking.rs
+++ b/leptos_i18n_macro/src/load_locales/tracking.rs
@@ -2,40 +2,55 @@ use std::{path::PathBuf, rc::Rc};
 
 use super::key::Key;
 
-#[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
-thread_local! {
-    pub static LOCALES_PATH: std::cell::RefCell<Vec<String>>  = const { std::cell::RefCell::new(Vec::new()) };
-}
+#[cfg(feature = "track_locale_files")]
+mod inner {
+    use super::*;
 
-#[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
-pub fn generate_file_tracking() -> proc_macro2::TokenStream {
-    LOCALES_PATH
-        .with_borrow(|paths| quote::quote!(#(const _: &'static [u8] = include_bytes!(#paths);)*))
-}
+    #[cfg(not(feature = "nightly"))]
+    thread_local! {
+        pub static LOCALES_PATH: std::cell::RefCell<Vec<String>>  = const { std::cell::RefCell::new(Vec::new()) };
+    }
 
-#[cfg(any(not(feature = "track_locale_files"), feature = "nightly"))]
-pub fn generate_file_tracking() -> proc_macro2::TokenStream {
-    proc_macro2::TokenStream::new()
-}
+    #[cfg(not(feature = "nightly"))]
+    pub fn generate_file_tracking() -> proc_macro2::TokenStream {
+        LOCALES_PATH.with_borrow(
+            |paths| quote::quote!(#(const _: &'static [u8] = include_bytes!(#paths);)*),
+        )
+    }
 
-#[cfg(any(feature = "nightly", feature = "track_locale_files"))]
-pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
-    use super::warning::Warning;
-    if let Some(path) = path.as_os_str().to_str() {
-        #[cfg(all(feature = "track_locale_files", not(feature = "nightly")))]
-        LOCALES_PATH.with_borrow_mut(|paths| paths.push(path.to_owned()));
-        #[cfg(feature = "nightly")]
-        proc_macro::tracked_path::path(path);
-    } else {
-        super::warning::emit_warning(Warning::NonUnicodePath {
-            locale: locale.clone(),
-            namespace: namespace.cloned(),
-            path: path.clone(),
-        });
+    #[cfg(feature = "nightly")]
+    pub fn generate_file_tracking() -> proc_macro2::TokenStream {
+        proc_macro2::TokenStream::new()
+    }
+
+    pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
+        use crate::load_locales::warning::{emit_warning, Warning};
+        if let Some(path) = path.as_os_str().to_str() {
+            #[cfg(not(feature = "nightly"))]
+            LOCALES_PATH.with_borrow_mut(|paths| paths.push(path.to_owned()));
+            #[cfg(feature = "nightly")]
+            proc_macro::tracked_path::path(path);
+        } else {
+            emit_warning(Warning::NonUnicodePath {
+                locale: locale.clone(),
+                namespace: namespace.cloned(),
+                path: path.clone(),
+            });
+        }
     }
 }
 
-#[cfg(not(any(feature = "nightly", feature = "track_locale_files")))]
-pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
-    let _ = (locale, namespace, path);
+#[cfg(not(feature = "track_locale_files"))]
+mod inner {
+    use super::*;
+
+    pub fn generate_file_tracking() -> proc_macro2::TokenStream {
+        proc_macro2::TokenStream::new()
+    }
+
+    pub fn track_file(locale: &Rc<Key>, namespace: Option<&Rc<Key>>, path: &PathBuf) {
+        let _ = (locale, namespace, path);
+    }
 }
+
+pub use inner::*;

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -15,7 +15,7 @@ pub enum Warning {
         locale: Rc<Key>,
         key_path: KeyPath,
     },
-    #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
+    #[cfg(feature = "track_locale_files")]
     NonUnicodePath {
         locale: Rc<Key>,
         namespace: Option<Rc<Key>>,
@@ -44,9 +44,9 @@ impl Display for Warning {
                 "Key {} is present in locale {:?} but not in default locale, it is ignored",
                 key_path, locale
             ),
-            #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
+            #[cfg(feature = "track_locale_files")]
             Warning::NonUnicodePath { locale, namespace: None, path } => write!(f, "File path for locale {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, path),
-            #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
+            #[cfg(feature = "track_locale_files")]
             Warning::NonUnicodePath { locale, namespace: Some(ns), path } => write!(f, "File path for locale {:?} in namespace {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, ns, path),
         }
     }

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -15,7 +15,7 @@ pub enum Warning {
         locale: Rc<Key>,
         key_path: KeyPath,
     },
-    #[cfg(feature = "nightly")]
+    #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
     NonUnicodePath {
         locale: Rc<Key>,
         namespace: Option<Rc<Key>>,
@@ -44,9 +44,9 @@ impl Display for Warning {
                 "Key {} is present in locale {:?} but not in default locale, it is ignored",
                 key_path, locale
             ),
-            #[cfg(feature = "nightly")]
+            #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
             Warning::NonUnicodePath { locale, namespace: None, path } => write!(f, "File path for locale {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, path),
-            #[cfg(feature = "nightly")]
+            #[cfg(any(feature = "nightly", feature = "track_locale_files"))]
             Warning::NonUnicodePath { locale, namespace: Some(ns), path } => write!(f, "File path for locale {:?} in namespace {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, ns, path),
         }
     }

--- a/leptos_i18n_macro/src/load_locales/warning.rs
+++ b/leptos_i18n_macro/src/load_locales/warning.rs
@@ -7,8 +7,20 @@ use std::{cell::RefCell, fmt::Display, rc::Rc};
 
 #[derive(Debug)]
 pub enum Warning {
-    MissingKey { locale: Rc<Key>, key_path: KeyPath },
-    SurplusKey { locale: Rc<Key>, key_path: KeyPath },
+    MissingKey {
+        locale: Rc<Key>,
+        key_path: KeyPath,
+    },
+    SurplusKey {
+        locale: Rc<Key>,
+        key_path: KeyPath,
+    },
+    #[cfg(feature = "nightly")]
+    NonUnicodePath {
+        locale: Rc<Key>,
+        namespace: Option<Rc<Key>>,
+        path: std::path::PathBuf,
+    },
 }
 
 thread_local! {
@@ -32,6 +44,10 @@ impl Display for Warning {
                 "Key {} is present in locale {:?} but not in default locale, it is ignored",
                 key_path, locale
             ),
+            #[cfg(feature = "nightly")]
+            Warning::NonUnicodePath { locale, namespace: None, path } => write!(f, "File path for locale {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, path),
+            #[cfg(feature = "nightly")]
+            Warning::NonUnicodePath { locale, namespace: Some(ns), path } => write!(f, "File path for locale {:?} in namespace {:?} is not valid Unicode, can't add it to proc macro depedencies. Path: {:?}", locale, ns, path),
         }
     }
 }


### PR DESCRIPTION
Add the use of the [path tracking api](https://github.com/rust-lang/rust/issues/99515) to help with cargo-leptos watch.

Before if you added `watch-additional-files = ["locales"]` in you manifest for watching the locales, the build system would not see the translations files as dependencies and would not rerun the `load_locales!` macro, now if you use nightly the macro will add those files as a dependencies and would rerun when then changes. Unfortunately this API is unstable (pretty bad API for the moment to be honnest) so it is only enabled with the "nightly" feature.