### PR TITLE
Add `'static` bound to interpolation generics

### DIFF
--- a/leptos_i18n/src/macro_helpers/interpol_args.rs
+++ b/leptos_i18n/src/macro_helpers/interpol_args.rs
@@ -6,13 +6,13 @@ pub trait InterpolateVar: IntoView + Clone + 'static + Send + Sync {}
 impl<T: IntoView + Clone + 'static + Send + Sync> InterpolateVar for T {}
 
 /// Marker trait for a type that can be used as an interpolation component.
-pub trait InterpolateComp<O: IntoView + Clone>:
+pub trait InterpolateComp<O: IntoView + Clone + 'static>:
     Fn(leptos::children::ChildrenFn) -> O + Clone + 'static + Send + Sync
 {
 }
 
 impl<
-        O: IntoView + Clone,
+        O: IntoView + Clone + 'static,
         T: Fn(leptos::children::ChildrenFn) -> O + Clone + 'static + Send + Sync,
     > InterpolateComp<O> for T
 {

--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -135,7 +135,7 @@ impl Field {
             VarOrComp::Comp { into_view } => {
                 let ts = [
                     quote!(#generic: l_i18n_crate::__private::InterpolateComp<#into_view>),
-                    quote!(#into_view: l_i18n_crate::reexports::leptos::IntoView + Clone),
+                    quote!(#into_view: l_i18n_crate::reexports::leptos::IntoView + Clone + 'static),
                 ];
                 EitherIter::Iter2(ts.into_iter())
             }
@@ -682,7 +682,7 @@ impl Interpolation {
             return quote! {
                 #[allow(non_camel_case_types)]
                 impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
-                    pub fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone {
+                    pub fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone + 'static {
                         let _ = self;
                         #key
                     }
@@ -699,7 +699,7 @@ impl Interpolation {
             quote! {
                 #[allow(non_camel_case_types)]
                 impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
-                    pub async fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone {
+                    pub async fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone + 'static {
                         #destructure
                         match #locale_field {
                             #(
@@ -713,7 +713,7 @@ impl Interpolation {
             quote! {
                 #[allow(non_camel_case_types)]
                 impl<#(#left_generics,)*> #ident<#(#right_generics,)*> {
-                    pub fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone {
+                    pub fn into_view(self) -> impl l_i18n_crate::reexports::leptos::IntoView + Clone + 'static {
                         #destructure
                         match #locale_field {
                             #(


### PR DESCRIPTION
Due to the update of the `IntoView` trait, the bound `'static` is'nt part of it now and it was forgotten to add the bound during the update, causing errors for nested interpolated components. Fix #177 