### PR TITLE
Allow recursive defaults

### DIFF
--- a/leptos_i18n_macro/src/load_locales/interpolate.rs
+++ b/leptos_i18n_macro/src/load_locales/interpolate.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
+use leptos_i18n_parser::parse_locales::locale::DefaultedLocales;
 use leptos_i18n_parser::parse_locales::locale::InterpolationKeys;
 use leptos_i18n_parser::parse_locales::locale::Locale;
 use leptos_i18n_parser::parse_locales::parsed_value::ParsedValue;
@@ -251,7 +252,7 @@ impl Interpolation {
         key_path: &KeyPath,
         locale_type_ident: &syn::Ident,
         interpolate_display: bool,
-        defaults: &BTreeMap<Key, BTreeSet<Key>>,
+        defaults: &DefaultedLocales,
     ) -> Self {
         // filter defaulted locales
         let locales = locales
@@ -275,6 +276,8 @@ impl Interpolation {
 
         let typed_builder_name = format_ident!("{}Builder", ident);
         let display_struct_ident = format_ident!("{}Display", ident);
+
+        let computed_defaults = defaults.compute();
 
         let fields = Self::make_fields(keys);
 
@@ -307,7 +310,7 @@ impl Interpolation {
             &locales,
             key_path,
             locale_type_ident,
-            defaults,
+            &computed_defaults,
         );
 
         let debug_impl = Self::debug_impl(&builder_name, &ident, &fields);
@@ -322,7 +325,7 @@ impl Interpolation {
                 &fields,
                 &locales,
                 locale_type_ident,
-                defaults,
+                &computed_defaults,
             );
             let builder_display = Self::builder_string_build_fns(
                 enum_ident,

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -600,6 +600,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     let literal_accessors = literal_keys
         .iter()
         .map(|(key, literal_type, defaults)| {
+            let computed_defaults= defaults.compute();
             if cfg!(feature = "show_keys_only") {
                 let key_str = key_path.to_string_with_key(key);
                 if cfg!(all(feature = "dynamic_load", not(feature = "ssr"))) {
@@ -635,7 +636,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
                     }
                     let ident = &locale.top_locale_name;
                     let accessor = strings_accessor_method_name(locale);
-                    let defaulted = defaults.get(&locale.top_locale_name).map(|defaulted_locales| {
+                    let defaulted = computed_defaults.get(&locale.top_locale_name).map(|defaulted_locales| {
                         defaulted_locales.iter().map(|key| {
                             quote!(| #enum_ident::#key)
                         }).collect::<TokenStream>()

--- a/leptos_i18n_parser/src/parse_locales/parsed_value.rs
+++ b/leptos_i18n_parser/src/parse_locales/parsed_value.rs
@@ -10,8 +10,8 @@ use crate::utils::{formatter::Formatter, Key, KeyPath, UnwrapAt};
 use super::{
     error::{Error, Result},
     locale::{
-        DefaultTo, InterpolOrLit, InterpolationKeys, LiteralType, Locale, LocaleSeed, LocaleValue,
-        LocalesOrNamespaces, RangeOrPlural,
+        DefaultTo, DefaultedLocales, InterpolOrLit, InterpolationKeys, LiteralType, Locale,
+        LocaleSeed, LocaleValue, LocalesOrNamespaces, RangeOrPlural,
     },
     plurals::Plurals,
     ranges::Ranges,
@@ -604,10 +604,7 @@ impl ParsedValue {
                 Ok(())
             }
             (ParsedValue::Default, LocaleValue::Value { defaults, .. }) => {
-                defaults
-                    .entry(default_to.get_key())
-                    .or_default()
-                    .insert(top_locale);
+                defaults.push(top_locale, default_to.get_key());
                 Ok(())
             }
             // Both subkeys
@@ -752,6 +749,7 @@ impl ParsedValue {
 
     pub fn make_locale_value(
         &mut self,
+        default_locale: &Key,
         key_path: &mut KeyPath,
         strings: &mut StringIndexer,
     ) -> Result<LocaleValue> {
@@ -771,7 +769,7 @@ impl ParsedValue {
                 this.index_strings(strings);
                 this.get_keys(key_path).map(|value| LocaleValue::Value {
                     value,
-                    defaults: Default::default(),
+                    defaults: DefaultedLocales::new(default_locale.clone()),
                 })
             }
         }


### PR DESCRIPTION
allow recursive defaults and detect cycles, if a cycle is encountered use the default locale.
This has no effect for now as the only default is the default locale, but needed for some later features