### PR TITLE
Allow to configure locales inheritance

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Configuration](./setting_up/01_configuration.md)
   - [File structure](./setting_up/02_file_structure.md)
   - [Namespaces](./setting_up/03_namespaces.md)
+  - [Inheritance](./setting_up/04_inheritance.md)
 - [Declare Translations](./declare/README.md)
   - [Key-Value Pairs](./declare/01_key_value.md)
   - [Interpolation](./declare/02_interpolation.md)

--- a/docs/book/src/setting_up/01_configuration.md
+++ b/docs/book/src/setting_up/01_configuration.md
@@ -13,9 +13,11 @@ default = "en"
 locales = ["en", "fr"]
 ```
 
-There are 2 more optional values you can supply:
+There are more optional values you can supply:
 
 - `namespaces`: This is to split your translations into multiple files, we will cover it in a later chapter
 - `locales-dir`: This is to have a custom path to the directory containing the locales files, it defaults to `"./locales"`.
+- `translations-path`: Used in a CSR application with the `dynamic_load` feature, more information in a later chapter.
+- `inherits`: Allow to describe inheritance structure for locales, covered in a later chapter.
 
 Once this configuration is done, you can start writing your translations.

--- a/docs/book/src/setting_up/04_inheritance.md
+++ b/docs/book/src/setting_up/04_inheritance.md
@@ -1,0 +1,55 @@
+# Extanding a locale
+
+The `inherits` config options under the `[package.metadata.leptos-i18n]` can allow you to describe inheritance hierarchy for your locales:
+
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr", "fr-CA"]
+inherits = { fr-CA = "fr" }
+```
+
+This will default any missing keys in "fr-CA" to the value in "fr".
+
+The "general" default for missing keys will still be the default locale, so if a key is missing in both "fr" and "fr-CA", the key will use the value in "en".
+
+## Recursive inheritance
+
+You can have recursive inheritances, this is allowed and works as expected:
+
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr", "fr-CA", "fr-FR"]
+inherits = { fr-CA = "fr-FR", fr-FR = "fr" }
+```
+
+> note: cyclic inheritance is also valid but I don't see the use, it's only supported because if we didn't detected cycles we could have an endless loop when resolving what default to use, if a cycle is encountered on a missing key the default locale is used.
+
+## Missing key warnings
+
+if locale A extend locale B, missing key warnings will not be emitted for locale A.
+
+Explicitly setting the inheritance to the default locale is also a way to suppress missing key warnings for a given locale:
+
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr", "it"]
+inherits = { it = "en" }
+```
+
+While the above is technically already the default behavior, missing warnings will not be emitted for the "it" locale, but will be emitted for the "fr" locale.
+
+## Extends the default locale
+
+The default locale can not inherit.
+
+This is not allowed and will error:
+
+```toml
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en", "fr"]
+inherits = { en = "fr" }
+```

--- a/leptos_i18n_macro/src/load_locales/declare_locales.rs
+++ b/leptos_i18n_macro/src/load_locales/declare_locales.rs
@@ -419,6 +419,7 @@ impl syn::parse::Parse for ParsedInput {
                 name_spaces: None,
                 locales_dir: "".into(),
                 translations_uri: None,
+                extensions: Default::default(),
             },
             locales: LocalesOrNamespaces::Locales(locales),
             crate_path,

--- a/leptos_i18n_parser/src/parse_locales/locale.rs
+++ b/leptos_i18n_parser/src/parse_locales/locale.rs
@@ -671,15 +671,17 @@ impl Locale {
             key_path.pop_key();
         }
 
-        // reverse key comparaison
-        for key in self.keys.keys() {
-            if !keys.0.contains_key(key) {
-                key_path.push_key(key.clone());
-                warnings.emit_warning(Warning::SurplusKey {
-                    locale: top_locale.clone(),
-                    key_path: key_path.clone(),
-                });
-                key_path.pop_key();
+        if !cfg!(feature = "suppress_key_warnings") {
+            // reverse key comparaison
+            for key in self.keys.keys() {
+                if !keys.0.contains_key(key) {
+                    key_path.push_key(key.clone());
+                    warnings.emit_warning(Warning::SurplusKey {
+                        locale: top_locale.clone(),
+                        key_path: key_path.clone(),
+                    });
+                    key_path.pop_key();
+                }
             }
         }
 

--- a/leptos_i18n_parser/src/parse_locales/mod.rs
+++ b/leptos_i18n_parser/src/parse_locales/mod.rs
@@ -91,7 +91,7 @@ pub fn make_builder_keys(
 
     resolve_foreign_keys(&locales, &cfg_file.default, foreign_keys_paths.into_inner())?;
 
-    check_locales(locales, warnings)
+    check_locales(locales, &cfg_file.extensions, warnings)
 }
 
 pub fn parse_locales(
@@ -126,7 +126,11 @@ fn resolve_foreign_keys(
     Ok(())
 }
 
-fn check_locales(locales: LocalesOrNamespaces, warnings: &Warnings) -> Result<BuildersKeys> {
+fn check_locales(
+    locales: LocalesOrNamespaces,
+    extensions: &BTreeMap<Key, Key>,
+    warnings: &Warnings,
+) -> Result<BuildersKeys> {
     match locales {
         LocalesOrNamespaces::NameSpaces(mut namespaces) => {
             let mut keys = BTreeMap::new();
@@ -134,6 +138,7 @@ fn check_locales(locales: LocalesOrNamespaces, warnings: &Warnings) -> Result<Bu
                 let k = check_locales_inner(
                     &mut namespace.locales,
                     Some(namespace.key.clone()),
+                    extensions,
                     warnings,
                 )?;
                 keys.insert(namespace.key.clone(), k);
@@ -141,7 +146,7 @@ fn check_locales(locales: LocalesOrNamespaces, warnings: &Warnings) -> Result<Bu
             Ok(BuildersKeys::NameSpaces { namespaces, keys })
         }
         LocalesOrNamespaces::Locales(mut locales) => {
-            let keys = check_locales_inner(&mut locales, None, warnings)?;
+            let keys = check_locales_inner(&mut locales, None, extensions, warnings)?;
             Ok(BuildersKeys::Locales { locales, keys })
         }
     }
@@ -150,6 +155,7 @@ fn check_locales(locales: LocalesOrNamespaces, warnings: &Warnings) -> Result<Bu
 fn check_locales_inner(
     locales: &mut [Locale],
     namespace: Option<Key>,
+    extensions: &BTreeMap<Key, Key>,
     warnings: &Warnings,
 ) -> Result<BuildersKeysInner> {
     let mut locales_iter = locales.iter_mut();
@@ -164,10 +170,16 @@ fn check_locales_inner(
     for locale in locales_iter {
         let top_locale = locale.name.clone();
         let mut string_indexer = StringIndexer::default();
+
+        let default_to = match extensions.get(&top_locale) {
+            Some(default_to) => DefaultTo::Explicit(default_to),
+            None => DefaultTo::Implicit(&default_locale.top_locale_name),
+        };
+
         locale.merge(
             &mut default_keys,
             top_locale,
-            DefaultTo::Implicit(&default_locale.top_locale_name),
+            default_to,
             &mut key_path,
             &mut string_indexer,
             warnings,

--- a/leptos_i18n_parser/src/parse_locales/mod.rs
+++ b/leptos_i18n_parser/src/parse_locales/mod.rs
@@ -173,7 +173,13 @@ fn check_locales_inner(
 
         let default_to = match extensions.get(&top_locale) {
             Some(default_to) => DefaultTo::Explicit(default_to),
-            None => DefaultTo::Implicit(&default_locale.top_locale_name),
+            None => {
+                if cfg!(feature = "suppress_key_warnings") {
+                    DefaultTo::Explicit(&default_locale.top_locale_name)
+                } else {
+                    DefaultTo::Implicit(&default_locale.top_locale_name)
+                }
+            }
         };
 
         locale.merge(

--- a/leptos_i18n_parser/src/parse_locales/warning.rs
+++ b/leptos_i18n_parser/src/parse_locales/warning.rs
@@ -35,13 +35,6 @@ impl Warnings {
     }
 
     pub fn emit_warning(&self, warning: Warning) {
-        if matches!(
-            warning,
-            Warning::MissingKey { .. } | Warning::SurplusKey { .. }
-        ) && cfg!(feature = "suppress_key_warnings")
-        {
-            return;
-        }
         self.0.borrow_mut().push(warning);
     }
 


### PR DESCRIPTION
Allow to specify an inheritance for a locale:

```toml
[package.metadata.leptos-i18n]
default = "en"
locales = ["en", "fr", "fr-CA"]
inherits = { fr-CA = "fr" }
```

This will default any missing keys in "fr-CA" to the value in "fr".

The "general" default for missing keys will still be the default locale, so if a key is missing in both "fr" and "fr-CA", the key will use the value in "en".

## Recursive inheritance

You can have recursive inheritances, this is allowed and works as expected:

```toml
[package.metadata.leptos-i18n]
default = "en"
locales = ["en", "fr", "fr-CA", "fr-FR"]
inherits = { fr-CA = "fr-FR", fr-FR = "fr" }
```

> note: cyclic inheritance is also valid but I don't see the use, it's only supported because if we didn't detected cycles we could have an endless loop when resolving what default to use, if a cycle is encountered on a missing key the default locale is used.

## Missing key warnings

if locale A extend locale B, missing key warnings will not be emitted for locale A.

Explicitly setting the inheritance to the default locale is also a way to suppress missing key warnings for a given locale:

```toml
[package.metadata.leptos-i18n]
default = "en"
locales = ["en", "fr", "it"]
inherits = { it = "en" }
```

While the above is technically already the default behavior, missing warnings will not be emitted for the "it" locale, but will be emitted for the "fr" locale.

## Extends the default locale

The default locale can not inherit.

related discussion: #202 
