### PR TITLE
fixed string duplication for defaulted values

### DIFF
--- a/leptos_i18n_build/src/datakey.rs
+++ b/leptos_i18n_build/src/datakey.rs
@@ -25,8 +25,15 @@ pub fn find_used_datakey(keys: &BuildersKeysInner, used_icu_keys: &mut HashSet<O
     for locale_value in keys.0.values() {
         match locale_value {
             LocaleValue::Subkeys { keys, .. } => find_used_datakey(keys, used_icu_keys),
-            LocaleValue::Value(InterpolOrLit::Lit(_)) => {} // skip literals
-            LocaleValue::Value(InterpolOrLit::Interpol(interpolation_keys)) => {
+            LocaleValue::Value {
+                // skip literals
+                value: InterpolOrLit::Lit(_),
+                ..
+            } => {}
+            LocaleValue::Value {
+                value: InterpolOrLit::Interpol(interpolation_keys),
+                ..
+            } => {
                 for (_, var_infos) in interpolation_keys.iter_vars() {
                     if matches!(var_infos.range_count, Some(RangeOrPlural::Plural)) {
                         used_icu_keys.insert(Options::Plurals);

--- a/leptos_i18n_macro/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_macro/src/load_locales/parsed_value.rs
@@ -75,7 +75,8 @@ fn flatten(
     strings_count: usize,
 ) {
     match this {
-        ParsedValue::Subkeys(_) | ParsedValue::Default => {}
+        ParsedValue::Default => unreachable!("defaulted value should never have been rendered"),
+        ParsedValue::Subkeys(_) => unreachable!("subkeys should never have been rendered"),
         ParsedValue::Literal(lit) => tokens.push(Literal::from(lit).to_token_stream(strings_count)),
         ParsedValue::Ranges(ranges) => tokens.push(ranges::to_token_stream(ranges, strings_count)),
         ParsedValue::Variable { key, formatter } => {
@@ -130,7 +131,8 @@ fn flatten_string(
     strings_count: usize,
 ) {
     match this {
-        ParsedValue::Subkeys(_) | ParsedValue::Default => {}
+        ParsedValue::Default => unreachable!("defaulted value should never have been rendered"),
+        ParsedValue::Subkeys(_) => unreachable!("subkeys should never have been rendered"),
         ParsedValue::Literal(lit) => {
             let ts = Literal::from(lit).to_token_stream(strings_count);
             tokens.push(quote!(core::fmt::Display::fmt(&#ts, __formatter)))

--- a/leptos_i18n_parser/src/parse_locales/mod.rs
+++ b/leptos_i18n_parser/src/parse_locales/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use cfg_file::ConfigFile;
-use locale::{BuildersKeys, BuildersKeysInner, Locale, LocalesOrNamespaces};
+use locale::{BuildersKeys, BuildersKeysInner, DefaultTo, Locale, LocalesOrNamespaces};
 
 pub mod cfg_file;
 pub mod error;
@@ -165,8 +165,8 @@ fn check_locales_inner(
         let mut string_indexer = StringIndexer::default();
         locale.merge(
             &mut default_keys,
-            default_locale,
             top_locale,
+            DefaultTo::Implicit(&default_locale.top_locale_name),
             &mut key_path,
             &mut string_indexer,
             warnings,

--- a/leptos_i18n_parser/src/utils/mod.rs
+++ b/leptos_i18n_parser/src/utils/mod.rs
@@ -17,6 +17,7 @@ pub trait UnwrapAt {
 impl<T> UnwrapAt for Option<T> {
     type Value = T;
 
+    #[track_caller]
     fn unwrap_at(self, location: &str) -> Self::Value {
         let msg = format!("Unexpected None value at {}. If you got this error please open an issue on the leptos_i18n github repo.", location);
         self.expect(&msg)
@@ -26,6 +27,7 @@ impl<T> UnwrapAt for Option<T> {
 impl<T, E: Debug> UnwrapAt for Result<T, E> {
     type Value = T;
 
+    #[track_caller]
     fn unwrap_at(self, location: &str) -> Self::Value {
         let msg = format!("Unexpected Err value at {}. If you got this error please open an issue on the leptos_i18n github repo.", location);
         self.expect(&msg)


### PR DESCRIPTION
When a key was missing the value was defaulted to the default locale, but the process was to simply clone the value.
This worked perfectly but introduce some duplicates strings, now the value is not cloned anymore but marked to be defaulted to another locale, this basically change

```rust
match locale {
    Locale::en => "some string",
    Locale::fr =>  "some string", // <- duplicated string
}
```
to 
```rust
match locale {
    Locale::en | Locale::fr => "some string",
}
```