### PR TITLE
feat: add reverse_lookup code and example

### DIFF
--- a/examples/csr/reverse_lookup/.gitignore
+++ b/examples/csr/reverse_lookup/.gitignore
@@ -1,0 +1,10 @@
+Cargo.lock
+target
+dist
+!.vscode
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+package-lock.json

--- a/examples/csr/reverse_lookup/Cargo.toml
+++ b/examples/csr/reverse_lookup/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "reverse_lookup"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+leptos = { version = "0.8.15", features = ["csr"] }
+leptos_i18n = { path = "../../../leptos_i18n", features = ["csr", "reverse_lookup"] }
+gloo-net = { version = "0.6", features = ["http"] }
+console_error_panic_hook = { version = "0.1" }
+
+[build-dependencies.leptos_i18n_build]
+path = "../../../leptos_i18n_build"
+features = ["pretty_print", "csr"]

--- a/examples/csr/reverse_lookup/README.md
+++ b/examples/csr/reverse_lookup/README.md
@@ -1,0 +1,13 @@
+# Reverse Lookup Example
+
+This example demonstrates how to use `translation_map_builder` (behind the `reverse_lookup` feature) to translate dynamic strings received at runtime from a server you don't control.
+
+It fetches a string from an external API (httpbin.org) and uses locale JSON files to build a map from the default locale's values to the current locale's values.
+
+## How to run
+
+Simply use `trunk` to run it:
+
+```bash
+trunk serve --open
+```

--- a/examples/csr/reverse_lookup/build.rs
+++ b/examples/csr/reverse_lookup/build.rs
@@ -1,0 +1,25 @@
+use leptos_i18n_build::{Config, TranslationsInfos};
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=Cargo.toml");
+
+    let i18n_mod_directory = PathBuf::from(std::env::var_os("OUT_DIR").unwrap()).join("i18n");
+
+    let cfg = Config::new("en")?
+        .add_locale("fr")?
+        .add_locale("zh")?
+        .add_locale("es")?;
+
+    let translations_infos = TranslationsInfos::parse(cfg)?;
+
+    translations_infos.emit_diagnostics();
+
+    translations_infos.rerun_if_locales_changed();
+
+    translations_infos.generate_i18n_module(i18n_mod_directory)?;
+
+    Ok(())
+}

--- a/examples/csr/reverse_lookup/index.html
+++ b/examples/csr/reverse_lookup/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body></body>
+</html>

--- a/examples/csr/reverse_lookup/locales/en.json
+++ b/examples/csr/reverse_lookup/locales/en.json
@@ -1,0 +1,5 @@
+{
+    "select_lang": "Select a language",
+    "server_says": "The server says:",
+    "hello_world": "hello world"
+}

--- a/examples/csr/reverse_lookup/locales/es.json
+++ b/examples/csr/reverse_lookup/locales/es.json
@@ -1,0 +1,5 @@
+{
+    "select_lang": "Selecciona un idioma",
+    "server_says": "El servidor dice:",
+    "hello_world": "hola mundo"
+}

--- a/examples/csr/reverse_lookup/locales/fr.json
+++ b/examples/csr/reverse_lookup/locales/fr.json
@@ -1,0 +1,5 @@
+{
+    "select_lang": "Choisir une langue",
+    "server_says": "Le serveur dit :",
+    "hello_world": "bonjour le monde"
+}

--- a/examples/csr/reverse_lookup/locales/zh.json
+++ b/examples/csr/reverse_lookup/locales/zh.json
@@ -1,0 +1,5 @@
+{
+    "select_lang": "选择语言",
+    "server_says": "服务器说：",
+    "hello_world": "你好世界"
+}

--- a/examples/csr/reverse_lookup/src/app.rs
+++ b/examples/csr/reverse_lookup/src/app.rs
@@ -1,0 +1,69 @@
+use crate::i18n::*;
+use leptos::prelude::*;
+use leptos_i18n::translation_map_builder;
+
+#[component]
+#[allow(non_snake_case)]
+pub fn App() -> impl IntoView {
+    view! {
+        <I18nContextProvider>
+            <Inner />
+        </I18nContextProvider>
+    }
+}
+
+#[component]
+#[allow(non_snake_case)]
+fn Inner() -> impl IntoView {
+    let i18n = use_i18n();
+
+    let on_change = move |ev: leptos::ev::Event| {
+        let locale = match event_target_value(&ev).as_str() {
+            "fr" => Locale::fr,
+            "zh" => Locale::zh,
+            "es" => Locale::es,
+            _ => Locale::en,
+        };
+        i18n.set_locale(locale);
+    };
+
+    // Fetch "hello world" from a server we don't control.
+    let response = LocalResource::new(|| async {
+        gloo_net::http::Request::get("https://httpbin.org/base64/aGVsbG8gd29ybGQ=")
+            .send()
+            .await
+            .ok()?
+            .text()
+            .await
+            .ok()
+    });
+
+    // Map English string values to the current locale. Recomputes on locale change.
+    let lookup = Memo::new(move |_| {
+        let en = include_str!("../locales/en.json");
+        let target = match i18n.get_locale() {
+            Locale::en => en,
+            Locale::fr => include_str!("../locales/fr.json"),
+            Locale::zh => include_str!("../locales/zh.json"),
+            Locale::es => include_str!("../locales/es.json"),
+        };
+        translation_map_builder(en, target).expect("locale JSON is valid")
+    });
+
+    view! {
+        <label>{t!(i18n, select_lang)}": "</label>
+        <select on:change=on_change>
+            <option value="en">"English"</option>
+            <option value="fr">"Français"</option>
+            <option value="zh">"中文"</option>
+            <option value="es">"Español"</option>
+        </select>
+        <p>{t!(i18n, server_says)}</p>
+        <p>{move || {
+            response.read().as_ref().map(|r| match r {
+                Some(text) => lookup.read().get(text).cloned().unwrap_or_else(|| text.clone()),
+                None => "Failed to fetch".to_string(),
+            })
+        }}</p>
+    }
+}

--- a/examples/csr/reverse_lookup/src/main.rs
+++ b/examples/csr/reverse_lookup/src/main.rs
@@ -1,0 +1,10 @@
+#![deny(warnings)]
+
+pub mod app;
+include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
+
+fn main() {
+    use app::App;
+    console_error_panic_hook::set_once();
+    leptos::mount::mount_to_body(|| leptos::view! { <App /> })
+}

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -119,6 +119,7 @@ dynamic_load = [
   "dep:futures",
   "dep:serde_json",
 ]
+reverse_lookup = ["dep:serde_json"]
 
 
 # Features needed for the doctests

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -125,9 +125,18 @@ pub mod locale;
 mod locale_traits;
 mod macro_helpers;
 mod macros;
+#[cfg(feature = "reverse_lookup")]
+mod reverse_lookup;
 mod scopes;
 
 pub use macro_helpers::formatting;
+
+/// Build a map from default-locale values to target-locale values,
+/// useful for translating dynamic strings received at runtime.
+///
+/// Requires the `reverse_lookup` feature.
+#[cfg(feature = "reverse_lookup")]
+pub use reverse_lookup::translation_map_builder;
 
 pub use locale_traits::{Direction, Locale, LocaleKeys};
 

--- a/leptos_i18n/src/reverse_lookup.rs
+++ b/leptos_i18n/src/reverse_lookup.rs
@@ -1,0 +1,42 @@
+/// Build a [`HashMap`](std::collections::HashMap) mapping default-locale string values to target-locale string values.
+///
+/// Walks two JSON trees (parsed from locale files) in parallel and collects
+/// all leaf string pairs where the values differ.
+///
+/// # Errors
+///
+/// Returns a [`serde_json::Error`] if either JSON string is malformed.
+pub fn translation_map_builder(
+    default_json: &str,
+    target_json: &str,
+) -> Result<std::collections::HashMap<String, String>, serde_json::Error> {
+    use std::collections::HashMap;
+
+    fn collect_pairs(
+        default: &serde_json::Value,
+        target: &serde_json::Value,
+        map: &mut HashMap<String, String>,
+    ) {
+        match (default, target) {
+            (serde_json::Value::Object(d), serde_json::Value::Object(t)) => {
+                for (key, d_val) in d {
+                    if let Some(t_val) = t.get(key) {
+                        collect_pairs(d_val, t_val, map);
+                    }
+                }
+            }
+            (serde_json::Value::String(d), serde_json::Value::String(t)) => {
+                if d != t {
+                    map.insert(d.clone(), t.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let default: serde_json::Value = serde_json::from_str(default_json)?;
+    let target: serde_json::Value = serde_json::from_str(target_json)?;
+    let mut map = HashMap::new();
+    collect_pairs(&default, &target, &mut map);
+    Ok(map)
+}


### PR DESCRIPTION
## Add `reverse_lookup` (code and example)

- Add `reverse_lookup` feature with `translation_map_builder` — a utility that builds a `HashMap<String, String>` mapping default-locale string values to target-locale string values by walking two locale JSON trees in parallel
- Add CSR example (`examples/csr/reverse_lookup`) demonstrating how to translate dynamic strings received at runtime from an external API (httpbin.org) using the new feature

## Motivation

An application receiving strings from a server it doesn't control may need runtime translation. Like the existing `t!` macro, this requires compile-time json, however `translation_map_builder` fills a gap by letting you look up translations by *value* instead of by key.

## Changes

- **`leptos_i18n/src/reverse_lookup.rs`** — new module with `translation_map_builder(default_json, target_json) -> Result<HashMap<String, String>, serde_json::Error>`
- **`leptos_i18n/src/lib.rs`** — conditionally compile and re-export `translation_map_builder` behind `reverse_lookup` feature
- **`leptos_i18n/Cargo.toml`** — add `reverse_lookup` feature gated on `dep:serde_json`
- **`examples/csr/reverse_lookup/`** — full CSR example with 4 locales (en, fr, zh, es), fetches "hello world" from httpbin and translates it reactively on locale change