### PR TITLE
Feature to replace translations by the key during dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,8 @@ Better compilation errors are generated for interpolations with 4 keys or less.
 This is a feature as this code is not "necessary" and could slow compile times,
 advice is to enable it for debug builds but disable it for release builds.
 
+The `show_keys_only` feature makes every translations to only display it's corresponding key, this is usefull to track untranslated strings in you application.
+
 The `suppress_key_warnings` feature remove the warning emission of the `load_locales!()` macro when some keys are missing or ignored.
 
 The `json_files` feature tell the macro to expect JSON files for the locales, enabled by default

--- a/docs/book/src/06_features.md
+++ b/docs/book/src/06_features.md
@@ -26,6 +26,10 @@ This feature implement `Serialize` and `Deserialize` for the `Locale` enum
 
 This features allow the `load_locales!` macro to generate more code for interpolations, allowing better error reporting when keys are missing.
 
+#### `show_keys_only`
+
+This feature makes every translations to only display it's corresponding key, this is usefull to track untranslated strings in you application.
+
 #### `suppress_key_warnings`
 
 This features disable the warnings when a key is missing or in surplus, we discourage its usage and highly encourage the use of explicit defaults, but if its what's you want, we won't stop you.

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -42,6 +42,7 @@ experimental-islands = [
     "leptos/experimental-islands",
     "leptos_i18n_macro/experimental-islands",
 ]
+show_keys_only = ["leptos_i18n_macro/show_keys_only"]
 
 
 [package.metadata.cargo-all-features]
@@ -56,6 +57,7 @@ denylist = [
     "debug_interpolations",
     "suppress_key_warnings",
     "track_locale_files",
+    "show_keys_only",
 ]
 skip_feature_sets = [
     # Axum and Actix features are incompatible with each other - see `./src/server/mod.rs`, always exclude:

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -31,19 +31,20 @@
 //!
 //! # In depth documentation
 //!
-//! You can find the [book](https://github.com/Baptistemontan/leptos_i18n/tree/master/docs/book) on the github repo.
+//! You can find the [book](https://baptistemontan.github.io/leptos_i18n) on the github repo.
 //!
 //! # Feature Flags
-//! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
-//! - `json_files` (*Default*): Enable this feature if you use JSON files for declaring your locales.
-//! - `hydrate`: Enable this feature when building for the client with hydratation.
 //! - `actix`: Enable this feature when building for the server with actix as the backend (can't be enabled with the `axum` feature).
 //! - `axum`: Enable this feature when building for the server with axum as the backend (can't be enabled with the `actix` feature).
+//! - `hydrate`: Enable this feature when building for the client with hydratation.
 //! - `csr`: Enable this feature when building for the client with CSR.
 //! - `serde`: Enabling this feature implement `serde::Serialize` and `serde::Deserialize` for the locale enum.
 //! - `debug_interpolations`: Enable the macros to generate code to emit a warning if a key is supplied twice in interpolations and a better compilation error when a key is missing.
+//! - `show_keys_only`: This feature makes every translations to only display it's corresponding key, this is usefull to track untranslated strings in you application.
 //! - `suppress_key_warnings`: Disable the warning emission of the `load_locales!()` macro when some keys are missing or ignored.
+//! - `json_files` (*Default*): Enable this feature if you use JSON files for declaring your locales.
 //! - `yaml_files`: Enable this feature if you use YAML files for declaring your locales (can't be used with `json_files`).
+//! - `cookie` (*Default*): Enable this feature to set a cookie on the client to remember the last locale set.
 //! - `nightly`: On `nightly` Rust, enables the function-call syntax on the i18n context to get/set the locale.
 //! - `track_locale_files`: Enable the tracking of locale files as dependencies, usefull if you use some watcher. See the README for more infos.
 //!

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -33,6 +33,7 @@ yaml_files = ["serde_yaml"]
 interpolate_display = []
 track_locale_files = []
 experimental-islands = []
+show_keys_only = []
 
 [package.metadata.cargo-all-features]
 # cargo-all-features don't provide a way to always include one feature in a set, so CI will just do json...

--- a/leptos_i18n_macro/src/load_locales/cfg_file.rs
+++ b/leptos_i18n_macro/src/load_locales/cfg_file.rs
@@ -36,6 +36,8 @@ impl ConfigFile {
     pub fn new(manifest_dir_path: &mut PathBuf) -> Result<ConfigFile> {
         manifest_dir_path.push("Cargo.toml");
 
+        #[allow(clippy::needless_borrows_for_generic_args)]
+        // see https://github.com/rust-lang/rust-clippy/issues/12856
         let cfg_file_str =
             std::fs::read_to_string(&manifest_dir_path).map_err(Error::ManifestNotFound)?;
 

--- a/leptos_i18n_macro/src/load_locales/error.rs
+++ b/leptos_i18n_macro/src/load_locales/error.rs
@@ -101,7 +101,7 @@ impl Display for Error {
                 path, err
             ),
             Error::MissingKeyInLocale { key_path, locale } => write!(f,
-                "Some keys are different beetween locale files, locale {:?} is missing key: {}",
+                "Some keys are different beetween locale files, locale {:?} is missing key: \"{}\"",
                 locale, key_path
             ),
             Error::PluralParse {
@@ -136,7 +136,7 @@ impl Display for Error {
                 "Found duplicates namespaces in configuration (Cargo.toml): {:?}", 
                 duplicates
             ),
-            Error::PluralTypeMissmatch { key_path, type1, type2 } => write!(f, "Conflicting plural value type at key {}, found type {} but also type {}.", key_path, type1, type2),
+            Error::PluralTypeMissmatch { key_path, type1, type2 } => write!(f, "Conflicting plural value type at key \"{}\", found type {} but also type {}.", key_path, type1, type2),
             Error::InvalidKey(key) => write!(f, "invalid key {:?}, it can't be used as a rust identifier, try removing whitespaces and special characters.", key),
             Error::EmptyPlural => write!(f, "empty plurals are not allowed"),
             Error::InvalidPluralType(t) => write!(f, "invalid plural type {:?}", t),
@@ -146,14 +146,14 @@ impl Display for Error {
             Error::MissingFallback(t) => write!(f, "plural type {} require a fallback (or a fullrange \"..\")", t),
             Error::PluralSubkeys => write!(f, "subkeys for plurals are not allowed"),
             Error::SubKeyMissmatch { locale, key_path } => {
-                write!(f, "Missmatch value type beetween locale {:?} and default at key {}: one has subkeys and the other has direct value.", locale, key_path)
+                write!(f, "Missmatch value type beetween locale {:?} and default at key \"{}\": one has subkeys and the other has direct value.", locale, key_path)
             },
             Error::PluralNumberType { found, expected } => write!(f, "number type {} can't be used for plural type {}", found, expected),
-            Error::ExplicitDefaultInDefault(key_path) => write!(f, "Explicit defaults (null) are not allowed in default locale, at key {}", key_path),
-            Error::RecursiveForeignKey { locale, key_path } => write!(f, "Borrow Error while linking foreign key at key {} in locale {:?}, check for recursive foreign key.", key_path, locale),
-            Error::MissingForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key {} at key {} in locale {:?}, key don't exist.", foreign_key, key_path, locale),
+            Error::ExplicitDefaultInDefault(key_path) => write!(f, "Explicit defaults (null) are not allowed in default locale, at key \"{}\"", key_path),
+            Error::RecursiveForeignKey { locale, key_path } => write!(f, "Borrow Error while linking foreign key at key \"{}\" in locale {:?}, check for recursive foreign key.", key_path, locale),
+            Error::MissingForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key \"{}\" at key \"{}\" in locale {:?}, key don't exist.", foreign_key, key_path, locale),
             Error::Custom(s) => f.write_str(s),
-            Error::InvalidForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key {} at key {} in locale {:?}, foreign key to plurals or subkeys are not allowed.", foreign_key, key_path, locale),
+            Error::InvalidForeignKey { foreign_key, locale, key_path } => write!(f, "Invalid foreign key \"{}\" at key \"{}\" in locale {:?}, foreign key to plurals or subkeys are not allowed.", foreign_key, key_path, locale),
         }
     }
 }

--- a/leptos_i18n_macro/src/load_locales/key.rs
+++ b/leptos_i18n_macro/src/load_locales/key.rs
@@ -60,7 +60,7 @@ pub struct KeyPath {
 }
 
 impl KeyPath {
-    pub fn new(namespace: Option<Rc<Key>>) -> Self {
+    pub const fn new(namespace: Option<Rc<Key>>) -> Self {
         KeyPath {
             namespace,
             path: vec![],
@@ -74,11 +74,22 @@ impl KeyPath {
     pub fn pop_key(&mut self) -> Option<Rc<Key>> {
         self.path.pop()
     }
+
+    pub fn to_string_with_key(&self, key: &Key) -> String {
+        if self.namespace.is_none() && self.path.is_empty() {
+            return key.name.to_string();
+        }
+        let mut s = self.to_string();
+        if self.namespace.is_none() || !self.path.is_empty() {
+            s.push('.');
+        }
+        s.push_str(&key.name);
+        s
+    }
 }
 
 impl Display for KeyPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("\"")?;
         if let Some(namespace) = &self.namespace {
             write!(f, "{}::", namespace.name)?;
         }
@@ -89,7 +100,7 @@ impl Display for KeyPath {
                 write!(f, ".{}", key.name)?;
             }
         }
-        f.write_str("\"")
+        Ok(())
     }
 }
 

--- a/leptos_i18n_macro/src/load_locales/locale.rs
+++ b/leptos_i18n_macro/src/load_locales/locale.rs
@@ -100,6 +100,8 @@ fn find_file(path: &mut PathBuf) -> Result<File> {
 
     for ext in FILE_EXTS {
         path.set_extension(ext);
+        #[allow(clippy::needless_borrows_for_generic_args)]
+        // see https://github.com/rust-lang/rust-clippy/issues/12856
         match File::open(&path) {
             Ok(file) => return Ok(file),
             Err(err) => {
@@ -268,7 +270,7 @@ impl Locale {
 
         // reverse key comparaison
         for key in self.keys.keys() {
-            if keys.0.get(key).is_none() {
+            if !keys.0.contains_key(key) {
                 key_path.push_key(Rc::clone(key));
                 emit_warning(Warning::SurplusKey {
                     locale: top_locale.clone(),

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -18,7 +18,7 @@ pub mod warning;
 use cfg_file::ConfigFile;
 use error::{Error, Result};
 use interpolate::{create_empty_type, Interpolation};
-use key::Key;
+use key::{Key, KeyPath};
 use locale::{Locale, LocaleValue};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -169,7 +169,7 @@ fn create_locales_enum(cfg_file: &ConfigFile) -> TokenStream {
 }
 
 struct Subkeys<'a> {
-    original_key: &'a syn::Ident,
+    original_key: Rc<Key>,
     key: syn::Ident,
     mod_key: syn::Ident,
     locales: &'a [Locale],
@@ -177,13 +177,12 @@ struct Subkeys<'a> {
 }
 
 impl<'a> Subkeys<'a> {
-    pub fn new(key: &'a Key, locales: &'a [Locale], keys: &'a BuildersKeysInner) -> Self {
-        let original_key = &key.ident;
+    pub fn new(key: Rc<Key>, locales: &'a [Locale], keys: &'a BuildersKeysInner) -> Self {
         let mod_key = format_ident!("sk_{}", key.ident);
-        let key = format_ident!("{}_subkeys", key.ident);
+        let new_key = format_ident!("{}_subkeys", key.ident);
         Subkeys {
-            original_key,
-            key,
+            original_key: key,
+            key: new_key,
             mod_key,
             locales,
             keys,
@@ -211,6 +210,7 @@ fn create_locale_type_inner(
     locales: &[Locale],
     keys: &HashMap<Rc<Key>, LocaleValue>,
     is_namespace: bool,
+    key_path: &mut KeyPath,
 ) -> TokenStream {
     let default_match = get_default_match(default_locale, top_locales, locales);
 
@@ -228,13 +228,16 @@ fn create_locale_type_inner(
     let subkeys = keys
         .iter()
         .filter_map(|(key, value)| match value {
-            LocaleValue::Subkeys { locales, keys } => Some(Subkeys::new(key, locales, keys)),
+            LocaleValue::Subkeys { locales, keys } => {
+                Some(Subkeys::new(key.clone(), locales, keys))
+            }
             _ => None,
         })
         .collect::<Vec<_>>();
 
     let subkeys_ts = subkeys.iter().map(|sk| {
         let subkey_mod_ident = &sk.mod_key;
+        key_path.push_key(sk.original_key.clone());
         let subkey_impl = create_locale_type_inner(
             default_locale,
             &sk.key,
@@ -242,7 +245,9 @@ fn create_locale_type_inner(
             sk.locales,
             &sk.keys.0,
             true,
+            key_path,
         );
+        key_path.pop_key();
         quote! {
             pub mod #subkey_mod_ident {
                 use super::Locale;
@@ -286,9 +291,10 @@ fn create_locale_type_inner(
         .iter()
         .filter_map(|(key, value)| match value {
             LocaleValue::Value(None) | LocaleValue::Subkeys { .. } => None,
-            LocaleValue::Value(Some(keys)) => {
-                Some((key, Interpolation::new(key, keys, locales, &default_match)))
-            }
+            LocaleValue::Value(Some(keys)) => Some((
+                key,
+                Interpolation::new(key, keys, locales, &default_match, key_path),
+            )),
         })
         .collect::<Vec<_>>();
 
@@ -308,19 +314,22 @@ fn create_locale_type_inner(
     let default_locale = locales.first().unwrap();
 
     let new_match_arms = locales.iter().enumerate().map(|(i, locale)| {
-        let filled_string_fields =
-            string_keys
-                .iter()
-                .filter_map(|&key| match locale.keys.get(key) {
-                    Some(ParsedValue::String(str_value)) => Some(quote!(#key: #str_value)),
-                    _ => {
-                        let str_value = default_locale
-                            .keys
-                            .get(key)
-                            .and_then(ParsedValue::is_string)?;
-                        Some(quote!(#key: #str_value))
-                    }
-                });
+        let filled_string_fields = string_keys.iter().filter_map(|&key| {
+            if cfg!(feature = "show_keys_only") {
+                let key_str = key_path.to_string_with_key(key);
+                return Some(quote!(#key: #key_str));
+            }
+            match locale.keys.get(key) {
+                Some(ParsedValue::String(str_value)) => Some(quote!(#key: #str_value)),
+                _ => {
+                    let str_value = default_locale
+                        .keys
+                        .get(key)
+                        .and_then(ParsedValue::is_string)?;
+                    Some(quote!(#key: #str_value))
+                }
+            }
+        });
 
         let ident = &locale.top_locale_name;
         let pattern = (i != 0).then(|| quote!(Locale::#ident));
@@ -431,6 +440,7 @@ fn create_namespaces_types(
         let namespace_ident = &namespace.key.ident;
         let namespace_module_ident = create_namespace_mod_ident(namespace_ident);
         let keys = keys.get(&namespace.key).unwrap();
+        let mut key_path = KeyPath::new(Some(namespace.key.clone()));
         let type_impl = create_locale_type_inner(
             default_locale,
             namespace_ident,
@@ -438,6 +448,7 @@ fn create_namespaces_types(
             &namespace.locales,
             &keys.0,
             true,
+            &mut key_path,
         );
         quote! {
             pub mod #namespace_module_ident {
@@ -536,6 +547,7 @@ fn create_locale_type(keys: BuildersKeys, cfg_file: &ConfigFile) -> TokenStream 
             locales,
             &keys.0,
             false,
+            &mut KeyPath::new(None),
         ),
     }
 }


### PR DESCRIPTION
By enabling the `show_keys_only` feature, only the key is displayed.
This can be helpfull to detect non translated string in the application.

close #99 