### PR TITLE
fix(codegen): silence clippy lints on expect

### DIFF
--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -233,6 +233,7 @@ pub fn load_locales(
     Ok(quote! {
         pub mod i18n {
             #![allow(unused_braces)]
+            #![allow(clippy::expect_used)]
             #![allow(clippy::type_complexity)]
             #![allow(clippy::let_and_return)]
             #![allow(clippy::unit_arg)]


### PR DESCRIPTION
We use `deny(expect_used)` in our leptos crates because AFAIK leptos is still `panic = abort`, so any panics crash the whole WASM module. This conflicts with leptos_i18n_codegen because it generates code that uses `.expect`. This PR is just a one-line change to add `#![allow(clippy::expect_used)]` to the generated source code