### PR TITLE
fallback to base lang if exist

### DIFF
--- a/leptos_i18n_parser/src/parse_locales/locale.rs
+++ b/leptos_i18n_parser/src/parse_locales/locale.rs
@@ -194,16 +194,16 @@ pub struct LocaleSeed<'a> {
     pub errors: &'a Errors,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum DefaultTo<'a> {
-    Explicit(&'a Key),
-    Implicit(&'a Key),
+#[derive(Debug, Clone)]
+pub enum DefaultTo {
+    Explicit(Key),
+    Implicit(Key),
 }
 
-impl DefaultTo<'_> {
-    pub fn get_key(self) -> Key {
+impl DefaultTo {
+    pub fn get_key(&self) -> &Key {
         match self {
-            DefaultTo::Explicit(key) | DefaultTo::Implicit(key) => key.clone(),
+            DefaultTo::Explicit(key) | DefaultTo::Implicit(key) => key,
         }
     }
 }
@@ -619,7 +619,7 @@ impl Locale {
         &mut self,
         keys: &mut BuildersKeysInner,
         top_locale: Key,
-        default_to: DefaultTo,
+        default_to: &DefaultTo,
         key_path: &mut KeyPath,
         strings: &mut StringIndexer,
         warnings: &Warnings,

--- a/leptos_i18n_parser/src/parse_locales/parsed_value.rs
+++ b/leptos_i18n_parser/src/parse_locales/parsed_value.rs
@@ -649,7 +649,7 @@ impl ParsedValue {
         &mut self,
         keys: &mut LocaleValue,
         top_locale: Key,
-        default_to: DefaultTo,
+        default_to: &DefaultTo,
         key_path: &mut KeyPath,
         strings: &mut StringIndexer,
         warnings: &Warnings,
@@ -681,7 +681,7 @@ impl ParsedValue {
                 Ok(())
             }
             (ParsedValue::Default, LocaleValue::Value { defaults, .. }) => {
-                defaults.push(top_locale, default_to.get_key());
+                defaults.push(top_locale, default_to.get_key().clone());
                 Ok(())
             }
             // Both subkeys


### PR DESCRIPTION
Change the default behavior of locale inheritances, previously all locales fallback to the default locale, this PR changes that such that it first tries to find the base locale, such that `fr-CA`  will inherits by default from `fr`.
This is treated ***exactly*** as if we would have explicitly wrote `inherits = { fr-CA = "fr" }`.
The fallback locale resolution is pretty dumb, it just look at the base language and tries to find another locale that is *just* the base language.