### PR TITLE
Scoped contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: cargo test-all-features --n-chunks 2 --chunk 1
 
   macros_test:
+    # Why not also use cargo-all-features with the macros package ?
+    # Because all features are forwarded from leptos_i18n,
+    # so if some features mix creates a problem they will appear in leptos_i18n tests.
+    # All leptos_i18n_macro don't require any feature flag, so no need to test each feature and matchup
+    # just run once with default, this speeds up CI
     name: Test leptos_i18n_macro package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     # Why not also use cargo-all-features with the macros package ?
     # Because all features are forwarded from leptos_i18n,
     # so if some features mix creates a problem they will appear in leptos_i18n tests.
-    # All leptos_i18n_macro don't require any feature flag, so no need to test each feature and matchup
+    # All leptos_i18n_macro tests don't require any feature flag, so no need to test each feature and matchup
     # just run once with default, this speeds up CI
     name: Test leptos_i18n_macro package
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,14 @@ jobs:
           npx playwright install --with-deps
 
       - name: "e2e testing ${{ matrix.examples }} example"
+        id: e2e
         working-directory: examples/${{ matrix.examples }}
         run: npx playwright test
 
       - name: "Upload e2e report"
         uses: actions/upload-artifact@v4
-        # upload artifact only if test failed
-        if: ${{ failure() && !cancelled() }}
+        # upload artifact only if e2e test failed
+        if: steps.e2e.outcome == "failure" && ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.examples }}
           path: examples/${{ matrix.examples }}/playwright-report/
@@ -125,13 +126,14 @@ jobs:
           cargo install trunk
 
       - name: "e2e testing ${{ matrix.examples }} example"
+        id: e2e
         working-directory: examples/${{ matrix.examples }}
         run: npx playwright test
 
       - name: "Upload e2e report"
         uses: actions/upload-artifact@v4
-        # upload artifact only if test failed
-        if: ${{ failure() && !cancelled() }}
+        # upload artifact only if e2e test failed
+        if: steps.e2e.outcome == "failure" && ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.examples }}
           path: examples/${{ matrix.examples }}/playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,8 @@ env:
 
 jobs:
   lib_test:
-    name: Test ${{ matrix.package }} package
+    name: Test leptos_i18n package
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ["leptos_i18n", "leptos_i18n_macro"]
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -30,7 +26,20 @@ jobs:
         run: cargo install cargo-all-features
 
       - name: "Test all features"
-        run: cargo test-all-features --n-chunks ${{ strategy.job-total }} --chunk $(expr ${{ strategy.job-index }} + 1)
+        run: cargo test-all-features --n-chunks 2 --chunk 1
+
+  macros_test:
+    name: Test leptos_i18n_macro package
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+
+      - name: "Load cargo toolchain"
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: "Run tests"
+        run: cargo test --package leptos_i18n_macro
 
   test_ssr_examples:
     name: Test ${{ matrix.examples }} example

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,4 +1,4 @@
-This project contains the core of a new introductory guide to Leptos.
+This book is a documentation on how to setup and use the `leptos_i18` lib.
 
 It is built using `mdbook`. You can view a local copy by installing `mdbook`
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -19,5 +19,6 @@
   - [`t!` Macro](./usage/03_t_macro.md)
   - [`td!` Macro](./usage/04_td_macro.md)
   - [`td_string!` Macro](./usage/05_td_string_macro.md)
+  - [Scoping](./usage/06_scoping.md)
 - [Features](./06_features.md)
 - [Appendix: `i18n Ally` extension for VSC](./appendix_i18n_ally.md)

--- a/docs/book/src/usage/06_scoping.md
+++ b/docs/book/src/usage/06_scoping.md
@@ -1,0 +1,126 @@
+# Scoping
+
+If you are using subkeys or namespaces, access keys can get pretty big and repetitive,
+would'nt it be nice to scope a context to a namespace or subkeys ?
+
+Well this page explain how to do it!
+
+## The `scope_i18n!` macro
+
+Using namespaces and subkeys can make things quite cumbersome very fast, imagine you have this:
+
+```rust
+let i18n = use_i18n();
+
+t!(i18n, namespace.subkeys.value);
+t!(i18n, namespace.subkeys.more_subkeys.subvalue);
+t!(i18n, namespace.subkeys.more_subkeys.another_subvalue);
+```
+
+This only use `namespace.subkeys.*` but we have to repeat it everywhere,
+well here comes the `scope_i18n!` macro, you can rewrite to:
+
+```rust
+let i18n = use_i18n();
+let i18n = scope_i18n!(i18n, namespace.subkeys);
+
+t!(i18n, value);
+t!(i18n, more_subkeys.subvalue);
+t!(i18n, more_subkeys.another_subvalue);
+```
+
+This macro can be chained:
+
+```rust
+let i18n = use_i18n();
+let i18n = scope_i18n!(i18n, namespace);
+let i18n = scope_i18n!(i18n, subkeys);
+
+t!(i18n, value);
+
+let i18n = scope_i18n!(i18n, more_subkeys);
+t!(i18n, subvalue);
+t!(i18n, another_subvalue);
+```
+
+## The `use_i18n_scoped!` macro
+
+On the above exemple we do `let i18n = use_i18n();` but only access the context to scope it afterward, we could do
+
+```rust
+let i18n = scope_i18n!(use_i18n(), namespace.subkeys);
+```
+
+Well this is what the `use_i18n_scoped!` macro is for:
+
+```rust
+let i18n = use_i18n_scoped!(namespace.subkeys);
+
+t!(i18n, value);
+t!(i18n, more_subkeys.subvalue);
+t!(i18n, more_subkeys.another_subvalue);
+```
+
+## The `scope_locale!` macro
+
+The above exemples are to scope a context, but maybe you use `td!` a lot and run into the same problems:
+
+```rust
+fn foo(locale: Locale) {
+    td!(locale, namespace.subkeys.value);
+    td!(locale, namespace.subkeys.more_subkeys.subvalue);
+    td!(locale, namespace.subkeys.more_subkeys.another_subvalue);
+}
+```
+
+You can use the `scope_locale!` macro here:
+
+```rust
+fn foo(locale: Locale) {
+    let locale = scope_locale!(locale, namespace.subkeys);
+    td!(locale, value);
+    td!(locale, more_subkeys.subvalue);
+    td!(locale, more_subkeys.another_subvalue);
+}
+```
+
+And again, it is chainable:
+
+```rust
+fn foo(locale: Locale) {
+    let locale = scope_locale!(locale, namespace.subkeys);
+    td!(locale, value);
+    let locale = scope_locale!(locale, more_subkeys);
+    td!(locale, subvalue);
+    td!(locale, another_subvalue);
+}
+```
+
+## Caveat
+
+Unfortunatly, it looks too good te be true... What's the catch ? Where is the tradeoff ?
+
+To make this possible, it use a typestate pattern, but some of the types are hard to access as a user as they defined deep in the generated `i18n` module.
+This makes it difficult to write the type of a scoped context or a scoped locale.
+
+By default `I18nContext<L, S>` is only generic over `L` because the the `S` scope is the "default" one provided by `L`, so you can easily write `I18nContext<Locale>`.
+But once you scope it the `S` parameters will look like `i18n::namespaces::ns_namespace::subkeys::sk_subkeys::subkeys_subkeys`.
+
+Yes. This is the path to the struct holding the keys of `namespace.subkeys`.
+
+This makes it difficult to pass a scoped type around, as it would require to write `I18nContext<Locale, i18n::namespaces::ns_namespace::subkeys::sk_subkeys::subkeys_subkeys>`.
+
+Maybe in the future there will be a macro to write this horrible path for you, but I don't think it is really needed for now.
+
+If you look at the generated code you will see this:
+
+```rust
+let i18n = { leptos_i18n::__private::scope_ctx_util(use_i18n(), |_k| &_k.$keys) };
+```
+
+Hummm, what is this closure for? it's just here for type inference and key checking! The function parameter is even `_:fn(&OS) -> &NS`, it's never used.
+The function is even const (not for `scope_locale` tho, the only one that could really benefit from it lol, because trait functions can't be const...).
+
+But being a typestate using it or not actually result in the same code path.
+And with how agressive Rust is with inlining small functions, it probably compile to the exact same thing.
+So no runtime performance loss! Yeaah!

--- a/docs/expanded_macros/scope.md
+++ b/docs/expanded_macros/scope.md
@@ -1,0 +1,51 @@
+This document contain what the different scoping macros should expand to. Those macros output the same code whatever the feature flags, so no flags are relevant.
+
+# `use_i18n_scoped!`
+
+Code:
+
+```rust
+let i18n = use_i18n_scoped!($keys);
+```
+
+Expanded code:
+
+```rust
+let i18n = {
+    leptos_i18n::__private::scope_ctx_util(use_i18n(), |_k| &_k.$keys)
+};
+```
+
+# `scope_i18n!`
+
+Code:
+
+```rust
+let i18n = scope_i18n!($ctx, $keys);
+```
+
+Expanded code:
+
+```rust
+let i18n = {
+    leptos_i18n::__private::scope_ctx_util($ctx, |_k| &_k.$keys)
+};
+```
+
+Yes. `use_i18n_scoped!($keys)` is just `scope_i18n!(use_i18n(), $keys)`.
+
+# `scope_locale!`
+
+Code:
+
+```rust
+let locale = scope_i18n!($locale, $keys);
+```
+
+Expanded code:
+
+```rust
+let locale = {
+    leptos_i18n::__private::scope_locale_util($locale, |_k| &_k.$keys)
+};
+```

--- a/examples/subkeys/src/app.rs
+++ b/examples/subkeys/src/app.rs
@@ -23,10 +23,10 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn Subkeys() -> impl IntoView {
-    let i18n = use_i18n();
+    let i18n = use_i18n_scoped!(subkeys);
 
     view! {
-        <p>{t!(i18n, subkeys.subkey)}</p>
-        <p>{t!(i18n, subkeys.subsubkeys.subsubkey)}</p>
+        <p>{t!(i18n, subkey)}</p>
+        <p>{t!(i18n, subsubkeys.subsubkey)}</p>
     }
 }

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -129,6 +129,7 @@ mod context;
 mod fetch_locale;
 mod langid;
 mod locale_traits;
+mod scopes;
 mod server;
 
 pub mod display;
@@ -146,21 +147,16 @@ pub mod providers {
 }
 
 pub use leptos_i18n_macro::{
-    load_locales, t, t_display, t_string, td, td_display, td_string, tu, tu_display, tu_string,
+    load_locales, scope_i18n, scope_locale, t, t_display, t_string, td, td_display, td_string, tu,
+    tu_display, tu_string, use_i18n_scoped,
 };
+pub use scopes::{ConstScope, Scope};
 
 #[doc(hidden)]
 pub mod __private {
     pub use super::locale_traits::BuildStr;
     pub use leptos_i18n_macro::declare_locales;
     pub use unic_langid;
-}
-
-#[doc(hidden)]
-pub mod reexports {
-    pub use leptos_i18n_macro::{
-        load_locales, t, t_display, t_string, td, td_display, td_string, tu, tu_display, tu_string,
-    };
 }
 
 /// Utility macro for using reactive translations in a non reactive component when using islands.

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -155,6 +155,7 @@ pub use scopes::{ConstScope, Scope};
 #[doc(hidden)]
 pub mod __private {
     pub use super::locale_traits::BuildStr;
+    pub use crate::scopes::{scope_ctx_util, scope_locale_util};
     pub use leptos_i18n_macro::declare_locales;
     pub use unic_langid;
 }

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -56,6 +56,11 @@ pub trait Locale<L: Locale = Self>:
 
     /// Create this type from a base locale, this is used for wrappers around a locale such as scopes.
     fn from_base_locale(locale: L) -> Self;
+
+    /// Map the locale with another value, this is usefull to change the locale of a scope.
+    fn map_locale(self, locale: L) -> Self {
+        Self::from_base_locale(locale)
+    }
 }
 
 /// Trait implemented the struct representing the translation keys
@@ -106,17 +111,17 @@ mod test {
         locales: ["en", "fr"],
         en: {
             sk: {
-                ssk: "test",
+                ssk: "test en",
             },
         },
         fr: {
             sk: {
-                ssk: "test",
+                ssk: "test fr",
             },
         },
     }
 
-    use super::Locale as _;
+    use crate::{self as leptos_i18n, scope_locale, Locale as _};
     use i18n::Locale;
 
     #[test]
@@ -135,5 +140,13 @@ mod test {
 
         let res = Locale::find_locale(&["de", "fr-FR", "fr"]);
         assert_eq!(res, Locale::fr);
+    }
+
+    #[test]
+    fn test_scope() {
+        let en_sk = scope_locale!(Locale::en, sk);
+        assert_eq!(en_sk.get_keys().ssk, "test en");
+        let fr_sk = en_sk.map_locale(Locale::fr);
+        assert_eq!(fr_sk.get_keys().ssk, "test fr");
     }
 }

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -7,7 +7,7 @@ use crate::langid::{convert_vec_str_to_langids_lossy, filter_matches, find_match
 /// Trait implemented the enum representing the supported locales of the application
 ///
 /// Most functions of this crate are generic of type implementing this trait
-pub trait Locale:
+pub trait Locale<L: Locale = Self>:
     'static
     + Default
     + Clone
@@ -18,7 +18,7 @@ pub trait Locale:
     + PartialEq
 {
     /// The associated struct containing the translations
-    type Keys: LocaleKeys<Locale = Self>;
+    type Keys: LocaleKeys<Locale = L>;
 
     /// Return a static str that represent the locale.
     fn as_str(self) -> &'static str;
@@ -27,26 +27,35 @@ pub trait Locale:
     fn as_langid(self) -> &'static LanguageIdentifier;
 
     /// Return a static reference to an array containing all variants of this enum
-    fn get_all() -> &'static [Self];
+    fn get_all() -> &'static [L];
 
     /// Given a slice of accepted languages sorted in preferred order, return the locale that fit the best the request.
     fn find_locale<T: AsRef<[u8]>>(accepted_languages: &[T]) -> Self {
         let langids = convert_vec_str_to_langids_lossy(accepted_languages);
-        find_match(&langids, Self::get_all())
+        let l = find_match(&langids, Self::get_all());
+        Self::from_base_locale(l)
     }
 
     /// Given a langid, return a Vec of suitables `Locale` sorted in compatibility (first one being the best match).
     ///
     /// This function does not fallback to default if no match is found.
     fn find_matchs<T: AsRef<LanguageIdentifier>>(langid: T) -> Vec<Self> {
-        filter_matches(std::slice::from_ref(langid.as_ref()), Self::get_all())
+        let matches: Vec<L> =
+            filter_matches(std::slice::from_ref(langid.as_ref()), Self::get_all());
+        matches.into_iter().map(Self::from_base_locale).collect()
     }
 
     /// Return the keys based on self
     #[inline]
     fn get_keys(self) -> &'static Self::Keys {
-        LocaleKeys::from_locale(self)
+        LocaleKeys::from_locale(self.to_base_locale())
     }
+
+    /// Convert this type to the base locale, this is used for wrappers around a locale such as scopes.
+    fn to_base_locale(self) -> L;
+
+    /// Create this type from a base locale, this is used for wrappers around a locale such as scopes.
+    fn from_base_locale(locale: L) -> Self;
 }
 
 /// Trait implemented the struct representing the translation keys

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -54,7 +54,7 @@ pub trait Locale:
 /// You will probably never need to use it has it only serves the internals of the library.
 pub trait LocaleKeys: 'static + Clone + Copy {
     /// The associated enum representing the supported locales
-    type Locale: Locale<Keys = Self>;
+    type Locale: Locale;
 
     /// Return a static ref to Self containing the translations for the given locale
     fn from_locale(locale: Self::Locale) -> &'static Self;
@@ -95,8 +95,16 @@ mod test {
         path: crate,
         default: "en",
         locales: ["en", "fr"],
-        en: {},
-        fr: {},
+        en: {
+            sk: {
+                ssk: "test",
+            },
+        },
+        fr: {
+            sk: {
+                ssk: "test",
+            },
+        },
     }
 
     use super::Locale as _;

--- a/leptos_i18n/src/scopes.rs
+++ b/leptos_i18n/src/scopes.rs
@@ -62,14 +62,9 @@ pub const fn scope_ctx_util<L: Locale, OS: Scope<L>, NS: Scope<L>>(
 }
 
 #[doc(hidden)]
-pub fn scope_locale_util<
-    BL: Locale,
-    L: Locale<BL, Keys = OS::Keys>,
-    OS: Scope<BL>,
-    NS: Scope<BL>,
->(
+pub fn scope_locale_util<BL: Locale, L: Locale<BL>, NS: Scope<BL>>(
     locale: L,
-    map_fn: fn(&OS) -> &NS,
+    map_fn: fn(&<L as Locale<BL>>::Keys) -> &NS,
 ) -> ScopedLocale<BL, NS> {
     let _ = map_fn;
     ScopedLocale {

--- a/leptos_i18n/src/scopes.rs
+++ b/leptos_i18n/src/scopes.rs
@@ -45,7 +45,7 @@ impl<L: Locale, S: Scope<L>> ConstScope<L, S> {
     }
 
     #[doc(hidden)]
-    pub const fn map<NS: Scope<L>>(self, map_fn: fn(&S::Keys) -> &NS::Keys) -> ConstScope<L, NS> {
+    pub const fn map<NS: Scope<L>>(self, map_fn: fn(&S) -> &NS) -> ConstScope<L, NS> {
         let _ = map_fn;
         ConstScope(PhantomData)
     }
@@ -54,7 +54,7 @@ impl<L: Locale, S: Scope<L>> ConstScope<L, S> {
 #[doc(hidden)]
 pub const fn scope_ctx_util<L: Locale, OS: Scope<L>, NS: Scope<L>>(
     ctx: I18nContext<L, OS>,
-    map_fn: fn(&OS::Keys) -> &NS::Keys,
+    map_fn: fn(&OS) -> &NS,
 ) -> I18nContext<L, NS> {
     let old_scope = ConstScope::<L, OS>::new();
     let new_scope = old_scope.map(map_fn);
@@ -69,7 +69,7 @@ pub fn scope_locale_util<
     NS: Scope<BL>,
 >(
     locale: L,
-    map_fn: fn(&OS::Keys) -> &NS::Keys,
+    map_fn: fn(&OS) -> &NS,
 ) -> ScopedLocale<BL, NS> {
     let _ = map_fn;
     ScopedLocale {

--- a/leptos_i18n/src/scopes.rs
+++ b/leptos_i18n/src/scopes.rs
@@ -1,0 +1,49 @@
+use std::marker::PhantomData;
+
+use crate::{I18nContext, Locale, LocaleKeys};
+
+/// Represent a scope in a locale.
+pub trait Scope<L: Locale> {
+    /// The keys of the scopes
+    type Keys: LocaleKeys<Locale = L>;
+}
+
+impl<K: LocaleKeys> Scope<K::Locale> for K {
+    type Keys = K;
+}
+
+/// A struct that act as a marker for a scope, can be constructed as a constant and can be used to scope a context or a locale.
+pub struct ConstScope<L: Locale, S: Scope<L> = <L as Locale>::Keys>(PhantomData<(L, S)>);
+
+impl<L: Locale, S: Scope<L>> Default for ConstScope<L, S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<L: Locale, S: Scope<L>> Clone for ConstScope<L, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<L: Locale, S: Scope<L>> Copy for ConstScope<L, S> {}
+
+impl<L: Locale, S: Scope<L>> ConstScope<L, S> {
+    /// Create a marker for a scope
+    pub const fn new() -> Self {
+        ConstScope(PhantomData)
+    }
+
+    /// This function is a helper for type resolution in macros.
+    ///
+    /// You can use it but it's meant to be used inside `use_i18n_scoped!` and `scope_i18n`.
+    pub const fn new_from_ctx(_: I18nContext<L, S>) -> Self {
+        Self::new()
+    }
+
+    #[doc(hidden)]
+    pub const fn map<NS: Scope<L>>(self, _: fn(&S::Keys) -> &NS::Keys) -> ConstScope<L, NS> {
+        ConstScope(PhantomData)
+    }
+}

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 #![forbid(unsafe_code)]
-#![deny(warnings)]
+// #![deny(warnings)]
 #![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic, track_path))]
 //! # About Leptos i18n macro
 //!
@@ -10,6 +10,7 @@
 
 pub(crate) mod load_locales;
 pub(crate) mod t_macro;
+pub(crate) mod utils;
 
 use t_macro::{InputType, OutputType};
 
@@ -203,4 +204,92 @@ pub fn td_string(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[proc_macro]
 pub fn td_display(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     t_macro::t_macro(tokens, InputType::Locale, OutputType::Display)
+}
+
+/// Like `use_i18n` but enable to scope the context:
+///
+/// Instead of
+///
+/// ```rust, ignore
+/// let i18n = use_i18n;
+/// t!(i18n, namespace.subkeys.value);
+/// ```
+///
+/// You can do
+///
+/// ```rust, ignore
+/// let i18n = use_i18n_scoped!(namespace);
+/// t!(i18n, subkeys.value);
+/// ```
+///
+/// Or
+///
+/// ```rust, ignore
+/// let i18n = use_i18n_scoped!(namespace.subkeys);
+/// t!(i18n, value);
+/// ```
+///
+/// This macro is the equivalent to do
+///
+/// ```rust, ignore
+/// let i18n = use_i18n();
+/// let i18n = scope_i18n!(i18n, namespace.sukeys);
+/// ```
+#[proc_macro]
+pub fn use_i18n_scoped(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    utils::scoped::use_i18n_scoped(tokens)
+}
+
+/// Scope a context to the given keys
+///
+/// Instead of
+///
+/// ```rust, ignore
+/// let i18n = use_i18n;
+/// t!(i18n, namespace.subkeys.value);
+/// ```
+///
+/// You can do
+///
+/// ```rust, ignore
+/// let i18n = use_i18n();
+/// let namespace_i18n = scope_i18n!(i18n, namespace);
+///
+/// t!(namespace_i18n, subkeys.value);
+///
+/// let subkeys_i18n = scope_i18n!(namespace_i18n, subkeys);
+/// //  subkeys_i18n = scope_i18n!(i18n, namespace.subkeys);
+
+/// t!(subkeys_i18n, value);
+/// ```
+#[proc_macro]
+pub fn scope_i18n(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    utils::scoped::scope_i18n(tokens)
+}
+
+/// Scope a locale to the given keys
+///
+/// Instead of
+///
+/// ```rust, ignore
+/// let i18n = use_i18n;
+/// t!(i18n, namespace.subkeys.value);
+/// ```
+///
+/// You can do
+///
+/// ```rust, ignore
+/// let i18n = use_i18n();
+/// let namespace_i18n = scope_i18n!(i18n, namespace);
+///
+/// t!(namespace_i18n, subkeys.value);
+///
+/// let subkeys_i18n = scope_i18n!(namespace_i18n, subkeys);
+/// //  subkeys_i18n = scope_i18n!(i18n, namespace.subkeys);
+
+/// t!(subkeys_i18n, value);
+/// ```
+#[proc_macro]
+pub fn scope_locale(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    utils::scoped::scope_locale(tokens)
 }

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -226,6 +226,14 @@ fn create_locales_enum(
             fn get_all() -> &'static [Self] {
                 &[#(#enum_ident::#locales,)*]
             }
+
+            fn to_base_locale(self) -> Self {
+                self
+            }
+
+            fn from_base_locale(locale: Self) -> Self {
+                locale
+            }
         }
 
         impl core::str::FromStr for #enum_ident {

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -4,7 +4,8 @@ use syn::parse_macro_input;
 
 use crate::t_macro::interpolate::{InterpolatedValue, InterpolatedValueTokenizer};
 
-use self::parsed_input::{Keys, ParsedInput};
+use self::parsed_input::ParsedInput;
+use crate::utils::Keys;
 
 pub mod interpolate;
 pub mod parsed_input;

--- a/leptos_i18n_macro/src/utils/mod.rs
+++ b/leptos_i18n_macro/src/utils/mod.rs
@@ -1,0 +1,46 @@
+use quote::{quote, TokenStreamExt};
+use syn::Token;
+
+pub mod scoped;
+
+pub enum Keys {
+    SingleKey(syn::Ident),
+    Subkeys(Vec<syn::Ident>),
+}
+
+fn parse_subkeys(input: syn::parse::ParseStream, keys: &mut Vec<syn::Ident>) -> syn::Result<()> {
+    keys.push(input.parse()?);
+    while input.peek(Token![.]) {
+        input.parse::<Token![.]>()?;
+        keys.push(input.parse()?);
+    }
+    Ok(())
+}
+
+impl syn::parse::Parse for Keys {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let first_key = input.parse()?;
+        let dot = input.peek(Token![.]);
+        if dot || input.peek(Token![::]) {
+            if dot {
+                input.parse::<Token![.]>()?;
+            } else {
+                input.parse::<Token![::]>()?;
+            }
+            let mut keys = vec![first_key];
+            parse_subkeys(input, &mut keys)?;
+            Ok(Keys::Subkeys(keys))
+        } else {
+            Ok(Keys::SingleKey(first_key))
+        }
+    }
+}
+
+impl quote::ToTokens for Keys {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Keys::SingleKey(key) => tokens.append(key.clone()),
+            Keys::Subkeys(keys) => tokens.append_separated(keys, quote!(.)),
+        }
+    }
+}

--- a/leptos_i18n_macro/src/utils/scoped.rs
+++ b/leptos_i18n_macro/src/utils/scoped.rs
@@ -25,9 +25,9 @@ pub fn scope_i18n(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 fn scope_i18n_inner(input: ScopeParsedInput) -> TokenStream {
     let ScopeParsedInput { context, keys } = input;
-    quote! {
+    quote! {{
         leptos_i18n::__private::scope_ctx_util(#context, |_k| &_k.#keys)
-    }
+    }}
 }
 
 pub fn use_i18n_scoped(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -36,9 +36,9 @@ pub fn use_i18n_scoped(tokens: proc_macro::TokenStream) -> proc_macro::TokenStre
 }
 
 fn use_i18n_scoped_inner(keys: Keys) -> TokenStream {
-    quote! {
+    quote! {{
         leptos_i18n::__private::scope_ctx_util(use_i18n(), |_k| &_k.#keys)
-    }
+    }}
 }
 
 pub fn scope_locale(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -51,5 +51,5 @@ fn scope_locale_inner(input: ScopeParsedInput) -> TokenStream {
         context: locale,
         keys,
     } = input;
-    quote! { leptos_i18n::__private::scope_locale_util(#locale, |_k| &_k.#keys) }
+    quote! {{ leptos_i18n::__private::scope_locale_util(#locale, |_k| &_k.#keys) }}
 }

--- a/leptos_i18n_macro/src/utils/scoped.rs
+++ b/leptos_i18n_macro/src/utils/scoped.rs
@@ -25,11 +25,8 @@ pub fn scope_i18n(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 fn scope_i18n_inner(input: ScopeParsedInput) -> TokenStream {
     let ScopeParsedInput { context, keys } = input;
-    quote! { {
-
-        let scope =
+    quote! {
         leptos_i18n::__private::scope_ctx_util(#context, |_k| &_k.#keys)
-    }
     }
 }
 

--- a/leptos_i18n_macro/src/utils/scoped.rs
+++ b/leptos_i18n_macro/src/utils/scoped.rs
@@ -1,0 +1,58 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+use super::Keys;
+
+struct ScopeParsedInput {
+    pub context: syn::Expr,
+    pub keys: Keys,
+}
+
+impl syn::parse::Parse for ScopeParsedInput {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let context = input.parse()?;
+        input.parse::<syn::token::Comma>()?;
+        let keys = input.parse()?;
+        Ok(ScopeParsedInput { context, keys })
+    }
+}
+
+pub fn scope_i18n(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(tokens as ScopeParsedInput);
+    scope_i18n_inner(input).into()
+}
+
+fn scope_i18n_inner(input: ScopeParsedInput) -> TokenStream {
+    let ScopeParsedInput { context, keys } = input;
+    quote! { {
+
+        let scope =
+        leptos_i18n::__private::scope_ctx_util(#context, |_k| &_k.#keys)
+    }
+    }
+}
+
+pub fn use_i18n_scoped(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(tokens as Keys);
+    use_i18n_scoped_inner(input).into()
+}
+
+fn use_i18n_scoped_inner(keys: Keys) -> TokenStream {
+    quote! {
+        leptos_i18n::__private::scope_ctx_util(use_i18n(), |_k| &_k.#keys)
+    }
+}
+
+pub fn scope_locale(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(tokens as ScopeParsedInput);
+    scope_locale_inner(input).into()
+}
+
+fn scope_locale_inner(input: ScopeParsedInput) -> TokenStream {
+    let ScopeParsedInput {
+        context: locale,
+        keys,
+    } = input;
+    quote! { leptos_i18n::__private::scope_locale_util(#locale, |_k| &_k.#keys) }
+}

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -5,5 +5,6 @@ leptos_i18n::load_locales!();
 mod defaulted;
 mod foreign;
 mod plurals;
+mod scoped;
 mod subkeys;
 mod tests;

--- a/tests/json/src/scoped.rs
+++ b/tests/json/src/scoped.rs
@@ -3,22 +3,22 @@ use common::*;
 
 #[test]
 fn subkey_3() {
-    let EN = scope_locale!(Locale::en, subkeys);
-    let FR = scope_locale!(Locale::en, subkeys);
+    let en_scope = scope_locale!(Locale::en, subkeys);
+    let fr_scope = scope_locale!(Locale::en, subkeys);
 
     let count = || 0;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(FR, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(FR, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(FR, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/json/src/scoped.rs
+++ b/tests/json/src/scoped.rs
@@ -1,0 +1,24 @@
+use crate::i18n::*;
+use common::*;
+
+#[test]
+fn subkey_3() {
+    let EN = scope_locale!(Locale::en, subkeys);
+    let FR = scope_locale!(Locale::en, subkeys);
+
+    let count = || 0;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "zero");
+    let fr = tdbg!(FR, subkey_3, count);
+    assert_eq_rendered!(fr, "0");
+    let count = || 1;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "one");
+    let fr = tdbg!(FR, subkey_3, count);
+    assert_eq_rendered!(fr, "1");
+    let count = || 3;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "3");
+    let fr = tdbg!(FR, subkey_3, count);
+    assert_eq_rendered!(fr, "3");
+}

--- a/tests/json/src/scoped.rs
+++ b/tests/json/src/scoped.rs
@@ -4,7 +4,7 @@ use common::*;
 #[test]
 fn subkey_3() {
     let en_scope = scope_locale!(Locale::en, subkeys);
-    let fr_scope = scope_locale!(Locale::en, subkeys);
+    let fr_scope = scope_locale!(Locale::fr, subkeys);
 
     let count = || 0;
     let en = tdbg!(en_scope, subkey_3, count);

--- a/tests/namespaces/src/lib.rs
+++ b/tests/namespaces/src/lib.rs
@@ -1,7 +1,7 @@
+#![cfg(test)]
 #![deny(warnings)]
 leptos_i18n::load_locales!();
 
-#[cfg(test)]
 mod first_ns;
-#[cfg(test)]
+mod scoped;
 mod second_ns;

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -50,7 +50,8 @@ fn scoped_plurals() {
         let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "fallback");
     }
-    let fr = tdbg!(Locale::fr, first_namespace.plural_only_en, count);
+
+    let fr = tdbg!(fr_scope, count);
     assert_eq_rendered!(fr, "pas de plurals en français");
 }
 
@@ -72,6 +73,6 @@ fn scoped_sub_subkeys() {
     let count = || 3;
     let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(en_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -3,51 +3,51 @@ use common::*;
 
 #[test]
 fn scoped() {
-    let EN = scope_locale!(Locale::en, first_namespace);
-    let FR = scope_locale!(Locale::fr, first_namespace);
+    let en_scope = scope_locale!(Locale::en, first_namespace);
+    let fr_scope = scope_locale!(Locale::fr, first_namespace);
 
-    let en = tdbg!(EN, click_to_change_lang);
+    let en = tdbg!(en_scope, click_to_change_lang);
     assert_eq!(en, "Click to change language");
-    let fr = tdbg!(FR, click_to_change_lang);
+    let fr = tdbg!(fr_scope, click_to_change_lang);
     assert_eq!(fr, "Cliquez pour changez de langue");
 
-    let en = tdbg!(EN, common_key);
+    let en = tdbg!(en_scope, common_key);
     assert_eq!(en, "first namespace");
-    let fr = tdbg!(FR, common_key);
+    let fr = tdbg!(fr_scope, common_key);
     assert_eq!(fr, "premier namespace");
 }
 
 #[test]
 fn scoped_plurals() {
-    let EN = scope_locale!(Locale::en, first_namespace);
-    let FR = scope_locale!(Locale::fr, first_namespace);
+    let en_scope = scope_locale!(Locale::en, first_namespace);
+    let fr_scope = scope_locale!(Locale::fr, first_namespace);
 
     let count = move || 0;
-    let en = tdbg!(EN, plural_only_en, count);
+    let en = tdbg!(en_scope, plural_only_en, count);
     assert_eq_rendered!(en, "exact");
     for i in -3..0 {
         let count = move || i;
-        let en = tdbg!(EN, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "unbounded start");
     }
     for i in 99..103 {
         let count = move || i;
-        let en = tdbg!(EN, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "unbounded end");
     }
     for i in 1..3 {
         let count = move || i;
-        let en = tdbg!(EN, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "excluded end");
     }
     for i in 3..=8 {
         let count = move || i;
-        let en = tdbg!(EN, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "included end");
     }
     for i in [30, 40, 55, 73] {
         let count = move || i;
-        let en = tdbg!(EN, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, count);
         assert_eq_rendered!(en, "fallback");
     }
     let fr = tdbg!(Locale::fr, first_namespace.plural_only_en, count);
@@ -56,22 +56,22 @@ fn scoped_plurals() {
 
 #[test]
 fn scoped_sub_subkeys() {
-    let EN = scope_locale!(Locale::en, second_namespace.subkeys);
-    let FR = scope_locale!(Locale::fr, second_namespace.subkeys);
+    let en_scope = scope_locale!(Locale::en, second_namespace.subkeys);
+    let fr_scope = scope_locale!(Locale::fr, second_namespace.subkeys);
 
     let count = || 0;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(FR, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "zero");
     let count = || 1;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(FR, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(EN, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(EN, subkey_3, count);
+    let fr = tdbg!(en_scope, subkey_3, count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -1,0 +1,77 @@
+use crate::i18n::*;
+use common::*;
+
+#[test]
+fn scoped() {
+    let EN = scope_locale!(Locale::en, first_namespace);
+    let FR = scope_locale!(Locale::fr, first_namespace);
+
+    let en = tdbg!(EN, click_to_change_lang);
+    assert_eq!(en, "Click to change language");
+    let fr = tdbg!(FR, click_to_change_lang);
+    assert_eq!(fr, "Cliquez pour changez de langue");
+
+    let en = tdbg!(EN, common_key);
+    assert_eq!(en, "first namespace");
+    let fr = tdbg!(FR, common_key);
+    assert_eq!(fr, "premier namespace");
+}
+
+#[test]
+fn scoped_plurals() {
+    let EN = scope_locale!(Locale::en, first_namespace);
+    let FR = scope_locale!(Locale::fr, first_namespace);
+
+    let count = move || 0;
+    let en = tdbg!(EN, plural_only_en, count);
+    assert_eq_rendered!(en, "exact");
+    for i in -3..0 {
+        let count = move || i;
+        let en = tdbg!(EN, plural_only_en, count);
+        assert_eq_rendered!(en, "unbounded start");
+    }
+    for i in 99..103 {
+        let count = move || i;
+        let en = tdbg!(EN, plural_only_en, count);
+        assert_eq_rendered!(en, "unbounded end");
+    }
+    for i in 1..3 {
+        let count = move || i;
+        let en = tdbg!(EN, plural_only_en, count);
+        assert_eq_rendered!(en, "excluded end");
+    }
+    for i in 3..=8 {
+        let count = move || i;
+        let en = tdbg!(EN, plural_only_en, count);
+        assert_eq_rendered!(en, "included end");
+    }
+    for i in [30, 40, 55, 73] {
+        let count = move || i;
+        let en = tdbg!(EN, plural_only_en, count);
+        assert_eq_rendered!(en, "fallback");
+    }
+    let fr = tdbg!(Locale::fr, first_namespace.plural_only_en, count);
+    assert_eq_rendered!(fr, "pas de plurals en français");
+}
+
+#[test]
+fn scoped_sub_subkeys() {
+    let EN = scope_locale!(Locale::en, second_namespace.subkeys);
+    let FR = scope_locale!(Locale::fr, second_namespace.subkeys);
+
+    let count = || 0;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "zero");
+    let fr = tdbg!(FR, subkey_3, count);
+    assert_eq_rendered!(fr, "zero");
+    let count = || 1;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "one");
+    let fr = tdbg!(FR, subkey_3, count);
+    assert_eq_rendered!(fr, "1");
+    let count = || 3;
+    let en = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(en, "3");
+    let fr = tdbg!(EN, subkey_3, count);
+    assert_eq_rendered!(fr, "3");
+}

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -51,7 +51,7 @@ fn scoped_plurals() {
         assert_eq_rendered!(en, "fallback");
     }
 
-    let fr = tdbg!(fr_scope, count);
+    let fr = tdbg!(fr_scope, plural_only_en, count);
     assert_eq_rendered!(fr, "pas de plurals en français");
 }
 


### PR DESCRIPTION
This PR add a new scoping feature.

This new feature is meant to improve the DX by being able to scope a context, such that instead of

```rust
let i18n = use_i18n();

t!(i18n, namespace.subkeys.value);
```
You can now do

```rust
let ns = use_i18n_scoped!(namespace);
t!(ns, subkeys.value);
let sk = use_i18n_scoped!(namespace.subkey);
t!(sk, value);
```

And you can scope already defined context:
```rust
let i18n = use_i18n();
let sk = scope_i18n!(namespace.subkey);
t!(sk, value);
```

`use_i18n_scoped!(...)` expends to `scope_i18n!(use_i18n(), ...)`.

Everything is typestate, this feature should be zero cost.