### PR TITLE
Allow use of ssr and hydrate cfg together without compile error

### DIFF
--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -409,7 +409,7 @@ pub fn use_i18n_context<L: Locale>() -> I18nContext<L> {
 }
 
 #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
-fn embed_translations<L: Locale>(
+fn embed_translations_fn<L: Locale>(
     reg_ctx: crate::fetch_translations::RegisterCtx<L>,
 ) -> impl IntoView {
     let translations = reg_ctx.to_array();
@@ -446,7 +446,7 @@ fn provide_i18n_context_component_inner<L: Locale, Chil: IntoView>(
     ssr_lang_header_getter: Option<UseLocalesOptions>,
     children: impl FnOnce() -> Chil,
 ) -> impl IntoView {
-    #[cfg(all(feature = "dynamic_load", feature = "hydrate"))]
+    #[cfg(all(feature = "dynamic_load", feature = "hydrate", not(feature = "ssr")))]
     let embed_translations = crate::fetch_translations::init_translations::<L>();
     #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
     let reg_ctx = crate::fetch_translations::RegisterCtx::<L>::provide_context();
@@ -460,7 +460,7 @@ fn provide_i18n_context_component_inner<L: Locale, Chil: IntoView>(
     let i18n = provide_i18n_context_with_options_inner(options);
     let children = children();
     #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
-    let embed_translations = move || embed_translations(reg_ctx.clone());
+    let embed_translations = move || embed_translations_fn(reg_ctx.clone());
     #[cfg(not(all(feature = "dynamic_load", any(feature = "ssr", feature = "hydrate"))))]
     let embed_translations = view! { <script /> };
     if set_lang_attr_on_html.unwrap_or(true) {

--- a/leptos_i18n/src/fetch_translations.rs
+++ b/leptos_i18n/src/fetch_translations.rs
@@ -31,7 +31,7 @@ pub trait TranslationUnit: Sized {
         async move { core::ops::Deref::deref(fut.await) }
     }
 
-    #[cfg(all(feature = "dynamic_load", feature = "hydrate"))]
+    #[cfg(all(feature = "dynamic_load", feature = "hydrate", not(feature = "ssr")))]
     fn init_translations(values: Vec<Box<str>>) {
         let string_lock = Self::get_strings_lock();
         let fut = string_lock.get_or_init(async { StringArray::cast(values) });


### PR DESCRIPTION
Due to some cfg, there was some implementation conflicts when enabling the `ssr` and `hydrate` feature together, this is'nt really a problem as one should'nt do that anyway, but some people enable them both during dev for LSPs. Enabling them both will spit out non-working stuff but will compile without error, panicking at runtime if anyway tries to actually run it.