### PR TITLE
Use `typed-builder` for interpolations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: "Install cargo-all-features"
-        run: cargo install cargo-all-features
+        run: cargo install cargo-all-features --locked
 
       - name: "Test all features"
         run: cargo test-all-features --n-chunks 2 --chunk 1
@@ -76,7 +76,7 @@ jobs:
           targets: "wasm32-unknown-unknown"
 
       - name: "Install cargo-leptos"
-        run: cargo install cargo-leptos
+        run: cargo install cargo-leptos --locked
 
       - name: "Build ${{ matrix.examples }} example"
         working-directory: examples/ssr/${{ matrix.examples }}
@@ -138,7 +138,7 @@ jobs:
           targets: "wasm32-unknown-unknown"
 
       - name: "Install trunk"
-        run: cargo install trunk
+        run: cargo install trunk --locked
 
       - name: "Build ${{ matrix.examples }} example"
         working-directory: examples/csr/${{ matrix.examples }}
@@ -153,7 +153,6 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps
-          cargo install trunk
 
       - name: "e2e testing ${{ matrix.examples }} example"
         id: e2e

--- a/README.md
+++ b/README.md
@@ -345,28 +345,7 @@ t!(i18n, key, count, <b>, other_key = ..)
 
 You may need to display different messages depending on a count, for example one when there is 0 elements, another when there is only one, and a last one when the count is anything else.
 
-You declare them in a sequence of plurals, there is 2 syntax for the plurals, first is being a map with the `count` and the `value`:
-
-```json
-{
-  "click_count": [
-    {
-      "count": 0,
-      "value": "You have not clicked yet"
-    },
-    {
-      "count": "1",
-      "value": "You clicked once"
-    },
-    {
-      "count": "_",
-      "value": "You clicked {{ count }} times"
-    }
-  ]
-}
-```
-
-The other one is a sequence where the first element is the value and the other elements are the counts:
+You declare them in a sequence of plurals with a sequence where the first element is the value and the other elements are the counts:
 
 ```json
 {
@@ -378,8 +357,6 @@ The other one is a sequence where the first element is the value and the other e
 }
 ```
 
-You can mix them up as you want.
-
 The count can be a string `"0"` or a litteral `0`.
 
 When using plurals, variable name `count` is reserved and takes as a value `T: Fn() -> N + Clone + 'static` where `N` is the specified type.
@@ -389,15 +366,9 @@ By default `N` is `i32` but you can change that by specifying the type as the **
 {
   "money_count": [
     "f32",
-    {
-      "count": "0.0",
-      "value": "You are broke"
-    },
+    ["you are broke", 0.0]
     ["You owe money", "..0.0"],
-    {
-      "count": "_",
-      "value": "You have {{ count }}€"
-    }
+    ["You have {{ count }}€"]
   ]
 }
 ```
@@ -419,7 +390,7 @@ match N::from(count()) {
 
 Because it expand to a match statement, a compilation error will be produced if the full range of `N` is not covered.
 
-But floats (`f32` and `f64`) are not accepted in match statements it expand to a `if-else` chain, therefore must end by a `else` block, so a fallback `_` or `..` is required.
+But floats (`f32` and `f64`) are not accepted in match statements, so they expand to a `if-else` chain, therefore must end by a `else` block, so a fallback `_` or `..` is required.
 
 The plural above would generate code similar to this:
 
@@ -442,30 +413,27 @@ If multiple locales use plurals for the same key, the count type must be the sam
 
 (PS: Floats are generaly not a good idea for money.)
 
-You can also have multiple conditions by either separate them by `|` or put them in a sequence:
-
 ```json
 {
   "click_count": [
     "u32",
-    {
-      "count": "0 | 5",
-      "value": "You clicked 0 or 5 times"
-    },
+    ["You clicked 0 or 5 times", 0, 5]
     ["You clicked once", 1],
-    {
-      "count": ["2..=10", 20],
-      "value": "You clicked {{ count }} times"
-    },
+    ["You clicked {{ count }} times", "2..=10", 20]
     ["You clicked 30 or 40 times", 30, 40],
-    {
-      "value": "You clicked <b>a lot</b>"
-    }
+    ["value": "You clicked <b>a lot</b>"]
   ]
 }
 ```
 
-If a plural is a fallback it can omit the `count` key in a map or with only supply the value: `["fallback value"]`
+If a plural is a fallback it can only supply the value: `["fallback value"]`
+
+To supply the count for the plural in the `t!` macro, use `$`:
+
+```rust
+let count = move || counter.get();
+t!(i18n, click_count, $ = count)
+```
 
 ### Subkeys
 

--- a/docs/book/src/declare/03_plurals.md
+++ b/docs/book/src/declare/03_plurals.md
@@ -137,3 +137,33 @@ The "You clicked {{ count }} times" kind of gave it away, but you can use interp
   ]
 }
 ```
+
+With plurals, `{{ count }}` is a special variable that refers to the count provided to the plural, so you don't need to also provide it:
+
+```json
+{
+  "click_count": [
+    ["You have not clicked yet", 0],
+    ["You clicked once", 1],
+    ["You clicked {{ count }} times"]
+  ]
+}
+```
+
+```rust
+t!(i18n, click_count, $ = || 0);
+```
+
+Will result in `"You have not clicked yet"` and
+
+```rust
+t!(i18n, click_count, $ = || 5);
+```
+
+Will result in `"You clicked 5 times"`.
+
+Providing `count` will create an error:
+
+```rust
+t!(i18n, click_count, count = 12, $ = || 5); // compilation error
+```

--- a/docs/book/src/usage/04_t_macro.md
+++ b/docs/book/src/usage/04_t_macro.md
@@ -153,7 +153,11 @@ Basically `<name .../>` expand to `move |children| view! { <name ...>{children}<
 
 ## Plurals
 
-Plurals expect a variable named `count`, that implement `Fn() -> N + Clone + 'static` where `N` is the specified type of the plural (default is `i32`).
+Plurals expect a variable `$` that implement `Fn() -> N + Clone + 'static` where `N` is the specified type of the plural (default is `i32`).
+
+```rust
+t!(i18n, key_to_plural, $ = count);
+```
 
 ## Access subkeys
 

--- a/examples/csr/counter_plurals/src/app.rs
+++ b/examples/csr/counter_plurals/src/app.rs
@@ -32,7 +32,7 @@ fn Counter() -> impl IntoView {
     let count = move || counter.get();
 
     view! {
-        <p>{t!(i18n, click_count, count)}</p>
+        <p>{t!(i18n, click_count, $ = count)}</p>
         <button on:click=inc>{t!(i18n, click_to_inc)}</button>
     }
 }

--- a/examples/csr/yaml/src/app.rs
+++ b/examples/csr/yaml/src/app.rs
@@ -32,7 +32,7 @@ fn Counter() -> impl IntoView {
     let count = move || counter.get();
 
     view! {
-        <p>{t!(i18n, click_count, count)}</p>
+        <p>{t!(i18n, click_count, $ = count)}</p>
         <button on:click=inc>{t!(i18n, click_to_inc)}</button>
     }
 }

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -22,6 +22,7 @@ http = { version = "1", optional = true }
 leptos-use = "0.11"
 codee = "0.1"
 unic-langid = { version = "0.9", features = ["macros"] }
+typed-builder = "0.19"
 
 [features]
 default = ["cookie", "json_files"]

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -129,6 +129,7 @@ pub mod context;
 mod fetch_locale;
 mod langid;
 mod locale_traits;
+mod macro_helpers;
 mod routing;
 mod scopes;
 mod server;
@@ -147,11 +148,12 @@ pub use scopes::{ConstScope, Scope};
 
 #[doc(hidden)]
 pub mod __private {
-    pub use crate::locale_traits::BuildStr;
+    pub use crate::macro_helpers::*;
     pub use crate::routing::i18n_routing;
-    pub use crate::scopes::{scope_ctx_util, scope_locale_util};
+    pub use leptos;
     pub use leptos_i18n_macro::declare_locales;
     pub use leptos_router;
+    pub use typed_builder;
     pub use unic_langid;
 }
 

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, str::FromStr};
+use std::str::FromStr;
 
 use unic_langid::LanguageIdentifier;
 
@@ -73,35 +73,6 @@ pub trait LocaleKeys: 'static + Clone + Copy {
 
     /// Return a static ref to Self containing the translations for the given locale
     fn from_locale(locale: Self::Locale) -> &'static Self;
-}
-
-/// This is used to call `.build` on `&str` when building interpolations.
-///
-/// If it's a `&str` it will just return the str,
-/// but if it's a builder `.build` will either emit an error for a missing key or if all keys
-/// are supplied it will return the correct value
-///
-/// It has no uses outside of the internals of the `t!` macro.
-#[doc(hidden)]
-pub trait BuildStr: Sized {
-    #[inline]
-    fn build(self) -> Self {
-        self
-    }
-
-    #[inline]
-    fn build_display(self) -> Self {
-        self
-    }
-
-    fn build_string(self) -> Cow<'static, str>;
-}
-
-impl BuildStr for &'static str {
-    #[inline]
-    fn build_string(self) -> Cow<'static, str> {
-        Cow::Borrowed(self)
-    }
 }
 
 #[cfg(test)]

--- a/leptos_i18n/src/macro_helpers.rs
+++ b/leptos_i18n/src/macro_helpers.rs
@@ -19,6 +19,16 @@ pub trait InterpolateCount<T>: Fn() -> T + Clone + 'static {}
 
 impl<T, F: Fn() -> T + Clone + 'static> InterpolateCount<T> for F {}
 
+#[doc(hidden)]
+pub struct DisplayBuilder(Cow<'static, str>);
+
+impl DisplayBuilder {
+    #[inline]
+    pub fn build(self) -> Cow<'static, str> {
+        self.0
+    }
+}
+
 /// This is used to call `.build` on `&str` when building interpolations.
 ///
 /// If it's a `&str` it will just return the str,
@@ -29,22 +39,27 @@ impl<T, F: Fn() -> T + Clone + 'static> InterpolateCount<T> for F {}
 #[doc(hidden)]
 pub trait BuildStr: Sized {
     #[inline]
-    fn build(self) -> Self {
+    fn view_builder(self) -> Self {
         self
     }
 
     #[inline]
-    fn build_display(self) -> Self {
+    fn string_builder(self) -> Self {
         self
     }
 
-    fn build_string(self) -> Cow<'static, str>;
+    fn display_builder(self) -> DisplayBuilder;
+
+    #[inline]
+    fn build(self) -> Self {
+        self
+    }
 }
 
 impl BuildStr for &'static str {
     #[inline]
-    fn build_string(self) -> Cow<'static, str> {
-        Cow::Borrowed(self)
+    fn display_builder(self) -> DisplayBuilder {
+        DisplayBuilder(Cow::Borrowed(self))
     }
 }
 

--- a/leptos_i18n/src/macro_helpers.rs
+++ b/leptos_i18n/src/macro_helpers.rs
@@ -1,9 +1,11 @@
 #![doc(hidden)]
 
 use leptos::IntoView;
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt::Display};
 
-use crate::{scopes::ScopedLocale, ConstScope, I18nContext, Locale, Scope};
+use crate::{
+    display::DisplayComponent, scopes::ScopedLocale, ConstScope, I18nContext, Locale, Scope,
+};
 
 // Interpolation
 
@@ -11,20 +13,44 @@ pub trait InterpolateVar: IntoView + Clone + 'static {}
 
 impl<T: IntoView + Clone + 'static> InterpolateVar for T {}
 
+pub fn check_var(var: impl InterpolateVar) -> impl InterpolateVar {
+    var
+}
+
+pub fn check_var_string(var: impl Display) -> impl Display {
+    var
+}
+
 pub trait InterpolateComp<O: IntoView>: Fn(leptos::ChildrenFn) -> O + Clone + 'static {}
 
 impl<O: IntoView, T: Fn(leptos::ChildrenFn) -> O + Clone + 'static> InterpolateComp<O> for T {}
 
+pub fn check_comp<V: IntoView>(comp: impl InterpolateComp<V>) -> impl InterpolateComp<V> {
+    comp
+}
+
+pub fn check_comp_string(comp: impl DisplayComponent) -> impl DisplayComponent {
+    comp
+}
+
 pub trait InterpolateCount<T>: Fn() -> T + Clone + 'static {}
 
 impl<T, F: Fn() -> T + Clone + 'static> InterpolateCount<T> for F {}
+
+pub fn check_count<T>(count: impl InterpolateCount<T>) -> impl InterpolateCount<T> {
+    count
+}
+
+pub fn check_count_string<T>(count: T) -> T {
+    count
+}
 
 #[doc(hidden)]
 pub struct DisplayBuilder(Cow<'static, str>);
 
 impl DisplayBuilder {
     #[inline]
-    pub fn build(self) -> Cow<'static, str> {
+    pub fn build_display(self) -> Cow<'static, str> {
         self.0
     }
 }
@@ -39,7 +65,7 @@ impl DisplayBuilder {
 #[doc(hidden)]
 pub trait BuildStr: Sized {
     #[inline]
-    fn view_builder(self) -> Self {
+    fn builder(self) -> Self {
         self
     }
 
@@ -52,6 +78,11 @@ pub trait BuildStr: Sized {
 
     #[inline]
     fn build(self) -> Self {
+        self
+    }
+
+    #[inline]
+    fn build_string(self) -> Self {
         self
     }
 }

--- a/leptos_i18n/src/macro_helpers.rs
+++ b/leptos_i18n/src/macro_helpers.rs
@@ -1,0 +1,70 @@
+#![doc(hidden)]
+
+use leptos::IntoView;
+use std::borrow::Cow;
+
+use crate::{scopes::ScopedLocale, ConstScope, I18nContext, Locale, Scope};
+
+// Interpolation
+
+pub trait InterpolateVar: IntoView + Clone + 'static {}
+
+impl<T: IntoView + Clone + 'static> InterpolateVar for T {}
+
+pub trait InterpolateComp<O: IntoView>: Fn(leptos::ChildrenFn) -> O + Clone + 'static {}
+
+impl<O: IntoView, T: Fn(leptos::ChildrenFn) -> O + Clone + 'static> InterpolateComp<O> for T {}
+
+pub trait InterpolateCount<T>: Fn() -> T + Clone + 'static {}
+
+impl<T, F: Fn() -> T + Clone + 'static> InterpolateCount<T> for F {}
+
+/// This is used to call `.build` on `&str` when building interpolations.
+///
+/// If it's a `&str` it will just return the str,
+/// but if it's a builder `.build` will either emit an error for a missing key or if all keys
+/// are supplied it will return the correct value
+///
+/// It has no uses outside of the internals of the `t!` macro.
+#[doc(hidden)]
+pub trait BuildStr: Sized {
+    #[inline]
+    fn build(self) -> Self {
+        self
+    }
+
+    #[inline]
+    fn build_display(self) -> Self {
+        self
+    }
+
+    fn build_string(self) -> Cow<'static, str>;
+}
+
+impl BuildStr for &'static str {
+    #[inline]
+    fn build_string(self) -> Cow<'static, str> {
+        Cow::Borrowed(self)
+    }
+}
+
+// Scoping
+
+#[doc(hidden)]
+pub const fn scope_ctx_util<L: Locale, OS: Scope<L>, NS: Scope<L>>(
+    ctx: I18nContext<L, OS>,
+    map_fn: fn(&OS) -> &NS,
+) -> I18nContext<L, NS> {
+    let old_scope = ConstScope::<L, OS>::new();
+    let new_scope = old_scope.map(map_fn);
+    ctx.scope(new_scope)
+}
+
+#[doc(hidden)]
+pub fn scope_locale_util<BL: Locale, L: Locale<BL>, NS: Scope<BL>>(
+    locale: L,
+    map_fn: fn(&<L as Locale<BL>>::Keys) -> &NS,
+) -> ScopedLocale<BL, NS> {
+    let _ = map_fn;
+    ScopedLocale::new(locale.to_base_locale())
+}

--- a/leptos_i18n/src/scopes.rs
+++ b/leptos_i18n/src/scopes.rs
@@ -55,31 +55,18 @@ impl<L: Locale, S: Scope<L>> ConstScope<L, S> {
     }
 }
 
-#[doc(hidden)]
-pub const fn scope_ctx_util<L: Locale, OS: Scope<L>, NS: Scope<L>>(
-    ctx: I18nContext<L, OS>,
-    map_fn: fn(&OS) -> &NS,
-) -> I18nContext<L, NS> {
-    let old_scope = ConstScope::<L, OS>::new();
-    let new_scope = old_scope.map(map_fn);
-    ctx.scope(new_scope)
-}
-
-#[doc(hidden)]
-pub fn scope_locale_util<BL: Locale, L: Locale<BL>, NS: Scope<BL>>(
-    locale: L,
-    map_fn: fn(&<L as Locale<BL>>::Keys) -> &NS,
-) -> ScopedLocale<BL, NS> {
-    let _ = map_fn;
-    ScopedLocale {
-        locale: locale.to_base_locale(),
-        scope_marker: PhantomData,
-    }
-}
-
 pub struct ScopedLocale<L: Locale, S: Scope<L> = <L as Locale>::Keys> {
-    locale: L,
+    pub locale: L,
     scope_marker: PhantomData<S>,
+}
+
+impl<L: Locale, S: Scope<L>> ScopedLocale<L, S> {
+    pub const fn new(locale: L) -> Self {
+        ScopedLocale {
+            locale,
+            scope_marker: PhantomData,
+        }
+    }
 }
 
 impl<L: Locale, S: Scope<L>> Debug for ScopedLocale<L, S> {

--- a/leptos_i18n_macro/src/lib.rs
+++ b/leptos_i18n_macro/src/lib.rs
@@ -1,6 +1,6 @@
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 #![forbid(unsafe_code)]
-// #![deny(warnings)]
+#![deny(warnings)]
 #![cfg_attr(feature = "nightly", feature(proc_macro_diagnostic, track_path))]
 //! # About Leptos i18n macro
 //!

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -73,6 +73,7 @@ impl Interpolation {
             &fields,
             &into_views,
         );
+
         let dummy_impl = Self::dummy_impl(
             &ident,
             &dummy_ident,
@@ -82,6 +83,7 @@ impl Interpolation {
             &fields,
             &into_views,
         );
+
         let into_view_impl = Self::into_view_impl(
             key,
             &ident,
@@ -93,6 +95,7 @@ impl Interpolation {
             key_path,
             &into_views,
         );
+
         let debug_impl = Self::debug_impl(&builder_name, &ident, &fields, &into_views);
 
         let display_impl = if cfg!(feature = "interpolate_display") {
@@ -177,7 +180,7 @@ impl Interpolation {
                     }
                 }
 
-                pub fn new_builder<#(#left_generics,)*>(self) -> #type_builder_name<#(#right_generics,)* ((#enum_ident,), (core::marker::PhantomData<(#(#into_views,)*)>,), #(#builder_marker,)*)> {
+                pub fn view_builder<#(#left_generics,)*>(self) -> #type_builder_name<#(#right_generics,)* ((#enum_ident,), (core::marker::PhantomData<(#(#into_views,)*)>,), #(#builder_marker,)*)> {
                     #ident::builder().#locale_field(self.#locale_field).#into_view_field(core::marker::PhantomData)
                 }
             }
@@ -193,7 +196,10 @@ impl Interpolation {
         fields: &[Field],
         into_views: &[&syn::Ident],
     ) -> TokenStream {
-        let generics = Self::bounded_generics(fields, into_views);
+        let generics = fields
+            .iter()
+            .map(|field| &field.generic)
+            .chain(into_views.iter().copied());
 
         let fields = fields.iter().map(|field| {
             let key = field.kind;

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -381,6 +381,13 @@ impl Interpolation {
 
         let destructure = quote!(let Self { #(#fields_key,)* #locale_field, .. } = self;);
 
+        let plural = fields
+            .iter()
+            .any(|field| matches!(field.kind, InterpolateKey::Count(_)));
+
+        let var_count =
+            plural.then(|| quote!(let var_count = core::clone::Clone::clone(&plural_count);));
+
         let locales_impls =
             Self::create_locale_string_impl(key, enum_ident, locales, default_match);
 
@@ -389,6 +396,7 @@ impl Interpolation {
             impl<#(#left_generics,)*> ::core::fmt::Display for #ident<#(#right_generics,)*> {
                 fn fmt(&self, __formatter: &mut ::core::fmt::Formatter<'_>) -> core::fmt::Result {
                     #destructure
+                    #var_count
                     match #locale_field {
                         #(
                             #locales_impls,
@@ -450,6 +458,13 @@ impl Interpolation {
 
         let destructure = quote!(let Self { #(#fields_key,)* #locale_field, .. } = self;);
 
+        let plural = fields
+            .iter()
+            .any(|field| matches!(field.kind, InterpolateKey::Count(_)));
+
+        let var_count =
+            plural.then(|| quote!(let var_count = core::clone::Clone::clone(&plural_count);));
+
         let locales_impls = Self::create_locale_impl(key, enum_ident, locales, default_match);
 
         quote! {
@@ -457,6 +472,7 @@ impl Interpolation {
             impl<#(#left_generics,)*> leptos::IntoView for #ident<#(#right_generics,)*> {
                 fn into_view(self) -> leptos::View {
                     #destructure
+                    #var_count
                     match #locale_field {
                         #(
                             #locales_impls,

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -10,19 +10,15 @@ use super::{
     parsed_value::{InterpolateKey, ParsedValue},
 };
 
-const MAX_KEY_GENERATE_BUILD_DEBUG: usize = 4;
-
 pub struct Interpolation {
     pub ident: syn::Ident,
-    pub default_generic_ident: TokenStream,
     pub imp: TokenStream,
 }
 
 struct Field<'a> {
     generic: syn::Ident,
-    name: String,
     kind: &'a InterpolateKey,
-    real_name: &'a str,
+    into_view: Option<syn::Ident>,
 }
 
 impl Interpolation {
@@ -38,29 +34,54 @@ impl Interpolation {
 
         let ident = syn::Ident::new(&builder_name, Span::call_site());
 
+        let dummy_ident = format_ident!("{}_dummy", ident);
+
         let locale_field = Key::new("_locale").unwrap();
+        let into_view_field = Key::new("_into_views_marker").unwrap();
 
         let fields = keys_set
             .iter()
             .map(|kind| {
-                let real_name = kind.get_real_name();
                 let key = kind
                     .as_key()
                     .map(|key| key.name.as_str())
                     .unwrap_or("var_count");
-                let name = format!("__{}", key);
+                let name = format!("__{}__", key);
                 let generic = syn::Ident::new(&name, Span::call_site());
+                let into_view = kind
+                    .as_comp()
+                    .map(|key| format_ident!("__{}_into_view__", key.ident));
                 Field {
                     generic,
-                    name,
                     kind,
-                    real_name,
+                    into_view,
                 }
             })
             .collect::<Vec<_>>();
 
-        let type_def = Self::create_type(&ident, enum_ident, &fields);
-        let builder_impl = Self::builder_impl(&ident, &locale_field, &fields);
+        let into_views = fields
+            .iter()
+            .filter_map(|f| f.into_view.as_ref())
+            .collect::<Vec<_>>();
+
+        let type_def = Self::create_types(
+            &ident,
+            &dummy_ident,
+            enum_ident,
+            &locale_field,
+            &into_view_field,
+            &fields,
+            &into_views,
+        );
+        let dummy_impl = Self::dummy_impl(
+            &ident,
+            &dummy_ident,
+            enum_ident,
+            &locale_field,
+            &into_view_field,
+            &fields,
+            &into_views,
+        );
         let into_view_impl = Self::into_view_impl(
             key,
             &ident,
@@ -70,8 +91,9 @@ impl Interpolation {
             locales,
             default_match,
             key_path,
+            &into_views,
         );
-        let debug_impl = Self::debug_impl(&builder_name, &ident, &fields);
+        let debug_impl = Self::debug_impl(&builder_name, &ident, &fields, &into_views);
 
         let display_impl = if cfg!(feature = "interpolate_display") {
             Self::display_impl(
@@ -87,16 +109,8 @@ impl Interpolation {
             quote!()
         };
 
-        let new_impl = Self::new_impl(&ident, enum_ident, &locale_field, &fields);
-        let default_generics = fields
-            .iter()
-            .map(|_| quote!(builders::EmptyInterpolateValue));
-        let default_generic_ident = quote!(#ident<#(#default_generics,)*>);
-
         let imp = quote! {
             #type_def
-
-            #new_impl
 
             #into_view_impl
 
@@ -104,498 +118,115 @@ impl Interpolation {
 
             #display_impl
 
-            #builder_impl
+            #dummy_impl
         };
 
         Self {
             imp,
-            ident,
-            default_generic_ident,
+            ident: dummy_ident,
         }
     }
 
-    fn new_impl(
+    fn dummy_impl(
         ident: &syn::Ident,
+        dummy_ident: &syn::Ident,
         enum_ident: &syn::Ident,
         locale_field: &Key,
+        into_view_field: &Key,
         fields: &[Field],
+        into_views: &[&syn::Ident],
     ) -> TokenStream {
-        let generics = fields.iter().map(|_| quote!(EmptyInterpolateValue));
+        let type_builder_name = format_ident!("{}Builder", ident);
 
-        let fields = fields.iter().map(|field| {
-            let field_key = field.kind;
-            quote!(#field_key: EmptyInterpolateValue)
-        });
+        let into_view_generics = into_views
+            .iter()
+            .map(|into_view| quote!(#into_view: l_i18n_crate::__private::leptos::IntoView));
+
+        let left_generics = fields
+            .iter()
+            .map(|field| {
+                let ident = &field.generic;
+                let generic_bound = field.kind.get_generic();
+                if let Some(into_view) = field.into_view.as_ref() {
+                    quote!(#ident: #generic_bound<#into_view>)
+                } else {
+                    quote!(#ident: #generic_bound)
+                }
+            })
+            .chain(into_view_generics);
+
+        let right_generics = fields
+            .iter()
+            .map(|field| &field.generic)
+            .chain(into_views.iter().copied());
+
+        let builder_marker = fields.iter().map(|_| quote!(()));
 
         quote! {
-            impl #ident<#(#generics,)*> {
+            impl #dummy_ident {
                 pub const fn new(#locale_field: #enum_ident) -> Self {
                     Self {
-                        #(#fields,)*
                         #locale_field
                     }
                 }
-            }
-        }
-    }
 
-    fn split_at<T>(slice: &[T], i: usize) -> (&[T], &T, &[T]) {
-        let (left, rest) = slice.split_at(i);
-        let (mid, right) = rest.split_first().unwrap();
-        (left, mid, right)
-    }
-    fn genenerate_set_fns(ident: &syn::Ident, locale_field: &Key, fields: &[Field]) -> TokenStream {
-        (0..fields.len())
-            .map(|i| Self::split_at(fields, i))
-            .map(|(left_fields, field, right_fields)| {
-                Self::create_field_set_fn(ident, locale_field, left_fields, right_fields, field)
-            })
-            .collect()
-    }
-
-    fn generate_build_fns(ident: &syn::Ident, fields: &[Field], locale_field: &Key) -> TokenStream {
-        if fields.len() > MAX_KEY_GENERATE_BUILD_DEBUG {
-            return Self::generate_success_build_fn(ident, fields);
-        }
-        let failing_builds = Self::generate_all_failing_build_fn(ident, fields, locale_field);
-        let success_build = Self::generate_success_build_fn(ident, fields);
-
-        quote! {
-            #(#failing_builds)*
-
-            #success_build
-        }
-    }
-
-    fn generate_string_build(ident: &syn::Ident, fields: &[Field]) -> TokenStream {
-        let left_generics_string = fields.iter().filter_map(|field| {
-            let ident = &field.generic;
-            let generic = field.kind.get_string_generic().ok()?;
-            Some(quote!(#ident: #generic))
-        });
-
-        let right_generics_string = fields.iter().map(|field| match field.kind {
-            InterpolateKey::Count(t) => quote!(#t),
-            _ => {
-                let ident = &field.generic;
-                quote!(#ident)
-            }
-        });
-
-        quote! {
-            #[allow(non_camel_case_types)]
-            impl<#(#left_generics_string,)*> #ident<#(#right_generics_string,)*> {
-                #[inline]
-                pub fn build_display(self) -> Self {
-                    self
-                }
-
-                pub fn build_string(self) -> std::borrow::Cow<'static, str> {
-                    self.to_string().into()
+                pub fn new_builder<#(#left_generics,)*>(self) -> #type_builder_name<#(#right_generics,)* ((#enum_ident,), (core::marker::PhantomData<(#(#into_views,)*)>,), #(#builder_marker,)*)> {
+                    #ident::builder().#locale_field(self.#locale_field).#into_view_field(core::marker::PhantomData)
                 }
             }
         }
     }
 
-    fn generate_success_build_fn(ident: &syn::Ident, fields: &[Field]) -> TokenStream {
-        let left_generics = fields.iter().map(|field| {
-            let ident = &field.generic;
-            let generic = field.kind.get_generic();
-            quote!(#ident: #generic)
-        });
-
-        let right_generics = fields.iter().map(|field| {
-            let ident = &field.generic;
-            quote!(#ident)
-        });
-
-        let string_build = if cfg!(feature = "interpolate_display") {
-            Self::generate_string_build(ident, fields)
-        } else {
-            quote!()
-        };
-
-        quote! {
-
-            #[allow(non_camel_case_types)]
-            impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
-                #[inline]
-                pub fn build(self) -> Self {
-                    self
-                }
-            }
-
-            #string_build
-
-        }
-    }
-
-    fn builder_impl(ident: &syn::Ident, locale_field: &Key, fields: &[Field]) -> TokenStream {
-        let set_fns = Self::genenerate_set_fns(ident, locale_field, fields);
-
-        let build_fns = if cfg!(not(feature = "debug_interpolations")) {
-            Self::generate_success_build_fn(ident, fields)
-        } else {
-            Self::generate_build_fns(ident, fields, locale_field)
-        };
-
-        quote! {
-            #set_fns
-            #build_fns
-        }
-    }
-
-    fn create_type(ident: &syn::Ident, enum_ident: &syn::Ident, fields: &[Field]) -> TokenStream {
-        let generics = fields.iter().map(|field| &field.generic);
+    fn create_types(
+        ident: &syn::Ident,
+        dummy_ident: &syn::Ident,
+        enum_ident: &syn::Ident,
+        locale_field: &Key,
+        into_view_field: &Key,
+        fields: &[Field],
+        into_views: &[&syn::Ident],
+    ) -> TokenStream {
+        let generics = fields
+            .iter()
+            .map(|field| &field.generic)
+            .chain(into_views.iter().copied());
         let fields = fields.iter().map(|field| {
             let key = field.kind;
             let generic = &field.generic;
             quote!(#key: #generic)
         });
+        let into_views_marker = quote! {
+            #into_view_field: core::marker::PhantomData<(#(#into_views,)*)>
+        };
 
         quote! {
             #[allow(non_camel_case_types, non_snake_case)]
-            #[derive(Clone, Copy, Hash, PartialEq, Eq)]
+            #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+            pub struct #dummy_ident {
+                #locale_field: #enum_ident
+            }
+
+            #[allow(non_camel_case_types, non_snake_case)]
+            #[derive(l_i18n_crate::__private::typed_builder::TypedBuilder)]
+            #[builder(crate_module_path=l_i18n_crate::typed_builder)]
             pub struct #ident<#(#generics,)*> {
-                _locale: #enum_ident,
+                #locale_field: #enum_ident,
+                #into_views_marker,
                 #(#fields,)*
             }
         }
     }
 
-    fn generate_generics<'a, F, T: Clone + 'a>(
-        left_fields: &'a [Field],
-        field_generic: Option<T>,
-        right_fields: &'a [Field],
-        other_field_map_fn: F,
-    ) -> impl Iterator<Item = T> + 'a + Clone
-    where
-        F: FnMut(&'a Field) -> T + Copy + 'a,
-    {
-        left_fields
-            .iter()
-            .map(other_field_map_fn)
-            .chain(field_generic)
-            .chain(right_fields.iter().map(other_field_map_fn))
-    }
-
-    fn generate_default_constructed(
+    fn debug_impl(
+        builder_name: &str,
         ident: &syn::Ident,
         fields: &[Field],
-        locale_field: &Key,
+        into_views: &[&syn::Ident],
     ) -> TokenStream {
-        let populated_fields = fields
+        let left_generics = fields
             .iter()
-            .map(|field| {
-                let field_ident = field.kind;
-                let default = field.kind.get_default();
-                quote!(#field_ident: #default)
-            })
-            .chain(std::iter::once(
-                quote!(#locale_field: core::default::Default::default()),
-            ));
-
-        quote! {
-            #ident {
-                #(#populated_fields,)*
-            }
-        }
-    }
-
-    fn generate_all_failing_build_fn<'a>(
-        ident: &'a syn::Ident,
-        fields: &'a [Field],
-        locale_field: &Key,
-    ) -> impl Iterator<Item = TokenStream> + 'a {
-        let default_constructed = Self::generate_default_constructed(ident, fields, locale_field);
-        let output_generics = fields.iter().map(|field| {
-            let generic = field.kind.get_generic();
-            quote!(impl #generic)
-        });
-        let output = quote!(#ident<#(#output_generics,)*>);
-        let max = 1u64 << fields.len();
-        (0..max - 1).map(move |states| {
-            let fields_iter = fields.iter().enumerate().map(|(i, field)| {
-                let state = (states >> i & 1) == 1;
-                (state, field)
-            });
-            Self::generate_failing_build_fn(ident, &default_constructed, &output, fields_iter)
-        })
-    }
-
-    fn generate_failing_build_fn<'a, I>(
-        self_ident: &syn::Ident,
-        default_constructed: &TokenStream,
-        output: &TokenStream,
-        fields: I,
-    ) -> TokenStream
-    where
-        I: Iterator<Item = (bool, &'a Field<'a>)> + Clone,
-    {
-        use std::borrow::Cow;
-
-        let right_generics = fields.clone().map(|(set, field)| {
-            if set {
-                quote::ToTokens::to_token_stream(&field.generic)
-            } else {
-                quote!(EmptyInterpolateValue)
-            }
-        });
-        let left_generics = fields.clone().filter(|(set, _)| *set).map(|(_, field)| {
-            let ident = &field.generic;
-            let generic_bound = field.kind.get_generic();
-            quote!(#ident: #generic_bound)
-        });
-
-        let missing_fields = fields
-            .filter_map(|(set, field)| (!set).then_some(field))
-            .map(|field| match field.kind {
-                InterpolateKey::Count(_) | InterpolateKey::Variable(_) => field.real_name.into(),
-                InterpolateKey::Component(_) => format!("<{}>", field.real_name).into(),
-            })
-            .collect::<Vec<Cow<_>>>();
-
-        let error_message = format!("\nMissing interpolations keys: {:?}", missing_fields);
-
-        quote! {
-            impl<#(#left_generics,)*> #self_ident<#(#right_generics,)*> {
-                #[deprecated(note = #error_message)]
-                pub fn build(self) -> #output {
-                    panic!(#error_message);
-                    #[allow(unreachable_code)]
-                    #default_constructed
-                }
-            }
-        }
-    }
-
-    fn create_field_set_fn(
-        ident: &syn::Ident,
-        locale_field: &Key,
-        left_fields: &[Field],
-        right_fields: &[Field],
-        field: &Field,
-    ) -> TokenStream {
-        let quoted_gen = |field: &Field| {
-            let generic = &field.generic;
-            quote!(#generic)
-        };
-        let output_field_generic = field.kind.get_generic();
-        let output_generics = Self::generate_generics(
-            left_fields,
-            Some(quote!(impl #output_field_generic)),
-            right_fields,
-            quoted_gen,
-        );
-
-        let (output_field_generic_string, output_generics_string, bounds) =
-            if cfg!(feature = "interpolate_display") {
-                let (output_field_generic_string, bounds) = match field.kind.get_string_generic() {
-                    Ok(bounds) => (quote!(impl #bounds), bounds),
-                    Err(t) => (quote!(#t), quote!()),
-                };
-                let output_generics_string = Self::generate_generics(
-                    left_fields,
-                    Some(output_field_generic_string.clone()),
-                    right_fields,
-                    quoted_gen,
-                );
-                (
-                    output_field_generic_string,
-                    Some(output_generics_string),
-                    bounds,
-                )
-            } else {
-                (quote!(), None, quote!())
-            };
-
-        let other_fields = Self::generate_generics(left_fields, None, right_fields, |field| {
-            if let Some(key) = field.kind.as_key() {
-                quote!(#key)
-            } else {
-                quote!(var_count)
-            }
-        })
-        .chain(Some(quote!(#locale_field)));
-
-        let kind = field.kind;
-
-        let destructure = {
-            let other_fields = other_fields.clone();
-            quote!(let Self { #(#other_fields,)* .. } = self;)
-        };
-        let restructure = quote!(#ident { #(#other_fields,)* #kind });
-
-        let (set_function, set_str_function) = match kind {
-            InterpolateKey::Variable(key) => (
-                quote! {
-                    #[inline]
-                    pub fn #key<__T>(self, #key: __T) -> #ident<#(#output_generics,)*>
-                        where __T: leptos::IntoView + core::clone::Clone + 'static
-                    {
-                        #destructure
-                        #restructure
-                    }
-                },
-                if let Some(output_generics_string) = output_generics_string {
-                    let string_key = format_ident!("{}_string", key.ident);
-                    quote! {
-                        #[inline]
-                        pub fn #string_key(self, #key: #output_field_generic_string) -> #ident<#(#output_generics_string,)*>
-                        {
-                            #destructure
-                            #restructure
-                        }
-                    }
-                } else {
-                    quote!()
-                },
-            ),
-            InterpolateKey::Component(key) => (
-                quote! {
-                    #[inline]
-                    pub fn #key<__O, __T>(self, #key: __T) -> #ident<#(#output_generics,)*>
-                    where
-                        __O: leptos::IntoView,
-                        __T: Fn(leptos::ChildrenFn) -> __O + core::clone::Clone + 'static
-                    {
-                        #destructure
-                        let #key = move |children| leptos::IntoView::into_view(#key(children));
-                        #restructure
-                    }
-                },
-                if let Some(output_generics_string) = output_generics_string {
-                    let string_key = format_ident!("{}_string", key.ident);
-                    quote! {
-                        #[inline]
-                        pub fn #string_key(self, #key: #output_field_generic_string) -> #ident<#(#output_generics_string,)*>
-                        {
-                            #destructure
-                            #restructure
-                        }
-                    }
-                } else {
-                    quote!()
-                },
-            ),
-            InterpolateKey::Count(plural_type) => (
-                quote! {
-                    #[inline]
-                    pub fn var_count<__T>(self, var_count: __T) -> #ident<#(#output_generics,)*>
-                        where __T: Fn() -> #plural_type + core::clone::Clone + 'static,
-                    {
-                        #destructure
-                        #restructure
-                    }
-                },
-                if let Some(output_generics_string) = output_generics_string {
-                    quote! {
-                        #[inline]
-                    pub fn var_count_string(self, var_count: #plural_type) -> #ident<#(#output_generics_string,)*>
-                    {
-                        #destructure
-                        #restructure
-                    }
-                    }
-                } else {
-                    quote!()
-                },
-            ),
-        };
-
-        if cfg!(feature = "debug_interpolations") {
-            let left_generics_empty =
-                Self::generate_generics(left_fields, None, right_fields, |field| &field.generic);
-            let left_generics_already_set = Self::generate_generics(
-                left_fields,
-                Some({
-                    let field_gen = &field.generic;
-                    quote!(#field_gen: #output_field_generic)
-                }),
-                right_fields,
-                quoted_gen,
-            );
-            let right_generics_empty = Self::generate_generics(
-                left_fields,
-                Some(quote!(EmptyInterpolateValue)),
-                right_fields,
-                quoted_gen,
-            );
-            let right_generics_already_set =
-                Self::generate_generics(left_fields, Some(&field.generic), right_fields, |field| {
-                    &field.generic
-                });
-
-            let compile_warning = match field.kind {
-                InterpolateKey::Count(_) => "variable `count` is already set".to_string(),
-                InterpolateKey::Variable(_) => format!("variable `{}` is already set", field.name),
-                InterpolateKey::Component(_) => {
-                    format!("component `{}` is already set", field.name)
-                }
-            };
-
-            let string_impl = if cfg!(feature = "interpolate_display") {
-                let left_generics_empty_string = left_generics_empty.clone();
-                let right_generics_empty_string = right_generics_empty.clone();
-                let left_generics_already_set_string = Self::generate_generics(
-                    left_fields,
-                    Some({
-                        let field_gen = &field.generic;
-                        quote!(#field_gen: #bounds)
-                    }),
-                    right_fields,
-                    quoted_gen,
-                );
-                let right_generics_already_set_string = right_generics_already_set.clone();
-                quote! {
-                    #[allow(non_camel_case_types)]
-                    impl<#(#left_generics_empty_string,)*> #ident<#(#right_generics_empty_string,)*> {
-                        #set_str_function
-                    }
-
-                    #[allow(non_camel_case_types)]
-                    impl<#(#left_generics_already_set_string,)*> #ident<#(#right_generics_already_set_string,)*> {
-                        #[deprecated(note = #compile_warning)]
-                        #set_str_function
-                    }
-                }
-            } else {
-                quote!()
-            };
-
-            quote! {
-                #[allow(non_camel_case_types)]
-                impl<#(#left_generics_empty,)*> #ident<#(#right_generics_empty,)*> {
-                    #set_function
-                }
-                #[allow(non_camel_case_types)]
-                impl<#(#left_generics_already_set,)*> #ident<#(#right_generics_already_set,)*> {
-                    #[deprecated(note = #compile_warning)]
-                    #set_function
-                }
-
-                #string_impl
-            }
-        } else {
-            let left_generics =
-                Self::generate_generics(left_fields, Some(&field.generic), right_fields, |field| {
-                    &field.generic
-                });
-            let right_generics = left_generics.clone();
-
-            quote! {
-                #[allow(non_camel_case_types)]
-                impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
-                    #set_function
-
-                    #set_str_function
-                }
-            }
-        }
-    }
-
-    fn debug_impl(builder_name: &str, ident: &syn::Ident, fields: &[Field]) -> TokenStream {
-        let left_generics = fields.iter().map(|field| &field.generic);
+            .map(|field| &field.generic)
+            .chain(into_views.iter().copied());
 
         let right_generics = left_generics.clone();
 
@@ -641,8 +272,8 @@ impl Interpolation {
 
         quote! {
             #[allow(non_camel_case_types)]
-            impl<#(#left_generics,)*> core::fmt::Display for #ident<#(#right_generics,)*> {
-                fn fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            impl<#(#left_generics,)*> ::core::fmt::Display for #ident<#(#right_generics,)*> {
+                fn fmt(&self, __formatter: &mut ::core::fmt::Formatter<'_>) -> core::fmt::Result {
                     #destructure
                     match #locale_field {
                         #(
@@ -664,17 +295,29 @@ impl Interpolation {
         locales: &[Locale],
         default_match: &TokenStream,
         key_path: &KeyPath,
+        into_views: &[&syn::Ident],
     ) -> TokenStream {
-        let left_generics = fields.iter().map(|field| {
-            let ident = &field.generic;
-            let generic = field.kind.get_generic();
-            quote!(#ident: #generic)
-        });
+        let into_view_generics = into_views
+            .iter()
+            .map(|into_view| quote!(#into_view: l_i18n_crate::__private::leptos::IntoView));
 
-        let right_generics = fields.iter().map(|field| {
-            let ident = &field.generic;
-            quote!(#ident)
-        });
+        let left_generics = fields
+            .iter()
+            .map(|field| {
+                let ident = &field.generic;
+                let generic = field.kind.get_generic();
+                if let Some(into_view) = field.into_view.as_ref() {
+                    quote!(#ident: #generic<#into_view>)
+                } else {
+                    quote!(#ident: #generic)
+                }
+            })
+            .chain(into_view_generics);
+
+        let right_generics = fields
+            .iter()
+            .map(|field| &field.generic)
+            .chain(into_views.iter().copied());
 
         if cfg!(feature = "show_keys_only") {
             let key = key_path.to_string_with_key(key);
@@ -691,7 +334,7 @@ impl Interpolation {
 
         let fields_key = fields.iter().map(|f| f.kind);
 
-        let destructure = quote!(let Self { #(#fields_key,)* #locale_field } = self;);
+        let destructure = quote!(let Self { #(#fields_key,)* #locale_field, .. } = self;);
 
         let locales_impls = Self::create_locale_impl(key, enum_ident, locales, default_match);
 

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -445,7 +445,7 @@ fn create_locale_type_inner(
         .collect::<Vec<_>>();
 
     let builder_fields = builders.iter().map(|(key, inter)| {
-        let inter_ident = &inter.default_generic_ident;
+        let inter_ident = &inter.ident;
         quote!(pub #key: builders::#inter_ident)
     });
 

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -622,7 +622,7 @@ impl InterpolateKey {
     pub fn as_ident(&self) -> syn::Ident {
         match self {
             InterpolateKey::Variable(key) | InterpolateKey::Component(key) => key.ident.clone(),
-            InterpolateKey::Count(_) => format_ident!("var_count"),
+            InterpolateKey::Count(_) => format_ident!("plural_count"),
         }
     }
 
@@ -642,7 +642,7 @@ impl InterpolateKey {
 
     pub fn get_real_name(&self) -> &str {
         match self {
-            InterpolateKey::Count(_) => "count",
+            InterpolateKey::Count(_) => "plural_count",
             InterpolateKey::Variable(key) => key.name.strip_prefix("var_").unwrap(),
             InterpolateKey::Component(key) => key.name.strip_prefix("comp_").unwrap(),
         }

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -640,14 +640,6 @@ impl InterpolateKey {
         }
     }
 
-    pub fn get_real_name(&self) -> &str {
-        match self {
-            InterpolateKey::Count(_) => "plural_count",
-            InterpolateKey::Variable(key) => key.name.strip_prefix("var_").unwrap(),
-            InterpolateKey::Component(key) => key.name.strip_prefix("comp_").unwrap(),
-        }
-    }
-
     pub fn get_generic(&self) -> TokenStream {
         match self {
             InterpolateKey::Variable(_) => {
@@ -667,21 +659,6 @@ impl InterpolateKey {
             InterpolateKey::Count(t) => Err(*t),
             InterpolateKey::Variable(_) => Ok(quote!(core::fmt::Display)),
             InterpolateKey::Component(_) => Ok(quote!(l_i18n_crate::display::DisplayComponent)),
-        }
-    }
-
-    pub fn get_default(&self) -> TokenStream {
-        match self {
-            InterpolateKey::Variable(_) => {
-                quote!(())
-            }
-            InterpolateKey::Count(plural_type) => match plural_type {
-                PluralType::F32 | PluralType::F64 => quote!(|| 0.0),
-                _ => quote!(|| 0),
-            },
-            InterpolateKey::Component(_) => {
-                quote!(|_: leptos::ChildrenFn| core::default::Default::default())
-            }
         }
     }
 }

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -633,6 +633,13 @@ impl InterpolateKey {
         }
     }
 
+    pub fn as_comp(&self) -> Option<&Rc<Key>> {
+        match self {
+            InterpolateKey::Component(k) => Some(k),
+            _ => None,
+        }
+    }
+
     pub fn get_real_name(&self) -> &str {
         match self {
             InterpolateKey::Count(_) => "count",
@@ -644,16 +651,14 @@ impl InterpolateKey {
     pub fn get_generic(&self) -> TokenStream {
         match self {
             InterpolateKey::Variable(_) => {
-                quote!(leptos::IntoView + core::clone::Clone + 'static)
+                quote!(l_i18n_crate::__private::InterpolateVar)
             }
             InterpolateKey::Count(plural_type) => {
-                quote!(Fn() -> #plural_type + core::clone::Clone + 'static)
+                quote!(l_i18n_crate::__private::InterpolateCount<#plural_type>)
             }
-            InterpolateKey::Component(_) => quote!(
-                Fn(leptos::ChildrenFn) -> leptos::View
-                    + core::clone::Clone
-                    + 'static
-            ),
+            InterpolateKey::Component(_) => {
+                quote!(l_i18n_crate::__private::InterpolateComp)
+            }
         }
     }
 

--- a/leptos_i18n_macro/src/load_locales/plural.rs
+++ b/leptos_i18n_macro/src/load_locales/plural.rs
@@ -232,15 +232,12 @@ impl Plurals {
         let captured_values = captured_values.map(|keys| {
             let keys = keys
                 .into_iter()
-                .filter(|key| !matches!(key, InterpolateKey::Variable(k) if k.name == "var_count"))
                 .map(|key| quote!(let #key = core::clone::Clone::clone(&#key);));
             quote!(#(#keys)*)
         });
         let match_statement = quote! {
             {
                 let plural_count = plural_count();
-                #[allow(unused)]
-                let var_count = plural_count;
                 match plural_count {
                     #(
                         #match_arms,
@@ -270,8 +267,6 @@ impl Plurals {
 
         quote! {
             {
-                #[allow(unused)]
-                let var_count = plural_count;
                 let plural_count = *plural_count;
                 match plural_count {
                     #(
@@ -319,7 +314,6 @@ impl Plurals {
         let captured_values = captured_values.map(|keys| {
             let keys = keys
                 .into_iter()
-                .filter(|key| !matches!(key, InterpolateKey::Variable(k) if k.name == "var_count"))
                 .map(|key| quote!(let #key = core::clone::Clone::clone(&#key);));
             quote!(#(#keys)*)
         });
@@ -330,8 +324,6 @@ impl Plurals {
                     #captured_values
                     move || {
                         let plural_count = plural_count();
-                        #[allow(unused)]
-                        let var_count = plural_count;
                         #ifs
                     }
                 },
@@ -358,8 +350,6 @@ impl Plurals {
 
         quote! {
             {
-                #[allow(unused)]
-                let var_count = plural_count;
                 let plural_count = *plural_count;
                 #ifs
             }

--- a/leptos_i18n_macro/src/load_locales/plural.rs
+++ b/leptos_i18n_macro/src/load_locales/plural.rs
@@ -232,14 +232,20 @@ impl Plurals {
         let captured_values = captured_values.map(|keys| {
             let keys = keys
                 .into_iter()
+                .filter(|key| !matches!(key, InterpolateKey::Variable(k) if k.name == "var_count"))
                 .map(|key| quote!(let #key = core::clone::Clone::clone(&#key);));
             quote!(#(#keys)*)
         });
         let match_statement = quote! {
-            match var_count() {
-                #(
-                    #match_arms,
-                )*
+            {
+                let plural_count = plural_count();
+                #[allow(unused)]
+                let var_count = plural_count;
+                match plural_count {
+                    #(
+                        #match_arms,
+                    )*
+                }
             }
         };
 
@@ -263,10 +269,15 @@ impl Plurals {
         });
 
         quote! {
-            match *var_count {
-                #(
-                    #match_arms,
-                )*
+            {
+                #[allow(unused)]
+                let var_count = plural_count;
+                let plural_count = *plural_count;
+                match plural_count {
+                    #(
+                        #match_arms,
+                    )*
+                }
             }
         }
     }
@@ -308,6 +319,7 @@ impl Plurals {
         let captured_values = captured_values.map(|keys| {
             let keys = keys
                 .into_iter()
+                .filter(|key| !matches!(key, InterpolateKey::Variable(k) if k.name == "var_count"))
                 .map(|key| quote!(let #key = core::clone::Clone::clone(&#key);));
             quote!(#(#keys)*)
         });
@@ -317,7 +329,9 @@ impl Plurals {
                 {
                     #captured_values
                     move || {
-                        let plural_count = var_count();
+                        let plural_count = plural_count();
+                        #[allow(unused)]
+                        let var_count = plural_count;
                         #ifs
                     }
                 },
@@ -344,7 +358,9 @@ impl Plurals {
 
         quote! {
             {
-                let plural_count = *var_count;
+                #[allow(unused)]
+                let var_count = plural_count;
+                let plural_count = *plural_count;
                 #ifs
             }
         }

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -62,12 +62,12 @@ pub fn t_macro_inner(
 
         let inner = quote! {
             {
-                let _key = #get_key;
+                let _builder = #get_key.new_builder();
                 #(
-                    let _key = _key.#interpolations;
+                    let _builder = _builder.#interpolations;
                 )*
                 #[deny(deprecated)]
-                _key.#build_fn()
+                _builder.#build_fn()
             }
         };
 

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -1,9 +1,6 @@
-use interpolate::InterpolatedValueTokenizer;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::parse_macro_input;
-
-use crate::t_macro::interpolate::InterpolatedValue;
 
 use self::parsed_input::ParsedInput;
 use crate::utils::Keys;
@@ -51,14 +48,11 @@ pub fn t_macro_inner(
     let (inner, params) = if let Some(mut interpolations) = interpolations {
         let (keys, values): (Vec<_>, Vec<_>) = interpolations
             .iter_mut()
-            .map(InterpolatedValue::param)
+            .map(|inter| inter.param(output_type))
             .unzip();
         let params = quote! {
             let (#(#keys,)*) = (#(#values,)*);
         };
-        let interpolations = interpolations
-            .iter()
-            .map(|inter| InterpolatedValueTokenizer::new(inter, output_type));
 
         let inner = quote! {
             {

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -45,7 +45,7 @@ pub fn t_macro_inner(
     } = input;
 
     let get_key = input_type.get_key(context, keys);
-    let build_fn = output_type.build_fn();
+    let builder_fn = output_type.builder_fn();
 
     let (inner, params) = if let Some(mut interpolations) = interpolations {
         let (keys, values): (Vec<_>, Vec<_>) = interpolations
@@ -62,12 +62,12 @@ pub fn t_macro_inner(
 
         let inner = quote! {
             {
-                let _builder = #get_key.new_builder();
+                let _builder = #get_key.#builder_fn();
                 #(
                     let _builder = _builder.#interpolations;
                 )*
                 #[deny(deprecated)]
-                _builder.#build_fn()
+                _builder.build()
             }
         };
 
@@ -78,7 +78,7 @@ pub fn t_macro_inner(
                 #[allow(unused)]
                 use leptos_i18n::__private::BuildStr;
                 let _key = #get_key;
-                _key.#build_fn()
+                _key.#builder_fn().build()
             }
         };
         (inner, None)
@@ -88,11 +88,11 @@ pub fn t_macro_inner(
 }
 
 impl OutputType {
-    pub fn build_fn(self) -> TokenStream {
+    pub fn builder_fn(self) -> TokenStream {
         match self {
-            OutputType::View => quote!(build),
-            OutputType::String => quote!(build_string),
-            OutputType::Display => quote!(build_display),
+            OutputType::View => quote!(view_builder),
+            OutputType::String => quote!(string_builder),
+            OutputType::Display => quote!(display_builder),
         }
     }
 

--- a/leptos_i18n_macro/src/t_macro/mod.rs
+++ b/leptos_i18n_macro/src/t_macro/mod.rs
@@ -96,13 +96,6 @@ impl OutputType {
         }
     }
 
-    pub fn is_string(self) -> bool {
-        match self {
-            OutputType::View => false,
-            OutputType::String | OutputType::Display => true,
-        }
-    }
-
     pub fn comp_check_fn(self) -> TokenStream {
         match self {
             OutputType::View => quote!(leptos_i18n::__private::check_comp),

--- a/tests/json/src/defaulted.rs
+++ b/tests/json/src/defaulted.rs
@@ -20,16 +20,16 @@ fn defaulted_interpolation() {
 #[test]
 fn defaulted_plurals() {
     let count = || 0;
-    let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", count);
+    let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", count);
+    let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", $ = count);
     assert_eq_rendered!(fr, "zero");
 
     for i in [-3, 5, 12] {
         let count = move || i;
-        let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", count);
+        let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", $ = count);
         assert_eq_rendered!(en, "this plural is declared in locale en");
-        let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", count);
+        let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", $ = count);
         assert_eq_rendered!(fr, "this plural is declared in locale en");
     }
 }

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 #![deny(warnings)]
+
 leptos_i18n::load_locales!();
 
 mod defaulted;

--- a/tests/json/src/plurals.rs
+++ b/tests/json/src/plurals.rs
@@ -5,26 +5,26 @@ use common::*;
 fn f32_plural() {
     // count = 0
     let count = move || 0.0;
-    let en = tdbg!(Locale::en, f32_plural, count);
+    let en = tdbg!(Locale::en, f32_plural, $ = count);
     assert_eq_rendered!(en, "You are broke");
-    let fr = tdbg!(Locale::fr, f32_plural, count);
+    let fr = tdbg!(Locale::fr, f32_plural, $ = count);
     assert_eq_rendered!(fr, "Vous êtes pauvre");
 
     // count = ..0
     for i in [-100.34, -57.69, 0.0 - 0.00001] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_plural, count);
+        let en = tdbg!(Locale::en, f32_plural, $ = count);
         assert_eq_rendered!(en, "You owe money");
-        let fr = tdbg!(Locale::fr, f32_plural, count);
+        let fr = tdbg!(Locale::fr, f32_plural, $ = count);
         assert_eq_rendered!(fr, "Vous devez de l'argent");
     }
 
     // count = _
     for i in [100.34, 57.69, 0.0 + 0.00001] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_plural, count);
+        let en = tdbg!(Locale::en, f32_plural, $ = count);
         assert_eq_rendered!(en, format!("You have {}€", i));
-        let fr = tdbg!(Locale::fr, f32_plural, count);
+        let fr = tdbg!(Locale::fr, f32_plural, $ = count);
         assert_eq_rendered!(fr, format!("Vous avez {}€", i));
     }
 }
@@ -33,17 +33,17 @@ fn f32_plural() {
 fn u32_plural() {
     // count = 0
     let count = move || 0;
-    let en = tdbg!(Locale::en, u32_plural, count);
+    let en = tdbg!(Locale::en, u32_plural, $ = count);
     assert_eq_rendered!(en, "0");
-    let fr = tdbg!(Locale::fr, u32_plural, count);
+    let fr = tdbg!(Locale::fr, u32_plural, $ = count);
     assert_eq_rendered!(fr, "0");
 
     // count = 1..
     for i in [1, 45, 72] {
         let count = move || i;
-        let en = tdbg!(Locale::en, u32_plural, count);
+        let en = tdbg!(Locale::en, u32_plural, $ = count);
         assert_eq_rendered!(en, "1..");
-        let fr = tdbg!(Locale::fr, u32_plural, count);
+        let fr = tdbg!(Locale::fr, u32_plural, $ = count);
         assert_eq_rendered!(fr, "1..");
     }
 }
@@ -52,16 +52,16 @@ fn u32_plural() {
 fn u32_plural_string() {
     // count = 0
     let count = 0;
-    let en = td_string!(Locale::en, u32_plural, count);
+    let en = td_string!(Locale::en, u32_plural, $ = count);
     assert_eq!(en.to_string(), "0");
-    let fr = td_string!(Locale::fr, u32_plural, count);
+    let fr = td_string!(Locale::fr, u32_plural, $ = count);
     assert_eq!(fr.to_string(), "0");
 
     // count = 1..
     for count in [1, 45, 72] {
-        let en = td_string!(Locale::en, u32_plural, count);
+        let en = td_string!(Locale::en, u32_plural, $ = count);
         assert_eq!(en.to_string(), "1..");
-        let fr = td_string!(Locale::fr, u32_plural, count);
+        let fr = td_string!(Locale::fr, u32_plural, $ = count);
         assert_eq!(fr.to_string(), "1..");
     }
 }
@@ -71,36 +71,36 @@ fn or_plural() {
     // count = 0 | 5
     for i in [0, 5] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1, 4, 6, 9] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10, 12, 14, 20] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15, 17, 21, 56] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "fallback sans count");
     }
 }
@@ -110,36 +110,36 @@ fn f32_or_plural() {
     // count = 0 | 5
     for i in [0.0, 5.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1.0, 4.0, 6.0, 9.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10.0, 12.0, 14.0, 20.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15.0, 17.0, 21.0, 56.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "fallback avec tuple vide");
     }
 }
@@ -148,33 +148,33 @@ fn f32_or_plural() {
 fn f32_or_plural_string() {
     // count = 0 | 5
     for count in [0.0, 5.0] {
-        let en = td_string!(Locale::en, f32_OR_plural, count);
+        let en = td_string!(Locale::en, f32_OR_plural, $ = count);
         assert_eq!(en, "0 or 5");
-        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        let fr = td_string!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for count in [1.0, 4.0, 6.0, 9.0] {
-        let en = td_string!(Locale::en, f32_OR_plural, count);
+        let en = td_string!(Locale::en, f32_OR_plural, $ = count);
         assert_eq!(en, "1..5 | 6..10");
-        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        let fr = td_string!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for count in [10.0, 12.0, 14.0, 20.0] {
-        let en = td_string!(Locale::en, f32_OR_plural, count);
+        let en = td_string!(Locale::en, f32_OR_plural, $ = count);
         assert_eq!(en, "10..15 | 20");
-        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        let fr = td_string!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq!(fr, "10..15 | 20");
     }
 
     // count = _
     for count in [15.0, 17.0, 21.0, 56.0] {
-        let en = td_string!(Locale::en, f32_OR_plural, count);
+        let en = td_string!(Locale::en, f32_OR_plural, $ = count);
         assert_eq!(en, "fallback with no count");
-        let fr = td_string!(Locale::fr, f32_OR_plural, count);
+        let fr = td_string!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq!(fr, "fallback avec tuple vide");
     }
 }

--- a/tests/json/src/scoped.rs
+++ b/tests/json/src/scoped.rs
@@ -7,18 +7,18 @@ fn subkey_3() {
     let fr_scope = scope_locale!(Locale::fr, subkeys);
 
     let count = || 0;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/json/src/subkeys.rs
+++ b/tests/json/src/subkeys.rs
@@ -61,18 +61,18 @@ fn subkey_2_string() {
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/json/src/tests.rs
+++ b/tests/json/src/tests.rs
@@ -49,19 +49,19 @@ fn click_count_string() {
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }
 

--- a/tests/namespaces/src/first_ns.rs
+++ b/tests/namespaces/src/first_ns.rs
@@ -20,33 +20,33 @@ fn common_key() {
 #[test]
 fn plural_only_en() {
     let count = move || 0;
-    let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+    let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
     assert_eq_rendered!(en, "exact");
     for i in -3..0 {
         let count = move || i;
-        let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+        let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
         assert_eq_rendered!(en, "unbounded start");
     }
     for i in 99..103 {
         let count = move || i;
-        let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+        let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
         assert_eq_rendered!(en, "unbounded end");
     }
     for i in 1..3 {
         let count = move || i;
-        let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+        let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
         assert_eq_rendered!(en, "excluded end");
     }
     for i in 3..=8 {
         let count = move || i;
-        let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+        let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
         assert_eq_rendered!(en, "included end");
     }
     for i in [30, 40, 55, 73] {
         let count = move || i;
-        let en = tdbg!(Locale::en, first_namespace.plural_only_en, count);
+        let en = tdbg!(Locale::en, first_namespace.plural_only_en, $ = count);
         assert_eq_rendered!(en, "fallback");
     }
-    let fr = tdbg!(Locale::fr, first_namespace.plural_only_en, count);
+    let fr = tdbg!(Locale::fr, first_namespace.plural_only_en, $ = count);
     assert_eq_rendered!(fr, "pas de plurals en français");
 }

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -23,7 +23,7 @@ fn scoped_plurals() {
     let fr_scope = scope_locale!(Locale::fr, first_namespace);
 
     let count = move || 0;
-    let en = tdbg!(en_scope, plural_only_en, count);
+    let en = tdbg!(en_scope, plural_only_en, $ = count);
     assert_eq_rendered!(en, "exact");
     for i in -3..0 {
         let count = move || i;

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -27,31 +27,31 @@ fn scoped_plurals() {
     assert_eq_rendered!(en, "exact");
     for i in -3..0 {
         let count = move || i;
-        let en = tdbg!(en_scope, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, $ = count);
         assert_eq_rendered!(en, "unbounded start");
     }
     for i in 99..103 {
         let count = move || i;
-        let en = tdbg!(en_scope, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, $ = count);
         assert_eq_rendered!(en, "unbounded end");
     }
     for i in 1..3 {
         let count = move || i;
-        let en = tdbg!(en_scope, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, $ = count);
         assert_eq_rendered!(en, "excluded end");
     }
     for i in 3..=8 {
         let count = move || i;
-        let en = tdbg!(en_scope, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, $ = count);
         assert_eq_rendered!(en, "included end");
     }
     for i in [30, 40, 55, 73] {
         let count = move || i;
-        let en = tdbg!(en_scope, plural_only_en, count);
+        let en = tdbg!(en_scope, plural_only_en, $ = count);
         assert_eq_rendered!(en, "fallback");
     }
 
-    let fr = tdbg!(fr_scope, plural_only_en, count);
+    let fr = tdbg!(fr_scope, plural_only_en, $ = count);
     assert_eq_rendered!(fr, "pas de plurals en français");
 }
 
@@ -61,18 +61,18 @@ fn scoped_sub_subkeys() {
     let fr_scope = scope_locale!(Locale::fr, second_namespace.subkeys);
 
     let count = || 0;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "zero");
     let count = || 1;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(en_scope, subkey_3, count);
+    let en = tdbg!(en_scope, subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(fr_scope, subkey_3, count);
+    let fr = tdbg!(fr_scope, subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/namespaces/src/second_ns.rs
+++ b/tests/namespaces/src/second_ns.rs
@@ -54,19 +54,19 @@ fn subkey_2() {
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "zero");
     let count = || 1;
-    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, second_namespace.subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }
 

--- a/tests/yaml/src/defaulted.rs
+++ b/tests/yaml/src/defaulted.rs
@@ -20,16 +20,16 @@ fn defaulted_interpolation() {
 #[test]
 fn defaulted_plurals() {
     let count = || 0;
-    let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", count);
+    let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", count);
+    let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", $ = count);
     assert_eq_rendered!(fr, "zero");
 
     for i in [-3, 5, 12] {
         let count = move || i;
-        let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", count);
+        let en = tdbg!(Locale::en, defaulted_plurals, locale = "en", $ = count);
         assert_eq_rendered!(en, "this plural is declared in locale en");
-        let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", count);
+        let fr = tdbg!(Locale::fr, defaulted_plurals, locale = "en", $ = count);
         assert_eq_rendered!(fr, "this plural is declared in locale en");
     }
 }

--- a/tests/yaml/src/plurals.rs
+++ b/tests/yaml/src/plurals.rs
@@ -5,26 +5,26 @@ use common::*;
 fn f32_plural() {
     // count = 0
     let count = move || 0.0;
-    let en = tdbg!(Locale::en, f32_plural, count);
+    let en = tdbg!(Locale::en, f32_plural, $ = count);
     assert_eq_rendered!(en, "You are broke");
-    let fr = tdbg!(Locale::fr, f32_plural, count);
+    let fr = tdbg!(Locale::fr, f32_plural, $ = count);
     assert_eq_rendered!(fr, "Vous êtes pauvre");
 
     // count = ..0
     for i in [-100.34, -57.69, 0.0 - 0.00001] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_plural, count);
+        let en = tdbg!(Locale::en, f32_plural, $ = count);
         assert_eq_rendered!(en, "You owe money");
-        let fr = tdbg!(Locale::fr, f32_plural, count);
+        let fr = tdbg!(Locale::fr, f32_plural, $ = count);
         assert_eq_rendered!(fr, "Vous devez de l'argent");
     }
 
     // count = _
     for i in [100.34, 57.69, 0.0 + 0.00001] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_plural, count);
+        let en = tdbg!(Locale::en, f32_plural, $ = count);
         assert_eq_rendered!(en, format!("You have {}€", i));
-        let fr = tdbg!(Locale::fr, f32_plural, count);
+        let fr = tdbg!(Locale::fr, f32_plural, $ = count);
         assert_eq_rendered!(fr, format!("Vous avez {}€", i));
     }
 }
@@ -33,17 +33,17 @@ fn f32_plural() {
 fn u32_plural() {
     // count = 0
     let count = move || 0;
-    let en = tdbg!(Locale::en, u32_plural, count);
+    let en = tdbg!(Locale::en, u32_plural, $ = count);
     assert_eq_rendered!(en, "0");
-    let fr = tdbg!(Locale::fr, u32_plural, count);
+    let fr = tdbg!(Locale::fr, u32_plural, $ = count);
     assert_eq_rendered!(fr, "0");
 
     // count = 1..
     for i in [1, 45, 72] {
         let count = move || i;
-        let en = tdbg!(Locale::en, u32_plural, count);
+        let en = tdbg!(Locale::en, u32_plural, $ = count);
         assert_eq_rendered!(en, "1..");
-        let fr = tdbg!(Locale::fr, u32_plural, count);
+        let fr = tdbg!(Locale::fr, u32_plural, $ = count);
         assert_eq_rendered!(fr, "1..");
     }
 }
@@ -53,36 +53,36 @@ fn or_plural() {
     // count = 0 | 5
     for i in [0, 5] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1, 4, 6, 9] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10, 12, 14, 20] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15, 17, 21, 56] {
         let count = move || i;
-        let en = tdbg!(Locale::en, OR_plural, count);
+        let en = tdbg!(Locale::en, OR_plural, $ = count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = tdbg!(Locale::fr, OR_plural, count);
+        let fr = tdbg!(Locale::fr, OR_plural, $ = count);
         assert_eq_rendered!(fr, "fallback sans count");
     }
 }
@@ -92,36 +92,36 @@ fn f32_or_plural() {
     // count = 0 | 5
     for i in [0.0, 5.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "0 or 5");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "0 or 5");
     }
 
     // count = 1..5 | 6..10
     for i in [1.0, 4.0, 6.0, 9.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "1..5 | 6..10");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "1..5 | 6..10");
     }
 
     // count = 10..15 | 20
     for i in [10.0, 12.0, 14.0, 20.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "10..15 | 20");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "10..15 | 20");
     }
 
     // count = _
     for i in [15.0, 17.0, 21.0, 56.0] {
         let count = move || i;
-        let en = tdbg!(Locale::en, f32_OR_plural, count);
+        let en = tdbg!(Locale::en, f32_OR_plural, $ = count);
         assert_eq_rendered!(en, "fallback with no count");
-        let fr = tdbg!(Locale::fr, f32_OR_plural, count);
+        let fr = tdbg!(Locale::fr, f32_OR_plural, $ = count);
         assert_eq_rendered!(fr, "fallback avec tuple vide");
     }
 }

--- a/tests/yaml/src/subkeys.rs
+++ b/tests/yaml/src/subkeys.rs
@@ -27,18 +27,18 @@ fn subkey_2() {
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }

--- a/tests/yaml/src/tests.rs
+++ b/tests/yaml/src/tests.rs
@@ -34,18 +34,18 @@ fn click_count() {
 #[test]
 fn subkey_3() {
     let count = || 0;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "zero");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "0");
     let count = || 1;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "one");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "1");
     let count = || 3;
-    let en = tdbg!(Locale::en, subkeys.subkey_3, count);
+    let en = tdbg!(Locale::en, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(en, "3");
-    let fr = tdbg!(Locale::fr, subkeys.subkey_3, count);
+    let fr = tdbg!(Locale::fr, subkeys.subkey_3, $ = count);
     assert_eq_rendered!(fr, "3");
 }


### PR DESCRIPTION
This replace the in house badly written builders by [`typed-builder`](https://github.com/idanarye/rust-typed-builder/tree/master) 

close #116 