### PR TITLE
bumped dependency versions to resolve codee 0.2/0.3 version conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ leptos_i18n = { path = "./leptos_i18n", default-features = false, version = "0.5
 leptos_i18n_router = { path = "./leptos_i18n_router", version = "0.5.10" }
 
 # leptos
-leptos = { version = "0.7.0", default-features = false }
-leptos_router = { version = "0.7.0", default-features = false }
-leptos_meta = { version = "0.7.0", default-features = false }
+leptos = { version = "0.7.7", default-features = false }
+leptos_router = { version = "0.7.7", default-features = false }
+leptos_meta = { version = "0.7.7", default-features = false }
 
 # icu
 icu_locid = { version = "1.5", default-features = false }

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -11,14 +11,14 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos-use = { version = "0.15.0", default-features = false, features = [
+leptos-use = { version = "0.15.7", default-features = false, features = [
   "use_locales",
   "use_cookie",
 ] }
 leptos_i18n_macro = { workspace = true }
 leptos = { workspace = true }
 leptos_meta = { workspace = true }
-codee = "0.2"
+codee = "0.3"
 icu_locid = { workspace = true }
 icu_provider = { workspace = true, optional = true, features = [
   "sync",


### PR DESCRIPTION
Both the latest Leptos 0.7 and Leptos-Use 0.15 use codee 0.3