### PR TITLE
fix: make routing component transparent

### DIFF
--- a/leptos_i18n_router/src/components.rs
+++ b/leptos_i18n_router/src/components.rs
@@ -4,7 +4,7 @@ use leptos::component;
 use leptos_i18n::Locale;
 use leptos_router::{components::RouteChildren, ChooseView, MatchNestedRoutes, SsrMode};
 
-#[component]
+#[component(transparent)]
 pub fn I18nRoute<L, View, Chil>(
     /// The base path of this application.
     /// If you setup your i18n route such that the path is `/foo/:locale/bar`,


### PR DESCRIPTION
Routing components need to be transparent. It also supports compiling with erase_components cfg flag.