### PR TITLE
Header options

### DIFF
--- a/docs/book/src/06_features.md
+++ b/docs/book/src/06_features.md
@@ -10,6 +10,10 @@ This feature must be enabled when building the server with the actix backend
 
 This feature must be enabled when building the server with the actix backend
 
+### `ssr`
+
+This feature must be enabled when building the server. It is auto enabled by the `actix` or `axum` features, but if you use another backend you can use this feature and provide custom functions to get access to the request headers.
+
 #### `hydrate`
 
 This feature must be enabled when building the client in ssr mode

--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -125,25 +125,26 @@ The `I18nContextProvider` component accept multiple props, all optionnal (except
 
 ## Note on island
 
-If you use the `experimental-islands` feature from Leptos the `I18nContextProvider` loose one prop: `cookie_options`, because it is not serializable. If you need it you can use the `init_context_with_options` function and provide the context yourself:
+If you use the `experimental-islands` feature from Leptos the `I18nContextProvider` loose two props: `cookie_options` and `ssr_lang_header_getter`, because they are not serializable. If you need them you can use the `init_context_with_options` function and provide the context yourself:
 
 ```rust
 use leptos_i18n::init_i18n_context_with_options;
-use crate::i18n::*;
+use leptos_i18n::context::{CookieOptions, UseLocalesOptions};
 use leptos_meta::Html;
-use leptos::*;
+use leptos::prelude::*;
+use crate::i18n::*;
 
 #[island]
 fn MyI18nProvider(
-    enable_cookie: bool,
-    cookie_name: &str,
+    enable_cookie: Option<bool>,
+    cookie_name: Option<&str>,
     children: Children
 ) -> impl IntoView {
-    let my_cookie_options = /* create your options here */;
-    let ssr_lang_header_getter = /* create your options here */;
+    let my_cookie_options: CookieOptions<Locale> = /* create your options here */;
+    let ssr_lang_header_getter: UseLocalesOptions = /* create your options here */;
     let i18n = init_i18n_context_with_options::<Locale>(
-        Some(enable_cookie),
-        Some(cookie_name),
+        enable_cookie,
+        cookie_name,
         Some(my_cookie_options),
         Some(ssr_lang_header_getter)
     );

--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -128,7 +128,7 @@ The `I18nContextProvider` component accept multiple props, all optionnal (except
 If you use the `experimental-islands` feature from Leptos the `I18nContextProvider` loose one prop: `cookie_options`, because it is not serializable. If you need it you can use the `init_context_with_options` function and provide the context yourself:
 
 ```rust
-use leptos_i18n::init_context_with_options;
+use leptos_i18n::init_i18n_context_with_options;
 use crate::i18n::*;
 use leptos_meta::Html;
 use leptos::*;
@@ -140,7 +140,13 @@ fn MyI18nProvider(
     children: Children
 ) -> impl IntoView {
     let my_cookie_options = /* create your options here */;
-    let i18n = init_context_with_options::<Locale>(enable_cookie, cookie_name, my_cookie_options);
+    let ssr_lang_header_getter = /* create your options here */;
+    let i18n = init_i18n_context_with_options::<Locale>(
+        Some(enable_cookie),
+        Some(cookie_name),
+        Some(my_cookie_options),
+        Some(ssr_lang_header_getter)
+    );
     provide_context(i18n);
     let lang = move || i18n.get_locale().as_str();
     view! {

--- a/examples/ssr/axum_island/src/app.rs
+++ b/examples/ssr/axum_island/src/app.rs
@@ -9,7 +9,6 @@ pub fn App() -> impl IntoView {
             set_lang_attr_on_html=None
             enable_cookie=None
             cookie_name=None
-            ssr_lang_header_getter=None
         >
             <h1>
                 {ti!(HelloWorld, hello_world)}

--- a/examples/ssr/axum_island/src/app.rs
+++ b/examples/ssr/axum_island/src/app.rs
@@ -9,6 +9,7 @@ pub fn App() -> impl IntoView {
             set_lang_attr_on_html=None
             enable_cookie=None
             cookie_name=None
+            ssr_lang_header_getter=None
         >
             <h1>
                 {ti!(HelloWorld, hello_world)}

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -38,11 +38,9 @@ experimental-islands = [
     "leptos/experimental-islands",
     "leptos_i18n_macro/experimental-islands",
 ]
-
+ssr = ["leptos/ssr", "leptos_meta/ssr", "leptos-use/ssr", "leptos_router/ssr"]
 nightly = ["leptos/nightly", "leptos_i18n_macro/nightly"]
 
-# internal use, should be enabled via "actix" or "axum" feature.
-ssr = ["leptos/ssr", "leptos_meta/ssr", "leptos-use/ssr", "leptos_router/ssr"]
 
 # macro features
 show_keys_only = ["leptos_i18n_macro/show_keys_only"]

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -6,7 +6,7 @@ use leptos::{children, either::Either, prelude::*};
 use leptos_meta::{provide_meta_context, Html};
 use leptos_use::UseCookieOptions;
 use std::borrow::Cow;
-use tachys::{html::directive::IntoDirective, reactive_graph::OwnedView};
+use tachys::{html::directive::IntoDirective, reactive_graph::OwnedView, view::any_view::AnyView};
 
 use crate::{
     fetch_locale::{self, signal_maybe_once_then},
@@ -400,16 +400,9 @@ pub fn i18n_sub_context_provider_island<L: Locale>(
     children: children::Children,
     initial_locale: Option<L>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
-    ssr_lang_header_getter: Option<UseLocalesOptions>,
 ) -> impl IntoView {
     let initial_locale = initial_locale.map(|l| Signal::derive(move || l));
-    let ctx = init_i18n_subcontext_with_options::<L>(
-        initial_locale,
-        cookie_name,
-        cookie_options,
-        ssr_lang_header_getter,
-    );
+    let ctx = init_i18n_subcontext_with_options::<L>(initial_locale, cookie_name, None, None);
     run_as_children(ctx, children)
 }
 
@@ -477,16 +470,14 @@ pub fn provide_i18n_context_component_island<L: Locale>(
     set_lang_attr_on_html: Option<bool>,
     enable_cookie: Option<bool>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
-    ssr_lang_header_getter: Option<UseLocalesOptions>,
     children: children::Children,
 ) -> impl IntoView {
-    provide_i18n_context_component_inner(
+    provide_i18n_context_component_inner::<L, AnyView<Dom>>(
         set_lang_attr_on_html,
         enable_cookie,
         cookie_name,
-        cookie_options,
-        ssr_lang_header_getter,
+        None,
+        None,
         children,
     )
 }

--- a/leptos_i18n/src/fetch_locale.rs
+++ b/leptos_i18n/src/fetch_locale.rs
@@ -1,9 +1,10 @@
 use leptos::prelude::*;
+use leptos_use::UseLocalesOptions;
 
 use crate::Locale;
 
-pub fn fetch_locale<L: Locale>(current_cookie: Option<L>) -> Memo<L> {
-    let accepted_locales = leptos_use::use_locales();
+pub fn fetch_locale<L: Locale>(current_cookie: Option<L>, options: UseLocalesOptions) -> Memo<L> {
+    let accepted_locales = leptos_use::use_locales_with_options(options);
     let accepted_locale =
         Memo::new(move |_| accepted_locales.with(|accepted| L::find_locale(accepted)));
     if cfg!(feature = "ssr") {

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -122,16 +122,12 @@ fn load_locales_inner(
                 enable_cookie: Option<bool>,
                 /// Specify a name for the cookie, default to the library default.
                 cookie_name: Option<Cow<'static, str>>,
-                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
-                ssr_lang_header_getter: Option<UseLocalesOptions>,
                 children: Children
             ) -> impl IntoView {
                 l_i18n_crate::context::provide_i18n_context_component_island::<#enum_ident>(
                     set_lang_attr_on_html,
                     enable_cookie,
                     cookie_name,
-                    None,
-                    ssr_lang_header_getter,
                     children
                 )
             }
@@ -148,14 +144,11 @@ fn load_locales_inner(
                 initial_locale: Option<#enum_ident>,
                 /// If set save the locale in a cookie of the given name (does nothing without the `cookie` feature).
                 cookie_name: Option<Cow<'static, str>>,
-                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
-                ssr_lang_header_getter: Option<UseLocalesOptions>,
             ) -> impl IntoView {
                 l_i18n_crate::context::i18n_sub_context_provider_island::<#enum_ident>(
                     children,
                     initial_locale,
                     cookie_name,
-                    None,
                     ssr_lang_header_getter
                 )
             }

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -122,6 +122,8 @@ fn load_locales_inner(
                 enable_cookie: Option<bool>,
                 /// Specify a name for the cookie, default to the library default.
                 cookie_name: Option<Cow<'static, str>>,
+                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                ssr_lang_header_getter: Option<UseLocalesOptions>,
                 children: Children
             ) -> impl IntoView {
                 l_i18n_crate::context::provide_i18n_context_component_island::<#enum_ident>(
@@ -129,6 +131,7 @@ fn load_locales_inner(
                     enable_cookie,
                     cookie_name,
                     None,
+                    ssr_lang_header_getter,
                     children
                 )
             }
@@ -145,12 +148,15 @@ fn load_locales_inner(
                 initial_locale: Option<#enum_ident>,
                 /// If set save the locale in a cookie of the given name (does nothing without the `cookie` feature).
                 cookie_name: Option<Cow<'static, str>>,
+                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                ssr_lang_header_getter: Option<UseLocalesOptions>,
             ) -> impl IntoView {
                 l_i18n_crate::context::i18n_sub_context_provider_island::<#enum_ident>(
                     children,
                     initial_locale,
                     cookie_name,
-                    None
+                    None,
+                    ssr_lang_header_getter
                 )
             }
         }
@@ -175,6 +181,9 @@ fn load_locales_inner(
                 /// Options for the cookie, see `leptos_use::UseCookieOptions`.
                 #[prop(optional)]
                 cookie_options: Option<CookieOptions<#enum_ident>>,
+                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                #[prop(optional)]
+                ssr_lang_header_getter: Option<UseLocalesOptions>,
                 children: TypedChildren<Chil>
             ) -> impl IntoView {
                 l_i18n_crate::context::provide_i18n_context_component::<#enum_ident, Chil>(
@@ -182,6 +191,7 @@ fn load_locales_inner(
                     enable_cookie,
                     cookie_name,
                     cookie_options,
+                    ssr_lang_header_getter,
                     children
                 )
             }
@@ -203,12 +213,16 @@ fn load_locales_inner(
                 /// Options for the cookie, see `leptos_use::UseCookieOptions`.
                 #[prop(optional)]
                 cookie_options: Option<CookieOptions<#enum_ident>>,
+                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                #[prop(optional)]
+                ssr_lang_header_getter: Option<UseLocalesOptions>,
             ) -> impl IntoView {
                 l_i18n_crate::context::i18n_sub_context_provider_inner::<#enum_ident, Chil>(
                     children,
                     initial_locale,
                     cookie_name,
-                    cookie_options
+                    cookie_options,
+                    ssr_lang_header_getter
                 )
             }
         }
@@ -237,7 +251,7 @@ fn load_locales_inner(
             )]
             #[track_caller]
             pub fn provide_i18n_context() -> l_i18n_crate::I18nContext<#enum_ident> {
-                l_i18n_crate::context::provide_i18n_context_with_options_inner(None, None, None)
+                l_i18n_crate::context::provide_i18n_context_with_options_inner(None, None, None, None)
             }
 
             mod providers {
@@ -245,7 +259,7 @@ fn load_locales_inner(
                 use l_i18n_crate::reexports::leptos;
                 use leptos::prelude::{IntoView, Signal};
                 use std::borrow::Cow;
-                use l_i18n_crate::context::CookieOptions;
+                use l_i18n_crate::context::{CookieOptions, UseLocalesOptions};
 
                 #providers
             }

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -149,7 +149,6 @@ fn load_locales_inner(
                     children,
                     initial_locale,
                     cookie_name,
-                    ssr_lang_header_getter
                 )
             }
         }


### PR DESCRIPTION
Give options for custom header accessor. It was already the case for cookies, now also for `Accept-Languages` header.