### PR TITLE
Gen docs for keys

### DIFF
--- a/docs/book/src/setting_up/01_configuration.md
+++ b/docs/book/src/setting_up/01_configuration.md
@@ -128,6 +128,7 @@ There is also a way to inject your own formatter, this needs its own chapter, wh
 
 - Add some top level attributes for the generated module
 - Customize the name of the generated file
+- Generate doc comments on different items to see available namespaces, keys, subkeys, or args required for interpolations
 
 example:
 
@@ -138,7 +139,10 @@ let attributes = "#![allow(missing_docs)]".parse()?;
 
 let options = CodegenOptions::default()
   .top_level_attributes(Some(attributes))
-  .module_file_name("i18n.rs"); // "mod.rs" by default
+  .module_file_name("i18n.rs") // "mod.rs" by default
+  .gen_docs(true); // `true` by default
 
 translations_infos.generate_i18n_module_with_options(options)?;
 ```
+
+The later (`gen_docs`) is purely for UX ergonomics, disable it if you don't use intellisense or for CI runs

--- a/leptos_i18n/src/locale_traits.rs
+++ b/leptos_i18n/src/locale_traits.rs
@@ -221,8 +221,8 @@ mod test {
         }
         let fr_ssk = td_const!(Locale::fr, sk.ssk);
         assert!(check_str_eq_const(fr_ssk, "test fr"));
-        let fr_ssk = td_const!(Locale::en, sk.ssk);
-        assert!(check_str_eq_const(fr_ssk, "test en"));
+        let en_ssk = td_const!(Locale::en, sk.ssk);
+        assert!(check_str_eq_const(en_ssk, "test en"));
     };
 
     #[test]

--- a/leptos_i18n_build/src/lib.rs
+++ b/leptos_i18n_build/src/lib.rs
@@ -263,6 +263,7 @@ impl TranslationsInfos {
             options.crate_path.as_ref(),
             false,
             options.top_level_attributes.as_ref(),
+            options.gen_docs,
         )?;
 
         #[cfg(feature = "pretty_print")]

--- a/leptos_i18n_build/src/options.rs
+++ b/leptos_i18n_build/src/options.rs
@@ -16,6 +16,9 @@ pub struct CodegenOptions<'a> {
     pub module_file_name: &'a Path,
     /// Path to the `leptos_i18n` crate, usefull if the crate is not a direct depedency of the pacakage and is behind a reexport.
     pub crate_path: Option<syn::Path>,
+    /// Generate docs on `Locale` enum, subkeys, namespaces keys, and interpolations to display available keys or required arguments.
+    /// `true` by default
+    pub gen_docs: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -34,6 +37,7 @@ impl<'a> CodegenOptions<'a> {
             top_level_attributes: None,
             module_file_name: DEFAULT_FILE_NAME.as_ref(),
             crate_path: None,
+            gen_docs: true,
         }
     }
 
@@ -66,5 +70,10 @@ impl<'a> CodegenOptions<'a> {
     /// Path to the `leptos_i18n` crate, usefull if the crate is not a direct depedency of the pacakage and is behind a reexport.
     pub fn crate_path(self, crate_path: Option<syn::Path>) -> Self {
         Self { crate_path, ..self }
+    }
+
+    /// Allow to generate docs on `Locale` enum, subkeys, namespaces keys, and interpolations to display available keys or required arguments.
+    pub fn gen_docs(self, gen_docs: bool) -> Self {
+        Self { gen_docs, ..self }
     }
 }

--- a/leptos_i18n_codegen/src/lib.rs
+++ b/leptos_i18n_codegen/src/lib.rs
@@ -18,11 +18,13 @@ pub fn gen_code(
     crate_path: Option<&syn::Path>,
     emit_diagnostics: bool,
     top_level_attributes: Option<&TokenStream>,
+    gen_docs: bool,
 ) -> Result<TokenStream> {
     load_locales::load_locales(
         parsed_locales,
         crate_path,
         emit_diagnostics,
         top_level_attributes,
+        gen_docs,
     )
 }

--- a/leptos_i18n_codegen/src/load_locales/interpolate.rs
+++ b/leptos_i18n_codegen/src/load_locales/interpolate.rs
@@ -40,7 +40,7 @@ impl<T, A: Iterator<Item = T>, B: Iterator<Item = T>> Iterator for EitherIter<A,
 pub struct Interpolation {
     pub ident: syn::Ident,
     pub imp: TokenStream,
-    pub docs: String,
+    pub docs: TokenStream,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -275,6 +275,7 @@ impl Interpolation {
         locale_type_ident: &syn::Ident,
         defaults: &DefaultedLocales,
         options: &ParseOptions,
+        gen_docs: bool,
     ) -> Self {
         // filter defaulted locales
         let locales = locales
@@ -375,8 +376,15 @@ impl Interpolation {
             #dummy_impl
         };
 
-        let mut docs = String::new();
-        Self::gen_fields_docs(&mut docs, &fields).unwrap();
+        let docs = if gen_docs {
+            let mut docs = String::new();
+            Self::gen_fields_docs(&mut docs, &fields).unwrap();
+            quote! {
+                #[doc = #docs]
+            }
+        } else {
+            quote! {}
+        };
 
         Self {
             imp,

--- a/leptos_i18n_codegen/src/load_locales/interpolate.rs
+++ b/leptos_i18n_codegen/src/load_locales/interpolate.rs
@@ -377,7 +377,8 @@ impl Interpolation {
         };
 
         let docs = if gen_docs {
-            let mut docs = String::new();
+            let path = key_path.to_string_with_key(key);
+            let mut docs = format!("Full path: `{}`\n", path);
             Self::gen_fields_docs(&mut docs, &fields).unwrap();
             quote! {
                 #[doc = #docs]

--- a/leptos_i18n_codegen/src/load_locales/interpolate.rs
+++ b/leptos_i18n_codegen/src/load_locales/interpolate.rs
@@ -40,6 +40,7 @@ impl<T, A: Iterator<Item = T>, B: Iterator<Item = T>> Iterator for EitherIter<A,
 pub struct Interpolation {
     pub ident: syn::Ident,
     pub imp: TokenStream,
+    pub docs: String,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -374,10 +375,63 @@ impl Interpolation {
             #dummy_impl
         };
 
+        let mut docs = String::new();
+        Self::gen_fields_docs(&mut docs, &fields).unwrap();
+
         Self {
             imp,
             ident: dummy_ident,
+            docs,
         }
+    }
+
+    fn gen_fields_docs(docs: &mut String, fields: &[Field]) -> core::fmt::Result {
+        use core::fmt::Write;
+        let mut variables = fields
+            .iter()
+            .filter_map(|field| match &field.var_or_comp {
+                VarOrComp::Var { bounds, plural } => {
+                    let key = field.key.name.strip_prefix("var_")?;
+                    Some((key, bounds.as_slice(), plural.as_ref()))
+                }
+                VarOrComp::Comp { .. } => None,
+            })
+            .peekable();
+
+        if variables.peek().is_some() {
+            writeln!(docs, "## Vars :")?;
+            for (key, bounds, plural) in variables {
+                let _ = bounds;
+                match plural {
+                    Some(_) => writeln!(docs, "- `{}` (plural count)", key)?,
+                    None => writeln!(docs, "- `{}`", key)?,
+                }
+            }
+        }
+
+        let mut components = fields
+            .iter()
+            .filter_map(|field| match &field.var_or_comp {
+                VarOrComp::Var { .. } => None,
+                VarOrComp::Comp { self_closed, .. } => {
+                    let key = field.key.name.strip_prefix("comp_")?;
+                    Some((key, *self_closed))
+                }
+            })
+            .peekable();
+
+        if components.peek().is_some() {
+            writeln!(docs, "## Components :")?;
+            for (key, self_closed) in components {
+                if self_closed {
+                    writeln!(docs, "- `<{}/>`", key)?;
+                } else {
+                    writeln!(docs, "-  `<{}>`", key)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn builder_string_build_fns(

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -911,7 +911,9 @@ fn create_locale_type_inner<const IS_TOP: bool>(
 
     let builder_accessors = builders.iter().map(|(key, inter)| {
         let inter_ident = &inter.ident;
+        let docs = &inter.docs;
         quote! {
+            #[doc = #docs]
             pub const fn #key(self) -> builders::#inter_ident {
                 builders::#inter_ident::new(self.0)
             }

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -421,9 +421,9 @@ fn create_locales_enum(
     for (i, key) in locales.iter().enumerate() {
         use core::fmt::Write;
         if i == 0 {
-            writeln!(&mut docs, "- {} (default)", key).unwrap();
+            writeln!(&mut docs, "- `{}` (default)", key).unwrap();
         } else {
-            writeln!(&mut docs, "- {}", key).unwrap();
+            writeln!(&mut docs, "- `{}`", key).unwrap();
         }
     }
 
@@ -432,7 +432,7 @@ fn create_locales_enum(
             use core::fmt::Write;
             writeln!(&mut docs, "\n## Namespaces :").unwrap();
             for ns in namespaces {
-                writeln!(&mut docs, "- {}", ns.key).unwrap();
+                writeln!(&mut docs, "- `{}`", ns.key).unwrap();
             }
         }
         BuildersKeys::Locales { keys, .. } => {
@@ -1519,7 +1519,7 @@ fn gen_keys_doc(docs: &mut String, keys: &BTreeMap<Key, LocaleValue>) -> core::f
     if keys_iter.peek().is_some() {
         writeln!(docs, "\n## Keys :")?;
         for key in keys_iter {
-            writeln!(docs, "- {}", key)?;
+            writeln!(docs, "- `{}`", key)?;
         }
     }
 
@@ -1534,7 +1534,7 @@ fn gen_keys_doc(docs: &mut String, keys: &BTreeMap<Key, LocaleValue>) -> core::f
     if keys_iter.peek().is_some() {
         writeln!(docs, "## Subkeys :")?;
         for key in keys_iter {
-            writeln!(docs, "- {}", key)?;
+            writeln!(docs, "- `{}`", key)?;
         }
     }
 

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -30,6 +30,7 @@ pub fn load_locales(
     crate_path: Option<&syn::Path>,
     emit_diagnostics: bool,
     top_level_attributes: Option<&TokenStream>,
+    gen_docs: bool,
 ) -> Result<TokenStream> {
     let default_crate_path = syn::Path::from(syn::Ident::new("leptos_i18n", Span::call_site()));
     let crate_path = crate_path.unwrap_or(&default_crate_path);
@@ -71,6 +72,7 @@ pub fn load_locales(
         &translation_unit_enum_ident,
         cfg.translations_uri.as_deref(),
         &cfg.options,
+        gen_docs,
     );
     let locale_enum = create_locales_enum(
         builder_keys,
@@ -78,6 +80,7 @@ pub fn load_locales(
         &enum_ident,
         &translation_unit_enum_ident,
         &cfg.locales,
+        gen_docs,
     )?;
     let scopes_mod = create_scopes_module(builder_keys);
 
@@ -293,6 +296,7 @@ fn create_locales_enum(
     enum_ident: &syn::Ident,
     translation_unit_enum_ident: &syn::Ident,
     locales: &[Key],
+    gen_docs: bool,
 ) -> Result<TokenStream> {
     let as_str_match_arms = locales
         .iter()
@@ -416,32 +420,39 @@ fn create_locales_enum(
         }
     });
 
-    let mut docs = String::from("## Supported locales:\n");
-
-    for (i, key) in locales.iter().enumerate() {
-        use core::fmt::Write;
-        if i == 0 {
-            writeln!(&mut docs, "- `{}` (default)", key).unwrap();
-        } else {
-            writeln!(&mut docs, "- `{}`", key).unwrap();
-        }
-    }
-
-    match keys {
-        BuildersKeys::NameSpaces { namespaces, .. } => {
+    let docs = if gen_docs {
+        let mut docs = String::from("## Supported locales:\n");
+        for (i, key) in locales.iter().enumerate() {
             use core::fmt::Write;
-            writeln!(&mut docs, "\n## Namespaces :").unwrap();
-            for ns in namespaces {
-                writeln!(&mut docs, "- `{}`", ns.key).unwrap();
+            if i == 0 {
+                writeln!(&mut docs, "- `{}` (default)", key).unwrap();
+            } else {
+                writeln!(&mut docs, "- `{}`", key).unwrap();
             }
         }
-        BuildersKeys::Locales { keys, .. } => {
-            gen_keys_doc(&mut docs, &keys.0).unwrap();
+
+        match keys {
+            BuildersKeys::NameSpaces { namespaces, .. } => {
+                use core::fmt::Write;
+                writeln!(&mut docs, "\n## Namespaces :").unwrap();
+                for ns in namespaces {
+                    writeln!(&mut docs, "- `{}`", ns.key).unwrap();
+                }
+            }
+            BuildersKeys::Locales { keys, .. } => {
+                gen_keys_doc(&mut docs, &keys.0).unwrap();
+            }
+        };
+
+        quote! {
+            #[doc = #docs]
         }
+    } else {
+        quote! {}
     };
 
     let ts = quote! {
-        #[doc = #docs]
+        #docs
         #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Default)]
         #[allow(non_camel_case_types)]
         pub enum #enum_ident {
@@ -694,6 +705,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     namespace_name: Option<&str>,
     translations_uri: Option<&str>,
     options: &ParseOptions,
+    gen_docs: bool,
 ) -> TokenStream {
     let translations_key = Key::new(TRANSLATIONS_KEY).unwrap_at("TRANSLATIONS_KEY");
 
@@ -857,6 +869,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
             namespace_name,
             translations_uri,
             options,
+            gen_docs,
         );
         quote! {
             pub mod #subkey_mod_ident {
@@ -871,10 +884,17 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         let original_key = &sk.original_key;
         let key = &sk.key;
         let mod_ident = &sk.mod_key;
-        let mut docs = String::new();
-        gen_keys_doc(&mut docs, &sk.keys.0).unwrap();
+        let docs = if gen_docs {
+            let mut docs = String::new();
+            gen_keys_doc(&mut docs, &sk.keys.0).unwrap();
+            quote! {
+                #[doc = #docs]
+            }
+        } else {
+            quote! {}
+        };
         quote! {
-            #[doc = #docs]
+            #docs
             pub const fn #original_key(self) -> subkeys::#mod_ident::#key {
                 subkeys::#mod_ident::#key::__new_internal(self.0)
             }
@@ -903,6 +923,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
                 key,
                 Interpolation::new(
                     key, enum_ident, keys, locales, key_path, type_ident, defaults, options,
+                    gen_docs,
                 ),
             )),
             _ => None,
@@ -913,7 +934,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         let inter_ident = &inter.ident;
         let docs = &inter.docs;
         quote! {
-            #[doc = #docs]
+            #docs
             pub const fn #key(self) -> builders::#inter_ident {
                 builders::#inter_ident::new(self.0)
             }
@@ -1249,6 +1270,7 @@ fn create_namespaces_types(
     keys: &BTreeMap<Key, BuildersKeysInner>,
     translations_uri: Option<&str>,
     options: &ParseOptions,
+    gen_docs: bool,
 ) -> TokenStream {
     let namespaces = namespaces
         .iter()
@@ -1276,6 +1298,7 @@ fn create_namespaces_types(
                 Some(&namespace.key.name),
                 translations_uri,
                 options,
+                gen_docs,
             );
 
             quote! {
@@ -1291,11 +1314,18 @@ fn create_namespaces_types(
         .iter()
         .map(|(namespace, namespace_module_ident)| {
             let key = &namespace.key;
-            let keys = keys.get(key).unwrap_at("create_namespaces_types_2");
-            let mut docs = String::new();
-            gen_keys_doc(&mut docs, &keys.0).unwrap();
+            let docs = if gen_docs {
+                let keys = keys.get(key).unwrap_at("create_namespaces_types_2");
+                let mut docs = String::new();
+                gen_keys_doc(&mut docs, &keys.0).unwrap();
+                quote! {
+                    #[doc = #docs]
+                }
+            } else {
+                quote! {}
+            };
             quote! {
-                #[doc = #docs]
+                #docs
                 pub fn #key(self) -> namespaces::#namespace_module_ident::#key {
                     namespaces::#namespace_module_ident::#key::__new_internal(self.0)
                 }
@@ -1480,6 +1510,7 @@ fn create_locale_type(
     translation_unit_enum_ident: &syn::Ident,
     translations_uri: Option<&str>,
     options: &ParseOptions,
+    gen_docs: bool,
 ) -> TokenStream {
     match keys {
         BuildersKeys::NameSpaces { namespaces, keys } => create_namespaces_types(
@@ -1490,6 +1521,7 @@ fn create_locale_type(
             keys,
             translations_uri,
             options,
+            gen_docs,
         ),
         BuildersKeys::Locales { locales, keys } => create_locale_type_inner::<true>(
             keys_ident,
@@ -1502,6 +1534,7 @@ fn create_locale_type(
             None,
             translations_uri,
             options,
+            gen_docs,
         ),
     }
 }

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -73,8 +73,9 @@ pub fn load_locales(
         &cfg.options,
     );
     let locale_enum = create_locales_enum(
-        &enum_ident,
+        builder_keys,
         &keys_ident,
+        &enum_ident,
         &translation_unit_enum_ident,
         &cfg.locales,
     )?;
@@ -287,8 +288,9 @@ pub fn load_locales(
 }
 
 fn create_locales_enum(
-    enum_ident: &syn::Ident,
+    keys: &BuildersKeys,
     keys_ident: &syn::Ident,
+    enum_ident: &syn::Ident,
     translation_unit_enum_ident: &syn::Ident,
     locales: &[Key],
 ) -> Result<TokenStream> {
@@ -414,7 +416,32 @@ fn create_locales_enum(
         }
     });
 
+    let mut docs = String::from("## Supported locales:\n");
+
+    for (i, key) in locales.iter().enumerate() {
+        use core::fmt::Write;
+        if i == 0 {
+            writeln!(&mut docs, "- {} (default)", key).unwrap();
+        } else {
+            writeln!(&mut docs, "- {}", key).unwrap();
+        }
+    }
+
+    match keys {
+        BuildersKeys::NameSpaces { namespaces, .. } => {
+            use core::fmt::Write;
+            writeln!(&mut docs, "\n## Namespaces :").unwrap();
+            for ns in namespaces {
+                writeln!(&mut docs, "- {}", ns.key).unwrap();
+            }
+        }
+        BuildersKeys::Locales { keys, .. } => {
+            gen_keys_doc(&mut docs, &keys.0).unwrap();
+        }
+    };
+
     let ts = quote! {
+        #[doc = #docs]
         #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Default)]
         #[allow(non_camel_case_types)]
         pub enum #enum_ident {
@@ -844,11 +871,13 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         let original_key = &sk.original_key;
         let key = &sk.key;
         let mod_ident = &sk.mod_key;
+        let mut docs = String::new();
+        gen_keys_doc(&mut docs, &sk.keys.0).unwrap();
         quote! {
+            #[doc = #docs]
             pub const fn #original_key(self) -> subkeys::#mod_ident::#key {
                 subkeys::#mod_ident::#key::__new_internal(self.0)
             }
-
         }
     });
 
@@ -1260,7 +1289,11 @@ fn create_namespaces_types(
         .iter()
         .map(|(namespace, namespace_module_ident)| {
             let key = &namespace.key;
+            let keys = keys.get(key).unwrap_at("create_namespaces_types_2");
+            let mut docs = String::new();
+            gen_keys_doc(&mut docs, &keys.0).unwrap();
             quote! {
+                #[doc = #docs]
                 pub fn #key(self) -> namespaces::#namespace_module_ident::#key {
                     namespaces::#namespace_module_ident::#key::__new_internal(self.0)
                 }
@@ -1469,4 +1502,39 @@ fn create_locale_type(
             options,
         ),
     }
+}
+
+fn gen_keys_doc(docs: &mut String, keys: &BTreeMap<Key, LocaleValue>) -> core::fmt::Result {
+    use core::fmt::Write;
+    let mut keys_iter = keys
+        .iter()
+        .filter_map(|(key, value)| match value {
+            LocaleValue::Value { .. } => Some(key),
+            LocaleValue::Subkeys { .. } => None,
+        })
+        .peekable();
+
+    if keys_iter.peek().is_some() {
+        writeln!(docs, "\n## Keys :")?;
+        for key in keys_iter {
+            writeln!(docs, "- {}", key)?;
+        }
+    }
+
+    let mut keys_iter = keys
+        .iter()
+        .filter_map(|(key, value)| match value {
+            LocaleValue::Value { .. } => None,
+            LocaleValue::Subkeys { .. } => Some(key),
+        })
+        .peekable();
+
+    if keys_iter.peek().is_some() {
+        writeln!(docs, "## Subkeys :")?;
+        for key in keys_iter {
+            writeln!(docs, "- {}", key)?;
+        }
+    }
+
+    Ok(())
 }

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -600,6 +600,7 @@ impl<'a> Subkeys<'a> {
 
     pub fn new(
         key: Key,
+        key_path: &KeyPath,
         locales: &'a [Locale],
         keys: &'a BuildersKeysInner,
         gen_docs: bool,
@@ -607,7 +608,8 @@ impl<'a> Subkeys<'a> {
         let mod_key = Self::mod_ident(&key);
         let new_key = Self::item_ident(&key);
         let docs = if gen_docs {
-            let mut docs = String::new();
+            let path = key_path.to_string_with_key(&key);
+            let mut docs = format!("Full path: `{}`\n", path);
             gen_keys_doc(&mut docs, &keys.0).unwrap();
             quote! {
                 #[doc = #docs]
@@ -866,7 +868,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         .iter()
         .filter_map(|(key, value)| match value {
             LocaleValue::Subkeys { locales, keys } => {
-                Some(Subkeys::new(key.clone(), locales, keys, gen_docs))
+                Some(Subkeys::new(key.clone(), key_path, locales, keys, gen_docs))
             }
             _ => None,
         })
@@ -1302,7 +1304,7 @@ fn create_namespaces_types(
             let namespace_module_ident = create_namespace_mod_ident(&ns.key.ident);
             let docs = if gen_docs {
                 let keys = keys.get(&ns.key).unwrap_at("create_namespaces_types_2");
-                let mut docs = String::new();
+                let mut docs = format!("Full path: `{}`\n", ns.key);
                 gen_keys_doc(&mut docs, &keys.0).unwrap();
                 quote! {
                     #[doc = #docs]

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -586,6 +586,7 @@ struct Subkeys<'a> {
     mod_key: syn::Ident,
     locales: &'a [Locale],
     keys: &'a BuildersKeysInner,
+    docs: TokenStream,
 }
 
 impl<'a> Subkeys<'a> {
@@ -597,15 +598,30 @@ impl<'a> Subkeys<'a> {
         format_ident!("{}_subkeys", key)
     }
 
-    pub fn new(key: Key, locales: &'a [Locale], keys: &'a BuildersKeysInner) -> Self {
+    pub fn new(
+        key: Key,
+        locales: &'a [Locale],
+        keys: &'a BuildersKeysInner,
+        gen_docs: bool,
+    ) -> Self {
         let mod_key = Self::mod_ident(&key);
         let new_key = Self::item_ident(&key);
+        let docs = if gen_docs {
+            let mut docs = String::new();
+            gen_keys_doc(&mut docs, &keys.0).unwrap();
+            quote! {
+                #[doc = #docs]
+            }
+        } else {
+            quote! {}
+        };
         Subkeys {
             original_key: key,
             key: new_key,
             mod_key,
             locales,
             keys,
+            docs,
         }
     }
 }
@@ -705,6 +721,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     namespace_name: Option<&str>,
     translations_uri: Option<&str>,
     options: &ParseOptions,
+    docs: &TokenStream,
     gen_docs: bool,
 ) -> TokenStream {
     let translations_key = Key::new(TRANSLATIONS_KEY).unwrap_at("TRANSLATIONS_KEY");
@@ -849,7 +866,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         .iter()
         .filter_map(|(key, value)| match value {
             LocaleValue::Subkeys { locales, keys } => {
-                Some(Subkeys::new(key.clone(), locales, keys))
+                Some(Subkeys::new(key.clone(), locales, keys, gen_docs))
             }
             _ => None,
         })
@@ -869,6 +886,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
             namespace_name,
             translations_uri,
             options,
+            &sk.docs,
             gen_docs,
         );
         quote! {
@@ -884,15 +902,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
         let original_key = &sk.original_key;
         let key = &sk.key;
         let mod_ident = &sk.mod_key;
-        let docs = if gen_docs {
-            let mut docs = String::new();
-            gen_keys_doc(&mut docs, &sk.keys.0).unwrap();
-            quote! {
-                #[doc = #docs]
-            }
-        } else {
-            quote! {}
-        };
+        let docs = &sk.docs;
         quote! {
             #docs
             pub const fn #original_key(self) -> subkeys::#mod_ident::#key {
@@ -1204,6 +1214,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     };
 
     quote! {
+        #docs
         #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
         #[allow(non_camel_case_types, non_snake_case)]
         pub struct #type_ident(#enum_ident);
@@ -1272,17 +1283,40 @@ fn create_namespaces_types(
     options: &ParseOptions,
     gen_docs: bool,
 ) -> TokenStream {
+    let docs = if gen_docs {
+        use core::fmt::Write;
+        let mut docs = String::from("# Namespaces :\n");
+        for ns in namespaces {
+            writeln!(&mut docs, "- `{}`", ns.key.name).unwrap();
+        }
+        quote! {
+            #[doc = #docs]
+        }
+    } else {
+        quote! {}
+    };
+
     let namespaces = namespaces
         .iter()
         .map(|ns| {
             let namespace_module_ident = create_namespace_mod_ident(&ns.key.ident);
-            (ns, namespace_module_ident)
+            let docs = if gen_docs {
+                let keys = keys.get(&ns.key).unwrap_at("create_namespaces_types_2");
+                let mut docs = String::new();
+                gen_keys_doc(&mut docs, &keys.0).unwrap();
+                quote! {
+                    #[doc = #docs]
+                }
+            } else {
+                quote! {}
+            };
+            (ns, namespace_module_ident, docs)
         })
         .collect::<Vec<_>>();
 
     let namespaces_ts = namespaces
         .iter()
-        .map(|(namespace, namespace_module_ident)| {
+        .map(|(namespace, namespace_module_ident, docs)| {
             let keys = keys
                 .get(&namespace.key)
                 .unwrap_at("create_namespaces_types_1");
@@ -1298,6 +1332,7 @@ fn create_namespaces_types(
                 Some(&namespace.key.name),
                 translations_uri,
                 options,
+                docs,
                 gen_docs,
             );
 
@@ -1310,31 +1345,22 @@ fn create_namespaces_types(
             }
         });
 
-    let namespaces_accessors = namespaces
-        .iter()
-        .map(|(namespace, namespace_module_ident)| {
-            let key = &namespace.key;
-            let docs = if gen_docs {
-                let keys = keys.get(key).unwrap_at("create_namespaces_types_2");
-                let mut docs = String::new();
-                gen_keys_doc(&mut docs, &keys.0).unwrap();
+    let namespaces_accessors =
+        namespaces
+            .iter()
+            .map(|(namespace, namespace_module_ident, docs)| {
+                let key = &namespace.key;
                 quote! {
-                    #[doc = #docs]
+                    #docs
+                    pub fn #key(self) -> namespaces::#namespace_module_ident::#key {
+                        namespaces::#namespace_module_ident::#key::__new_internal(self.0)
+                    }
                 }
-            } else {
-                quote! {}
-            };
-            quote! {
-                #docs
-                pub fn #key(self) -> namespaces::#namespace_module_ident::#key {
-                    namespaces::#namespace_module_ident::#key::__new_internal(self.0)
-                }
-            }
-        });
+            });
 
-    let translations_unit_variants = namespaces.iter().map(|(ns, _)| ns.key.to_token_stream());
+    let translations_unit_variants = namespaces.iter().map(|(ns, _, _)| ns.key.to_token_stream());
 
-    let as_str_match_arms = namespaces.iter().map(|(ns, _)| {
+    let as_str_match_arms = namespaces.iter().map(|(ns, _, _)| {
         let ns_ident = &ns.key.ident;
         let ns_name = &ns.key.name;
         quote! {
@@ -1342,7 +1368,7 @@ fn create_namespaces_types(
         }
     });
 
-    let deserialize_match_arms = namespaces.iter().map(|(ns, _)| {
+    let deserialize_match_arms = namespaces.iter().map(|(ns, _, _)| {
         let ns_ident = &ns.key.ident;
         let ns_name = &ns.key.name;
         quote! {
@@ -1350,7 +1376,7 @@ fn create_namespaces_types(
         }
     });
 
-    let get_strings_match_arms = namespaces.iter().map(|(ns, namespace_module_ident)| {
+    let get_strings_match_arms = namespaces.iter().map(|(ns, namespace_module_ident, _)| {
         let ns_ident = &ns.key.ident;
         let maybe_await = cfg!(all(feature = "dynamic_load", feature = "csr")).then(|| quote!(.await));
         quote! {
@@ -1378,7 +1404,7 @@ fn create_namespaces_types(
     };
 
     let init_translations = if cfg!(all(feature = "dynamic_load", feature = "hydrate")) {
-        let match_arms = namespaces.iter().map(|(ns, namespace_module_ident)| {
+        let match_arms = namespaces.iter().map(|(ns, namespace_module_ident, _)| {
             let ns_ident = &ns.key.ident;
             quote! {
                 #translation_unit_enum_ident::#ns_ident => namespaces::#namespace_module_ident::#ns_ident::__init_translations__(locale, (), values)
@@ -1424,9 +1450,9 @@ fn create_namespaces_types(
             #(
                 #namespaces_ts
             )*
-
         }
 
+        #docs
         #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
         #[allow(non_snake_case)]
         pub struct #keys_ident(#enum_ident);
@@ -1523,19 +1549,31 @@ fn create_locale_type(
             options,
             gen_docs,
         ),
-        BuildersKeys::Locales { locales, keys } => create_locale_type_inner::<true>(
-            keys_ident,
-            None,
-            enum_ident,
-            translation_unit_enum_ident,
-            locales,
-            &keys.0,
-            &mut KeyPath::new(None),
-            None,
-            translations_uri,
-            options,
-            gen_docs,
-        ),
+        BuildersKeys::Locales { locales, keys } => {
+            let docs = if gen_docs {
+                let mut docs = String::new();
+                gen_keys_doc(&mut docs, &keys.0).unwrap();
+                quote! {
+                    #[doc = #docs]
+                }
+            } else {
+                quote! {}
+            };
+            create_locale_type_inner::<true>(
+                keys_ident,
+                None,
+                enum_ident,
+                translation_unit_enum_ident,
+                locales,
+                &keys.0,
+                &mut KeyPath::new(None),
+                None,
+                translations_uri,
+                options,
+                &docs,
+                gen_docs,
+            )
+        }
     }
 }
 

--- a/leptos_i18n_macro/src/load_locales/declare_locales.rs
+++ b/leptos_i18n_macro/src/load_locales/declare_locales.rs
@@ -46,7 +46,8 @@ pub fn declare_locales(tokens: proc_macro::TokenStream) -> proc_macro::TokenStre
         tracked_files: None,
     };
 
-    let result = leptos_i18n_codegen::gen_code(&parsed_locales, Some(&crate_path), true, None);
+    let result =
+        leptos_i18n_codegen::gen_code(&parsed_locales, Some(&crate_path), true, None, true);
     match result {
         Ok(ts) => ts.into(),
         Err(err) => {

--- a/leptos_i18n_macro/src/load_locales/mod.rs
+++ b/leptos_i18n_macro/src/load_locales/mod.rs
@@ -36,5 +36,5 @@ pub fn load_locales() -> Result<TokenStream> {
     let parsed_locales =
         leptos_i18n_parser::parse_locales::parse_locales(Some(manifest_dir_path), cfg)?;
 
-    leptos_i18n_codegen::gen_code(&parsed_locales, None, true, None)
+    leptos_i18n_codegen::gen_code(&parsed_locales, None, true, None, true)
 }

--- a/tests/namespaces/src/scoped.rs
+++ b/tests/namespaces/src/scoped.rs
@@ -27,3 +27,19 @@ fn scoped_sub_subkeys() {
     let fr = td!(fr_scope, subkey_3, count = 4);
     assert_eq_rendered!(fr, "4");
 }
+
+#[test]
+fn defined_scope() {
+    type FirstNamespaceScope = define_scope!(crate::i18n, first_namespace);
+
+    let locale = Locale::en.scope::<FirstNamespaceScope>();
+
+    let en = td!(locale, click_to_change_lang);
+    assert_eq_rendered!(en, "Click to change language");
+
+    type SubkeysScope = define_scope!(crate::i18n, second_namespace.subkeys);
+
+    let en_scope = Locale::en.scope::<SubkeysScope>();
+    let en = td!(en_scope, subkey_3, count = 0);
+    assert_eq_rendered!(en, "0");
+}


### PR DESCRIPTION
Generate docs for the `Locale` enum, for the subkeys, and the interpolation to display the available keys or required arguments:

<img width="378" height="375" alt="image" src="https://github.com/user-attachments/assets/78cb0e9a-09aa-41d9-933d-9540e4032793" />
<img width="662" height="206" alt="image" src="https://github.com/user-attachments/assets/0a0d1fcc-0640-4a2e-8e20-8fb51e58c859" />
<img width="555" height="292" alt="image" src="https://github.com/user-attachments/assets/5e425889-a110-4796-99a6-dbc8ba545699" />
<img width="481" height="220" alt="image" src="https://github.com/user-attachments/assets/21c896ae-ad57-4963-aa60-0e0997919087" />
<img width="748" height="297" alt="image" src="https://github.com/user-attachments/assets/09db30cb-a048-45bc-8eca-2de2f63b5ece" />


Might improve UX