### PR TITLE
Clone args for `t!`

### DIFF
--- a/docs/expanded_macros/t.md
+++ b/docs/expanded_macros/t.md
@@ -35,7 +35,7 @@ Expanded code:
     let ($variable,) = ($value_expr,);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.var_$variable($variable);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
         #[deny(deprecated)]
         _key.build()
     }
@@ -55,7 +55,7 @@ Expanded code:
     let ($variable,) = ($variable,);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.var_$variable($variable);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
         #[deny(deprecated)]
         _key.build()
     }
@@ -75,7 +75,7 @@ Expanded code:
     let ($component,) = ($component_expr,);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -93,7 +93,7 @@ Expanded code:
     let ($component,) = ($component,);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -114,8 +114,8 @@ Expanded code:
     let ($variable, $component,) = ($variable_expr, $component_expr,);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.var_$variable($variable);
-        let _key = _key.comp_$component($component);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -135,7 +135,7 @@ Expanded code:
     let ($component,) = (move |__children: leptos::ChildrenFn| { leptos::view! { <$component_name $($attrs)* >{move || __children()}</$component_name> } },);
     move || {
         let _key = leptos_i18n::I18nContext::get_keys(i18n).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }

--- a/docs/expanded_macros/td.md
+++ b/docs/expanded_macros/td.md
@@ -35,7 +35,7 @@ Expanded code:
     let ($variable,) = ($value_expr,);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.var_$variable($variable);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
         #[deny(deprecated)]
         _key.build()
     }
@@ -55,7 +55,7 @@ Expanded code:
     let ($variable,) = ($variable,);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.var_$variable($variable);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
         #[deny(deprecated)]
         _key.build()
     }
@@ -75,7 +75,7 @@ Expanded code:
     let ($component,) = ($component_expr,);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -93,7 +93,7 @@ Expanded code:
     let ($component,) = ($component,);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -114,8 +114,8 @@ Expanded code:
     let ($variable, $component,) = ($variable_expr, $component_expr,);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.var_$variable($variable);
-        let _key = _key.comp_$component($component);
+        let _key = _key.var_$variable(Clone::clone(&$variable));
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }
@@ -135,7 +135,7 @@ Expanded code:
     let ($component,) = (move |__children: leptos::ChildrenFn| { leptos::view! { <$component_name $($attrs)* >{move || __children()}</$component_name> } },);
     move || {
         let _key = leptos_i18n::Locale::get_keys(locale).$key;
-        let _key = _key.comp_$component($component);
+        let _key = _key.comp_$component(Clone::clone(&$component));
         #[deny(deprecated)]
         _key.build()
     }

--- a/leptos_i18n_macro/src/t_macro/interpolate.rs
+++ b/leptos_i18n_macro/src/t_macro/interpolate.rs
@@ -135,19 +135,19 @@ impl InterpolatedValue {
         match self {
             InterpolatedValue::Var(ident) => {
                 let var_ident = Self::format_ident(ident, true, string);
-                quote!(#var_ident(#ident))
+                quote!(#var_ident(Clone::clone(&#ident)))
             }
             InterpolatedValue::Comp(ident) => {
                 let comp_ident = Self::format_ident(ident, false, string);
-                quote!(#comp_ident(#ident))
+                quote!(#comp_ident(Clone::clone(&#ident)))
             }
             InterpolatedValue::AssignedVar { key, value } => {
                 let var_ident = Self::format_ident(key, true, string);
-                quote!(#var_ident(#value))
+                quote!(#var_ident(Clone::clone(&#value)))
             }
             InterpolatedValue::AssignedComp { key, value } => {
                 let comp_ident = Self::format_ident(key, false, string);
-                quote!(#comp_ident(#value))
+                quote!(#comp_ident(Clone::clone(&#value)))
             }
             InterpolatedValue::DirectComp {
                 key,

--- a/tests/json/src/tests.rs
+++ b/tests/json/src/tests.rs
@@ -73,3 +73,18 @@ fn interpolate_variable_and_comp() {
     let fr = tdbg!(Locale::fr, interpolate_variable_and_comp, <b> = <span/>, count = 34);
     assert_eq_rendered!(fr, "<span>34</span>");
 }
+
+#[test]
+fn non_copy_arg() {
+    fn check_impl_fn<T>(_: &impl Fn() -> T) {}
+
+    let count = String::from("count");
+    let en = td!(Locale::en, interpolate_variable_and_comp, <b> = <span attr:id="test"/>, count);
+    check_impl_fn(&en);
+    assert_eq_rendered!(en, "<span id=\"test\">count</span>");
+
+    let count = String::from("count");
+    let fr = td!(Locale::fr, interpolate_variable_and_comp, <b> = <span/>, count);
+    check_impl_fn(&fr);
+    assert_eq_rendered!(fr, "<span>count</span>");
+}


### PR DESCRIPTION
When a non-Copy arg is passed to the `t!` macro, the resulting closure is only FnOnce, even if the type of the arg impl `Clone`. 

Now clone the args making the function `Fn` and not just `FnOnce`.