### PR TITLE
fix: re-arrange workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,54 +17,28 @@ jobs:
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
-      - name: "Load cargo toolchain"
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          targets: wasm32-unknown-unknown
+          components: clippy,rustfmt
       - name: "Install cargo-all-features"
-        run: cargo install cargo-all-features --locked
-      - name: "Install clippy"
-        run: rustup component add clippy
+        run: cargo install --git https://github.com/sabify/cargo-all-features --branch arbitrary-command-support
       - name: "Run clippy"
-        run: cargo clippy --package leptos_i18n
+        run: cargo all-features clippy
       - name: "Test all features"
         working-directory: "leptos_i18n"
-        run: cargo test-all-features
-  subcrates_test:
-    # Why not also use cargo-all-features with the parser and macros packages ?
-    # Because all features are forwarded from leptos_i18n,
-    # so if some features mix creates a problem they will appear in leptos_i18n tests.
-    # All leptos_i18n_macro tests don't require any feature flag, so no need to test each feature and matchup
-    # just run once with default, this speeds up CI
-    name: Test ${{ matrix.packages }} package
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        packages: [leptos_i18n_macro, leptos_i18n_parser, leptos_i18n_build, leptos_i18n_codegen]
-    steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
-      - name: "Load cargo toolchain"
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: "clippy"
-      - name: "Run tests"
-        run: cargo test --package ${{ matrix.packages }}
-      - name: "Run clippy"
-        run: cargo clippy --package ${{ matrix.packages }}
+        run: cargo all-features test
+      - name: Check format
+        run: cargo fmt --check
   test_ssr_examples:
     name: Test ${{ matrix.examples }} SSR example
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        examples:
-          [
-            hello_world_actix,
-            hello_world_axum,
-            workspace,
-            axum_island,
-            routing_ssr,
-          ]
+        examples: [hello_world_actix, hello_world_axum, workspace, axum_island, routing_ssr]
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -199,19 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        examples:
-          [
-            counter,
-            counter_icu_datagen,
-            counter_plurals,
-            counter_ranges,
-            interpolation,
-            namespaces,
-            subkeys,
-            yaml,
-            routing_csr,
-            subcontext,
-          ]
+        examples: [counter, counter_icu_datagen, counter_plurals, counter_ranges, interpolation, namespaces, subkeys, yaml, routing_csr, subcontext]
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -258,10 +220,11 @@ jobs:
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
-      - name: "Install wasm32-unknown-unknown"
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "stable"
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - name: Running test suite ${{ matrix.tests_suites }}
         working-directory: tests/${{ matrix.tests_suites }}
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,41 +1,14 @@
 [workspace]
 resolver = "2"
 members = [
-  # libs
   "leptos_i18n",
   "leptos_i18n_macro",
   "leptos_i18n_parser",
   "leptos_i18n_build",
   "leptos_i18n_codegen",
   "leptos_i18n_router",
-  # tests
-  "tests/json",
-  "tests/yaml",
-  "tests/json5",
-  "tests/common",
-  "tests/namespaces",
-  # CSR examples
-  "examples/csr/counter",
-  "examples/csr/counter_icu_datagen",
-  "examples/csr/counter_plurals",
-  "examples/csr/counter_ranges",
-  "examples/csr/interpolation",
-  "examples/csr/namespaces",
-  "examples/csr/routing_csr",
-  "examples/csr/subcontext",
-  "examples/csr/subkeys",
-  "examples/csr/yaml",
-  # SSR examples
-  # "examples/ssr/axum_island", # skip to not enable "island" for whole workspace
-  # "examples/ssr/workspace", # can't have workspace be a member of a workspace
-  # "examples/ssr/hello_world_actix" # skip to not enable conflicting "axum" and "actix" features
-  "examples/ssr/hello_world_axum",
-  "examples/ssr/routing_ssr",
-  # Dynamic load examples
-  # Dyn load are skipped to not enable "dynamic_load" globaly.
-
 ]
-exclude = ["examples"]
+exclude = ["examples", "tests"]
 
 [workspace.package]
 version = "0.6.0-rc.2"
@@ -45,10 +18,9 @@ version = "0.6.0-rc.2"
 leptos_i18n_macro = { path = "./leptos_i18n_macro", default-features = false, version = "=0.6.0-rc.2" }
 leptos_i18n_parser = { path = "./leptos_i18n_parser", default-features = false, version = "=0.6.0-rc.2" }
 leptos_i18n_codegen = { path = "./leptos_i18n_codegen", default-features = false, version = "=0.6.0-rc.2" }
-
-leptos_i18n = { path = "./leptos_i18n", version = "0.6.0-rc.2" }
-leptos_i18n_router = { path = "./leptos_i18n_router", version = "0.6.0-rc.2" }
-leptos_i18n_build = { path = "./leptos_i18n_build", version = "0.6.0-rc.2" }
+leptos_i18n = { path = "./leptos_i18n", version = "0.6.0-rc.2", default-features = false }
+leptos_i18n_router = { path = "./leptos_i18n_router", version = "0.6.0-rc.2", default-features = false }
+leptos_i18n_build = { path = "./leptos_i18n_build", version = "0.6.0-rc.2", default-features = false }
 
 # leptos
 leptos = { version = "0.8.2", default-features = false }
@@ -71,4 +43,4 @@ icu_experimental = { version = "0.3.0", default-features = false }
 tinystr = "0.8.1"
 
 # internal use
-tests_common = { path = "./tests/common", version = "0.1.0" }
+# tests_common = { path = "./tests/common", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,3 @@ icu_list = { version = "2.0.0", default-features = false }
 icu_decimal = { version = "2.0.0", default-features = false }
 icu_experimental = { version = "0.3.0", default-features = false }
 tinystr = "0.8.1"
-
-# internal use
-# tests_common = { path = "./tests/common", version = "0.1.0" }

--- a/examples/csr/counter/Cargo.toml
+++ b/examples/csr/counter/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -18,5 +18,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/counter_icu_datagen/Cargo.toml
+++ b/examples/csr/counter_icu_datagen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, default-features = false, features = [
+leptos_i18n = { path = "../../../leptos_i18n", default-features = false, features = [
   "csr",
   "plurals",
   "format_nums",
@@ -36,7 +36,7 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]
 
 [profile.release]

--- a/examples/csr/counter_plurals/Cargo.toml
+++ b/examples/csr/counter_plurals/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr", "plurals"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr", "plurals"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -16,7 +16,7 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]
 
 [profile.release]

--- a/examples/csr/counter_ranges/Cargo.toml
+++ b/examples/csr/counter_ranges/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -16,5 +16,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/interpolation/Cargo.toml
+++ b/examples/csr/interpolation/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -18,5 +18,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/namespaces/Cargo.toml
+++ b/examples/csr/namespaces/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -19,5 +19,5 @@ locales = ["en", "fr"]
 namespaces = ["change_locale", "counter"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/routing_csr/Cargo.toml
+++ b/examples/csr/routing_csr/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
-leptos_i18n_router = { workspace = true }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
+leptos_i18n_router = { path = "../../../leptos_i18n_router" }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -21,5 +21,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/subcontext/Cargo.toml
+++ b/examples/csr/subcontext/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -18,5 +18,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/subkeys/Cargo.toml
+++ b/examples/csr/subkeys/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -18,5 +18,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/csr/yaml/Cargo.toml
+++ b/examples/csr/yaml/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 leptos = { version = "0.8.2", features = ["csr"] }
 leptos_meta = { version = "0.8.2" }
-leptos_i18n = { workspace = true, features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1" }
 wasm-bindgen = { version = "0.2" }
@@ -18,5 +18,5 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print", "csr"]

--- a/examples/ssr/hello_world_axum/Cargo.toml
+++ b/examples/ssr/hello_world_axum/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.8", optional = true }
 leptos = { version = "0.8.2" }
 leptos_meta = { version = "0.8.2" }
 leptos_axum = { version = "0.8.2", optional = true }
-leptos_i18n = { workspace = true }
+leptos_i18n = { path = "../../../leptos_i18n" }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = "0.2"
@@ -48,7 +48,7 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print"]
 
 [package.metadata.leptos]

--- a/examples/ssr/routing_ssr/Cargo.toml
+++ b/examples/ssr/routing_ssr/Cargo.toml
@@ -14,8 +14,8 @@ leptos = { version = "0.8.2" }
 leptos_meta = { version = "0.8.2" }
 leptos_axum = { version = "0.8.2", optional = true }
 leptos_router = { version = "0.8.2" }
-leptos_i18n = { workspace = true }
-leptos_i18n_router = { workspace = true }
+leptos_i18n = { path = "../../../leptos_i18n" }
+leptos_i18n_router = { path = "../../../leptos_i18n_router" }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = "0.2"
@@ -52,7 +52,7 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies.leptos_i18n_build]
-workspace = true
+path = "../../../leptos_i18n_build"
 features = ["pretty_print"]
 
 [package.metadata.leptos]

--- a/examples/ssr/workspace/client/Cargo.toml
+++ b/examples/ssr/workspace/client/Cargo.toml
@@ -13,7 +13,7 @@ actix-web = { version = "4.4", optional = true, features = ["macros"] }
 leptos = { version = "0.8.2" }
 leptos_meta = { version = "0.8.2" }
 leptos_actix = { version = "0.8.2", optional = true }
-leptos_i18n = { workspace = true }
+leptos_i18n = { path = "../../../../leptos_i18n" }
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wasm-bindgen = "0.2"
@@ -40,4 +40,6 @@ default = "en"
 locales = ["en", "fr"]
 
 [build-dependencies]
-leptos_i18n_build = { workspace = true, features = ["pretty_print"] }
+leptos_i18n_build = { path = "../../../../leptos_i18n_build", features = [
+  "pretty_print",
+] }

--- a/leptos_i18n/src/macro_helpers/formatting/mod.rs
+++ b/leptos_i18n/src/macro_helpers/formatting/mod.rs
@@ -447,6 +447,7 @@ pub(crate) mod data_provider {
     }
 
     #[cfg(feature = "icu_compiled_data")]
+    #[allow(dead_code)]
     #[derive(Default)]
     pub struct BakedDataProvider;
 

--- a/leptos_i18n_build/Cargo.toml
+++ b/leptos_i18n_build/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 leptos_i18n_parser = { workspace = true }
-leptos_i18n_codegen = { workspace = true }
+leptos_i18n_codegen = { workspace = true, default-features = true }
 
 icu_provider_export = { workspace = true, features = [
   "baked_exporter",

--- a/leptos_i18n_codegen/src/load_locales/interpolate.rs
+++ b/leptos_i18n_codegen/src/load_locales/interpolate.rs
@@ -1,27 +1,21 @@
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use leptos_i18n_parser::parse_locales::locale::DefaultedLocales;
-use leptos_i18n_parser::parse_locales::locale::InterpolationKeys;
-use leptos_i18n_parser::parse_locales::locale::Locale;
-use leptos_i18n_parser::parse_locales::options::Options;
-use leptos_i18n_parser::parse_locales::parsed_value::ParsedValue;
-use leptos_i18n_parser::utils::Key;
-use leptos_i18n_parser::utils::KeyPath;
-use leptos_i18n_parser::utils::UnwrapAt;
+use leptos_i18n_parser::{
+    parse_locales::{
+        locale::{DefaultedLocales, InterpolationKeys, Locale},
+        options::Options,
+        parsed_value::ParsedValue,
+    },
+    utils::{Key, KeyPath, UnwrapAt},
+};
 use proc_macro2::{Span, TokenStream};
-use quote::format_ident;
-use quote::quote;
-use quote::ToTokens;
+use quote::{format_ident, quote, ToTokens};
 
 use super::parsed_value;
 // use super::parsed_value::InterpolationKeys;
 // use super::parsed_value::RangeOrPlural;
-use super::parsed_value::TRANSLATIONS_KEY;
-use super::ranges::RangeType;
-use super::strings_accessor_method_name;
-use crate::utils::formatter::Formatter;
-use crate::utils::EitherOfWrapper;
+use super::{parsed_value::TRANSLATIONS_KEY, ranges::RangeType, strings_accessor_method_name};
+use crate::utils::{formatter::Formatter, EitherOfWrapper};
 
 pub const LOCALE_FIELD_KEY: &str = "_locale";
 

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -10,10 +10,11 @@ pub mod warning;
 use interpolate::Interpolation;
 use leptos_i18n_parser::{
     parse_locales::{
-        error::{Error, Result}, locale::{
-            BuildersKeys, BuildersKeysInner, InterpolOrLit, Locale, LocaleValue,
-            Namespace,
-        }, options::Options, parsed_value::ParsedValue, ParsedLocales
+        error::{Error, Result},
+        locale::{BuildersKeys, BuildersKeysInner, InterpolOrLit, Locale, LocaleValue, Namespace},
+        options::Options,
+        parsed_value::ParsedValue,
+        ParsedLocales,
     },
     utils::{
         key::{Key, KeyPath},
@@ -28,13 +29,19 @@ use warning::generate_warnings;
 
 pub fn load_locales(
     parsed_locales: &ParsedLocales,
-    crate_path: Option<&syn::Path>
+    crate_path: Option<&syn::Path>,
 ) -> Result<TokenStream> {
-
     let default_crate_path = syn::Path::from(syn::Ident::new("leptos_i18n", Span::call_site()));
     let crate_path = crate_path.unwrap_or(&default_crate_path);
 
-    let ParsedLocales { cfg_file, builder_keys, warnings, errors, tracked_files: _, options } = parsed_locales;
+    let ParsedLocales {
+        cfg_file,
+        builder_keys,
+        warnings,
+        errors,
+        tracked_files: _,
+        options,
+    } = parsed_locales;
 
     if cfg!(all(feature = "csr", feature = "dynamic_load")) && cfg_file.translations_uri.is_none() {
         return Err(Error::MissingTranslationsURI.into());
@@ -50,7 +57,7 @@ pub fn load_locales(
         &enum_ident,
         &translation_unit_enum_ident,
         cfg_file.translations_uri.as_deref(),
-        options
+        options,
     );
     let locale_enum = create_locales_enum(
         &enum_ident,
@@ -211,7 +218,7 @@ pub fn load_locales(
             #![allow(unused_braces)]
             #![allow(clippy::type_complexity)]
             #![allow(clippy::let_and_return)]
-            
+
             use #crate_path as l_i18n_crate;
 
             #locale_enum
@@ -548,7 +555,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     key_path: &mut KeyPath,
     namespace_name: Option<&str>,
     translations_uri: Option<&str>,
-    options: &Options
+    options: &Options,
 ) -> TokenStream {
     let translations_key = Key::new(TRANSLATIONS_KEY).unwrap_at("TRANSLATIONS_KEY");
 
@@ -711,7 +718,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
             &mut pushed_key,
             namespace_name,
             translations_uri,
-            options
+            options,
         );
         quote! {
             pub mod #subkey_mod_ident {
@@ -756,14 +763,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
             } => Some((
                 key,
                 Interpolation::new(
-                    key,
-                    enum_ident,
-                    keys,
-                    locales,
-                    key_path,
-                    type_ident,
-                    defaults,
-                    options
+                    key, enum_ident, keys, locales, key_path, type_ident, defaults, options,
                 ),
             )),
             _ => None,
@@ -824,7 +824,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
                         }
                     }
                 };
-                
+
                 let request_translations = if cfg!(all(feature = "dynamic_load", feature = "csr")) {
                     let uri = translations_uri.expect("Missing URI"); // Already check before
                     // trigger with rustc 1.85, still in nightly tho
@@ -1107,7 +1107,7 @@ fn create_namespaces_types(
     namespaces: &[Namespace],
     keys: &BTreeMap<Key, BuildersKeysInner>,
     translations_uri: Option<&str>,
-    options: &Options
+    options: &Options,
 ) -> TokenStream {
     let namespaces = namespaces
         .iter()
@@ -1134,7 +1134,7 @@ fn create_namespaces_types(
                 &mut key_path,
                 Some(&namespace.key.name),
                 translations_uri,
-                options
+                options,
             );
 
             quote! {
@@ -1334,7 +1334,7 @@ fn create_locale_type(
     enum_ident: &syn::Ident,
     translation_unit_enum_ident: &syn::Ident,
     translations_uri: Option<&str>,
-    options: &Options
+    options: &Options,
 ) -> TokenStream {
     match keys {
         BuildersKeys::NameSpaces { namespaces, keys } => create_namespaces_types(
@@ -1344,7 +1344,7 @@ fn create_locale_type(
             namespaces,
             keys,
             translations_uri,
-            options
+            options,
         ),
         BuildersKeys::Locales { locales, keys } => create_locale_type_inner::<true>(
             keys_ident,
@@ -1356,7 +1356,7 @@ fn create_locale_type(
             &mut KeyPath::new(None),
             None,
             translations_uri,
-            options
+            options,
         ),
     }
 }

--- a/leptos_i18n_codegen/src/load_locales/ranges.rs
+++ b/leptos_i18n_codegen/src/load_locales/ranges.rs
@@ -1,15 +1,12 @@
 use std::ops::Bound;
 
 use leptos_i18n_parser::{
-    parse_locales::parsed_value::ParsedValue,
-    utils::{Key, KeyPath},
-};
-use leptos_i18n_parser::{
     parse_locales::{
         locale::InterpolOrLit,
+        parsed_value::ParsedValue,
         ranges::{Range, RangeNumber, Ranges, UntypedRangesInner},
     },
-    utils::UnwrapAt,
+    utils::{Key, KeyPath, UnwrapAt},
 };
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};

--- a/leptos_i18n_macro/Cargo.toml
+++ b/leptos_i18n_macro/Cargo.toml
@@ -24,7 +24,7 @@ icu_locale = { workspace = true, features = ["compiled_data"] }
 fixed_decimal = { workspace = true, features = ["ryu"] }
 leptos_i18n_parser = { workspace = true }
 tinystr = { workspace = true }
-leptos_i18n_codegen = { workspace = true }
+leptos_i18n_codegen = { workspace = true, default-features = true }
 
 [features]
 default = []
@@ -36,21 +36,21 @@ csr = ["leptos_i18n_codegen/csr"]
 ssr = ["leptos_i18n_codegen/ssr"]
 plurals = ["leptos_i18n_parser/plurals", "leptos_i18n_codegen/plurals"]
 format_datetime = [
-    "leptos_i18n_parser/format_datetime",
-    "leptos_i18n_codegen/format_datetime",
+  "leptos_i18n_parser/format_datetime",
+  "leptos_i18n_codegen/format_datetime",
 ]
 format_list = [
-    "leptos_i18n_parser/format_list",
-    "leptos_i18n_codegen/format_list",
+  "leptos_i18n_parser/format_list",
+  "leptos_i18n_codegen/format_list",
 ]
 format_nums = [
-    "leptos_i18n_parser/format_nums",
-    "leptos_i18n_codegen/format_nums",
+  "leptos_i18n_parser/format_nums",
+  "leptos_i18n_codegen/format_nums",
 ]
 format_currency = [
-    "leptos_i18n_parser/format_currency",
-    "format_nums",
-    "leptos_i18n_codegen/format_currency",
+  "leptos_i18n_parser/format_currency",
+  "format_nums",
+  "leptos_i18n_codegen/format_currency",
 ]
 icu_compiled_data = []
 

--- a/leptos_i18n_parser/src/parse_locales/locale.rs
+++ b/leptos_i18n_parser/src/parse_locales/locale.rs
@@ -1,22 +1,26 @@
 use serde::de::MapAccess;
 
-use crate::parse_locales::options::{FileFormat, Options};
-use crate::utils::formatter::Formatter;
-use crate::utils::{Key, KeyPath, UnwrapAt};
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::fs::File;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use crate::{
+    parse_locales::options::{FileFormat, Options},
+    utils::{formatter::Formatter, Key, KeyPath, UnwrapAt},
+};
+use std::{
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashSet},
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
-use super::cfg_file::ConfigFile;
-use super::error::{Error, Errors, Result};
-use super::parsed_value::{ParsedValue, ParsedValueSeed};
-use super::plurals::{PluralForm, PluralRuleType, Plurals};
-use super::ranges::RangeType;
-use super::warning::{Warning, Warnings};
-use super::{ForeignKeysPaths, StringIndexer};
+use super::{
+    cfg_file::ConfigFile,
+    error::{Error, Errors, Result},
+    parsed_value::{ParsedValue, ParsedValueSeed},
+    plurals::{PluralForm, PluralRuleType, Plurals},
+    ranges::RangeType,
+    warning::{Warning, Warnings},
+    ForeignKeysPaths, StringIndexer,
+};
 
 #[derive(Debug)]
 #[non_exhaustive]

--- a/leptos_i18n_parser/src/utils/key.rs
+++ b/leptos_i18n_parser/src/utils/key.rs
@@ -1,9 +1,13 @@
-use crate::parse_locales::error::{Error, Result};
-use crate::parse_locales::VAR_COUNT_KEY;
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
-use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
+use crate::parse_locales::{
+    error::{Error, Result},
+    VAR_COUNT_KEY,
+};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::{Deref, DerefMut},
+    rc::Rc,
+};
 
 use super::UnwrapAt;
 

--- a/leptos_i18n_router/Cargo.toml
+++ b/leptos_i18n_router/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos_i18n = { workspace = true, default-features = false }
+leptos_i18n = { workspace = true }
 leptos = { workspace = true }
 leptos_router = { workspace = true }
 

--- a/tests/common/Cargo.toml
+++ b/tests/common/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { workspace = true }
+leptos = { version = "0.8.2" }

--- a/tests/json/Cargo.toml
+++ b/tests/json/Cargo.toml
@@ -9,11 +9,11 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { workspace = true, features = ["ssr"] }
-tests_common = { workspace = true }
+leptos = { version = "0.8.2", features = ["ssr"] }
+tests_common = { path = "../common" }
 
 [dependencies.leptos_i18n]
-workspace = true
+path = "../../leptos_i18n"
 features = [
   "plurals",
   "format_datetime",
@@ -23,7 +23,9 @@ features = [
 ]
 
 [build-dependencies]
-leptos_i18n_build = { workspace = true, features = ["pretty_print"] }
+leptos_i18n_build = { path = "../../leptos_i18n_build", features = [
+  "pretty_print",
+] }
 
 
 [package.metadata.leptos-i18n]

--- a/tests/json5/Cargo.toml
+++ b/tests/json5/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 leptos = { version = "0.8.2", features = ["ssr"] }
-tests_common = { workspace = true }
-leptos_i18n = { workspace = true }
+tests_common = { path = "../common" }
+leptos_i18n = { path = "../../leptos_i18n" }
 
 [build-dependencies]
-leptos_i18n_build = { workspace = true, features = ["pretty_print"] }
+leptos_i18n_build = { path = "../../leptos_i18n", features = ["pretty_print"] }
 
 
 [package.metadata.leptos-i18n]

--- a/tests/namespaces/Cargo.toml
+++ b/tests/namespaces/Cargo.toml
@@ -9,12 +9,14 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { workspace = true, features = ["ssr"] }
-tests_common = { workspace = true }
-leptos_i18n = { workspace = true }
+leptos = { version = "0.8.2", features = ["ssr"] }
+tests_common = { path = "../common" }
+leptos_i18n = { path = "../../leptos_i18n" }
 
 [build-dependencies]
-leptos_i18n_build = { workspace = true, features = ["pretty_print"] }
+leptos_i18n_build = { path = "../../leptos_i18n_build", features = [
+  "pretty_print",
+] }
 
 
 [package.metadata.leptos-i18n]

--- a/tests/yaml/Cargo.toml
+++ b/tests/yaml/Cargo.toml
@@ -10,11 +10,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 leptos = { version = "0.8.2", features = ["ssr"] }
-tests_common = { workspace = true }
-leptos_i18n = { workspace = true }
+tests_common = { path = "../common" }
+leptos_i18n = { path = "../../leptos_i18n" }
 
 [build-dependencies]
-leptos_i18n_build = { workspace = true, features = ["pretty_print"] }
+leptos_i18n_build = { path = "../../leptos_i18n_build", features = [
+  "pretty_print",
+] }
 
 
 [package.metadata.leptos-i18n]


### PR DESCRIPTION
What's changed in this PR:

- Re-arranged the workspace to exclude the examples and integration tests. It's not a good practice to add examples and integration tests as part of workspace members as they are not members and the workspace cannot distinguish between them and members.
- Enhanced CI to clippy all features and check formatting.