### PR TITLE
Default-locale prefix strategies for `I18nRoute`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,11 @@ dependencies = [
 name = "leptos_i18n_router"
 version = "0.6.2"
 dependencies = [
+ "http 0.2.12",
+ "http 1.4.0",
  "leptos",
+ "leptos_actix",
+ "leptos_axum",
  "leptos_i18n",
  "leptos_router",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ leptos_i18n_build = { path = "./leptos_i18n_build", version = "0.6.2", default-f
 leptos = { version = "0.8", default-features = false }
 leptos_router = { version = "0.8", default-features = false }
 leptos_meta = { version = "0.8", default-features = false }
+leptos_axum = { version = "0.8", default-features = false }
+leptos_actix = { version = "0.8", default-features = false }
 
 # icu
 icu = { version = "2.2", default-features = false }
@@ -63,3 +65,5 @@ typed-builder = { default-features = false, version = "0.23" }
 proc-macro2 = { default-features = false, version = "1.0" }
 serde = { default-features = false, version = "1.0" }
 js-sys = { default-features = false, version = "0.3" }
+axum_http = { default-features = false, version = "1.4", package = "http" }
+actix_http = { default-features = false, version = "0.2", package = "http" }

--- a/docs/book/src/usage/07_router.md
+++ b/docs/book/src/usage/07_router.md
@@ -43,9 +43,31 @@ If a locale is found those ways and it is not the default locale, this will trig
 
 This means if you access `"/counter"` with the cookie set to `fr` (default being `en`), then you will be redirected to `"/fr/counter"`.
 
+## Prefixing the Default Locale
+
+By default the default locale is served *without* a prefix (`/`, `/counter`), while every other locale is prefixed (`/fr`, `/fr/counter`). If you would rather have *every* locale prefixed, including the default one, pass the `prefix_default` prop:
+
+```rust,ignore
+use leptos_i18n_router::{I18nRoute, PrefixDefault};
+
+view! {
+    <I18nRoute<Locale, _, _> view=Outlet prefix_default=PrefixDefault::Always>
+        <Route path=path!("") view=Home />
+        <Route path=path!("counter") view=Counter />
+    </I18nRoute<Locale, _, _>>
+}
+```
+
+`PrefixDefault` has two variants:
+
+- `PrefixDefault::Never` (the default): the default locale is unprefixed. With `en` as default, the generated routes are `/`, `/counter`, `/en`, `/en/counter`, `/fr`, `/fr/counter`.
+- `PrefixDefault::Always`: the default locale is prefixed like the others. The unprefixed routes are no longer generated, so the routes become `/en`, `/en/counter`, `/fr`, `/fr/counter`. Accessing an unprefixed URL such as `/counter` triggers a redirection to the prefixed form (`/en/counter`), which avoids duplicate-content URLs.
+
+The prop defaults to `PrefixDefault::Never`, so existing applications keep their current behavior without any change.
+
 ## Switching Locale
 
-Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely.
+Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely (unless `prefix_default=PrefixDefault::Always`, in which case the default locale keeps its prefix).
 
 ## State Keeping
 

--- a/docs/book/src/usage/07_router.md
+++ b/docs/book/src/usage/07_router.md
@@ -45,7 +45,7 @@ This means if you access `"/counter"` with the cookie set to `fr` (default being
 
 ## Prefixing the Default Locale
 
-By default the default locale is served *without* a prefix (`/`, `/counter`), while every other locale is prefixed (`/fr`, `/fr/counter`). If you would rather have *every* locale prefixed, including the default one, pass the `prefix_default` prop:
+By default the default locale is served _without_ a prefix (`/`, `/counter`), while every other locale is prefixed (`/fr`, `/fr/counter`). If you would rather have _every_ locale prefixed, including the default one, pass the `prefix_default` prop:
 
 ```rust,ignore
 use leptos_i18n_router::{I18nRoute, PrefixDefault};
@@ -60,10 +60,10 @@ view! {
 
 `PrefixDefault` has two variants:
 
-- `PrefixDefault::Never` (the default): the default locale is unprefixed. With `en` as default, the generated routes are `/`, `/counter`, `/en`, `/en/counter`, `/fr`, `/fr/counter`.
-- `PrefixDefault::Always`: the default locale is prefixed like the others. The unprefixed routes are no longer generated, so the routes become `/en`, `/en/counter`, `/fr`, `/fr/counter`. Accessing an unprefixed URL such as `/counter` triggers a redirection to the prefixed form (`/en/counter`), which avoids duplicate-content URLs.
+- `PrefixDefault::Never` (the default): the default locale is served unprefixed. Path prefixed with the default locale (`/{def}/..`) will be redirected to the unprefixed one (`/..`) and emit a 301 status code on the server.
+- `PrefixDefault::Always`: the default locale is served prefixed like the others. Unprefixed paths (`/..`) redirects to a path prefixed with the resolved locale (`/{loc}/..`) and emit a 302 status code on the server.
 
-The prop defaults to `PrefixDefault::Never`, so existing applications keep their current behavior without any change.
+> note: The 301 redirect is only possible if you enabled the "axum"/"actix" feature on `leptos_i18n_router`, if not then a 302 redirect is emitted, as by default the server supplied redirect function only emits 302, so we need to patch it to emit 301.
 
 ## Switching Locale
 

--- a/docs/book/src/usage/07_router.md
+++ b/docs/book/src/usage/07_router.md
@@ -62,12 +62,34 @@ view! {
 
 - `PrefixDefault::Never` (the default): the default locale is unprefixed. With `en` as default, the generated routes are `/`, `/counter`, `/en`, `/en/counter`, `/fr`, `/fr/counter`.
 - `PrefixDefault::Always`: the default locale is prefixed like the others. The unprefixed routes are no longer generated, so the routes become `/en`, `/en/counter`, `/fr`, `/fr/counter`. Accessing an unprefixed URL such as `/counter` triggers a redirection to the prefixed form (`/en/counter`), which avoids duplicate-content URLs.
+- `PrefixDefault::AlwaysSplash`: like `Always`, every locale is prefixed (`/en`, `/fr`, …), **but** the unprefixed URLs are kept and *rendered* instead of being redirected — so you can show a language splash screen at the apex. The exception is when the visitor has an explicit locale cookie: they are redirected to `/{their_locale}/…`. See the next section.
 
 The prop defaults to `PrefixDefault::Never`, so existing applications keep their current behavior without any change.
 
+### Splash screen on the apex (`AlwaysSplash`)
+
+A common pattern is to show a language chooser on the apex domain for first-time visitors, while sending returning visitors straight to their preferred language. `PrefixDefault::AlwaysSplash` does exactly that:
+
+```rust,ignore
+use leptos_i18n_router::{I18nRoute, PrefixDefault};
+
+<I18nRoute<Locale, _, _> view=Outlet prefix_default=PrefixDefault::AlwaysSplash>
+    // Render a language chooser here for cookie-less visitors.
+    <Route path=path!("") view=LangSplash />
+    <Route path=path!("counter") view=Counter />
+</I18nRoute<Locale, _, _>>
+```
+
+The decision on an unprefixed URL is:
+
+- **A locale cookie is set** (the visitor previously chose a language): redirect to that locale's prefixed URL, e.g. `/` → `/fr`.
+- **No cookie**: render the unprefixed view as-is. The locale is *not* guessed-and-redirected from the `Accept-Language` header or `navigator`, so the visitor stays on the splash and can pick a language. Selecting one (via `i18n.set_locale(..)`) sets the cookie and navigates to the prefixed URL.
+
+This relies on `I18nContext::cookie_locale()`, which reports the locale stored in the cookie at initialization. Without the `cookie` feature there is never a cookie, so `AlwaysSplash` always renders the unprefixed view.
+
 ## Switching Locale
 
-Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely (unless `prefix_default=PrefixDefault::Always`, in which case the default locale keeps its prefix).
+Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely (unless `prefix_default` is `PrefixDefault::Always` or `PrefixDefault::AlwaysSplash`, in which case the default locale keeps its prefix).
 
 ## State Keeping
 

--- a/docs/book/src/usage/07_router.md
+++ b/docs/book/src/usage/07_router.md
@@ -58,45 +58,16 @@ view! {
 }
 ```
 
-`PrefixDefault` has three variants:
+`PrefixDefault` has two variants:
 
 - `PrefixDefault::Never` (the default): the default locale is unprefixed. With `en` as default, the generated routes are `/`, `/counter`, `/en`, `/en/counter`, `/fr`, `/fr/counter`.
 - `PrefixDefault::Always`: the default locale is prefixed like the others. The unprefixed routes are no longer generated, so the routes become `/en`, `/en/counter`, `/fr`, `/fr/counter`. Accessing an unprefixed URL such as `/counter` triggers a redirection to the prefixed form (`/en/counter`), which avoids duplicate-content URLs.
-- `PrefixDefault::AlwaysSplash`: like `Always`, every locale is prefixed (`/en`, `/fr`, …), **but** the unprefixed URLs are kept and *rendered* instead of being redirected — so you can show a language splash screen at the apex. The exception is when the visitor has an explicit locale cookie: they are redirected to `/{their_locale}/…`. See the next section.
 
 The prop defaults to `PrefixDefault::Never`, so existing applications keep their current behavior without any change.
 
-### Splash screen on the apex (`AlwaysSplash`)
-
-A common pattern is to show a language chooser on the apex domain for first-time visitors, while sending returning visitors straight to their preferred language. `PrefixDefault::AlwaysSplash` does exactly that:
-
-```rust,ignore
-use leptos_i18n_router::{I18nRoute, PrefixDefault};
-
-<I18nRoute<Locale, _, _> view=Outlet prefix_default=PrefixDefault::AlwaysSplash>
-    // Render a language chooser here for cookie-less visitors.
-    <Route path=path!("") view=LangSplash />
-    <Route path=path!("counter") view=Counter />
-</I18nRoute<Locale, _, _>>
-```
-
-The decision on an unprefixed URL is:
-
-- **A locale cookie is set** (the visitor previously chose a language): redirect to that locale's prefixed URL, e.g. `/` → `/fr`.
-- **No cookie**: render the unprefixed view as-is. The locale is *not* guessed-and-redirected from the `Accept-Language` header or `navigator`, so the visitor stays on the splash and can pick a language. Selecting one (via `i18n.set_locale(..)`) sets the cookie and navigates to the prefixed URL.
-
-The cookie redirect is performed **server-side only**, during SSR, as a real HTTP `302`, so a returning visitor is moved to `/{locale}/…` *before* the splash is ever rendered — no flash, no client-side "jump". The client never redirects away from an unprefixed URL on its own; this keeps the splash stable and avoids a jarring post-render navigation (in a CSR-only app there is no server redirect at all, so a cookie-holding visitor simply lands on the splash — redirect them yourself from the splash view if you need to).
-
-For the server-side redirect to fire, two things must be true:
-
-- The crate must actually be built for SSR: enable **`leptos_i18n_router/ssr`** in your server feature set (next to `leptos/ssr`, `leptos_router/ssr`, etc.). If it is missing, the router compiles without SSR support and silently skips the redirect.
-- The server must be able to read the cookie, which means enabling `leptos_i18n`'s `axum` or `actix` feature.
-
-This relies on `I18nContext::cookie_locale()`, which reports the locale stored in the cookie at initialization. Without the `cookie` feature there is never a cookie, so `AlwaysSplash` always renders the unprefixed view.
-
 ## Switching Locale
 
-Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely (unless `prefix_default` is `PrefixDefault::Always` or `PrefixDefault::AlwaysSplash`, in which case the default locale keeps its prefix).
+Switching locale updates the prefix accordingly. Switching from `en` to `fr` will set the prefix to `fr`, but switching to the default locale will remove the locale prefix entirely (unless `prefix_default=PrefixDefault::Always`, in which case the default locale keeps its prefix).
 
 ## State Keeping
 

--- a/docs/book/src/usage/07_router.md
+++ b/docs/book/src/usage/07_router.md
@@ -58,7 +58,7 @@ view! {
 }
 ```
 
-`PrefixDefault` has two variants:
+`PrefixDefault` has three variants:
 
 - `PrefixDefault::Never` (the default): the default locale is unprefixed. With `en` as default, the generated routes are `/`, `/counter`, `/en`, `/en/counter`, `/fr`, `/fr/counter`.
 - `PrefixDefault::Always`: the default locale is prefixed like the others. The unprefixed routes are no longer generated, so the routes become `/en`, `/en/counter`, `/fr`, `/fr/counter`. Accessing an unprefixed URL such as `/counter` triggers a redirection to the prefixed form (`/en/counter`), which avoids duplicate-content URLs.
@@ -84,6 +84,13 @@ The decision on an unprefixed URL is:
 
 - **A locale cookie is set** (the visitor previously chose a language): redirect to that locale's prefixed URL, e.g. `/` → `/fr`.
 - **No cookie**: render the unprefixed view as-is. The locale is *not* guessed-and-redirected from the `Accept-Language` header or `navigator`, so the visitor stays on the splash and can pick a language. Selecting one (via `i18n.set_locale(..)`) sets the cookie and navigates to the prefixed URL.
+
+The cookie redirect is performed **server-side only**, during SSR, as a real HTTP `302`, so a returning visitor is moved to `/{locale}/…` *before* the splash is ever rendered — no flash, no client-side "jump". The client never redirects away from an unprefixed URL on its own; this keeps the splash stable and avoids a jarring post-render navigation (in a CSR-only app there is no server redirect at all, so a cookie-holding visitor simply lands on the splash — redirect them yourself from the splash view if you need to).
+
+For the server-side redirect to fire, two things must be true:
+
+- The crate must actually be built for SSR: enable **`leptos_i18n_router/ssr`** in your server feature set (next to `leptos/ssr`, `leptos_router/ssr`, etc.). If it is missing, the router compiles without SSR support and silently skips the redirect.
+- The server must be able to read the cookie, which means enabling `leptos_i18n`'s `axum` or `actix` feature.
 
 This relies on `I18nContext::cookie_locale()`, which reports the locale stored in the cookie at initialization. Without the `cookie` feature there is never a cookie, so `AlwaysSplash` always renders the unprefixed view.
 

--- a/examples/ssr/routing_ssr/Cargo.toml
+++ b/examples/ssr/routing_ssr/Cargo.toml
@@ -41,9 +41,9 @@ ssr = [
   "dep:leptos_axum",
   "leptos/ssr",
   "leptos_meta/ssr",
-  "leptos_i18n/axum",
   "leptos_router/ssr",
-  "leptos_i18n_router/ssr",
+  "leptos_i18n/axum",
+  "leptos_i18n_router/axum",
   "leptos_i18n_build/ssr",
 ]
 

--- a/examples/ssr/routing_ssr/src/main.rs
+++ b/examples/ssr/routing_ssr/src/main.rs
@@ -3,9 +3,9 @@
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() {
-    use axum::{routing::post, Router};
+    use axum::{Router, routing::post};
     use leptos::prelude::*;
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::{LeptosRoutes, generate_route_list};
     use routing_ssr::{app::App, fileserv::file_and_error_handler};
     use tokio::net::TcpListener;
 

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -23,13 +23,6 @@ pub use leptos_use::UseLocalesOptions;
 #[derive(Debug, Clone, Copy)]
 struct AnyLocale(&'static str);
 
-/// Snapshot of the locale found in the cookie when the context was initialized,
-/// provided as a context value so consumers (e.g. the router) can tell whether
-/// the user has an explicitly stored locale preference. `None` when the `cookie`
-/// feature is disabled or no cookie was set.
-#[derive(Debug, Clone, Copy)]
-struct CookieLocale<L>(Option<L>);
-
 /// This context is the heart of the i18n system:
 ///
 /// It servers as a signal to the current locale and enable reactivity to locale change.
@@ -82,20 +75,6 @@ impl<L: Locale, S: Scope<L>> I18nContext<L, S> {
         {
             self.locale_signal.get_untracked()
         }
-    }
-
-    /// Return the locale that was read from the cookie when this context was
-    /// initialized, if any.
-    ///
-    /// This reflects an explicitly stored user preference (as opposed to a
-    /// locale guessed from the `Accept-Language` header or the `navigator`
-    /// API). It is a snapshot taken at initialization, not a reactive value.
-    /// Returns `None` when the `cookie` feature is disabled or no cookie was
-    /// set.
-    #[inline]
-    #[track_caller]
-    pub fn cookie_locale(self) -> Option<L> {
-        use_context::<CookieLocale<L>>().and_then(|c| c.0)
     }
 
     /// Return the keys for the current locale subscribing to any changes
@@ -205,13 +184,9 @@ const COOKIE_PREFERED_LANG: &str = "i18n_pref_locale";
 
 #[track_caller]
 fn init_context_inner<L: Locale>(
-    cookie_locale: Option<L>,
     set_lang_cookie: WriteSignal<Option<L>>,
     initial_locale: Memo<L>,
 ) -> I18nContext<L> {
-    // Expose the cookie locale snapshot so consumers like the router can tell
-    // whether the user has an explicitly stored preference.
-    provide_context(CookieLocale(cookie_locale));
     #[cfg(feature = "unified_contexts")]
     let locale_signal = {
         let init_loc = AnyLocale(initial_locale.get_untracked().as_str());
@@ -294,10 +269,10 @@ pub fn init_i18n_context_with_options<L: Locale>(options: I18nContextOptions<L>)
         (lang_cookie.into(), set_lang_cookie)
     };
 
-    let cookie_locale = lang_cookie.get_untracked();
-    let initial_locale = fetch_locale::fetch_locale(cookie_locale, ssr_lang_header_getter);
+    let initial_locale =
+        fetch_locale::fetch_locale(lang_cookie.get_untracked(), ssr_lang_header_getter);
 
-    init_context_inner::<L>(cookie_locale, set_lang_cookie, initial_locale)
+    init_context_inner::<L>(set_lang_cookie, initial_locale)
 }
 
 /// Initialize a `I18nContext` without providing it.
@@ -376,8 +351,6 @@ fn init_subcontext_with_options<L: Locale>(
 
     let parent_locale = signal_maybe_once_then(parent_locale, fetch_locale_memo);
 
-    let cookie_locale = lang_cookie.get_untracked();
-
     let initial_locale_listener = Memo::new(move |prev_locale| {
         let initial_locale = initial_locale.get();
         let cookie = lang_cookie.get_untracked();
@@ -391,7 +364,7 @@ fn init_subcontext_with_options<L: Locale>(
         }
     });
 
-    init_context_inner::<L>(cookie_locale, set_lang_cookie, initial_locale_listener)
+    init_context_inner::<L>(set_lang_cookie, initial_locale_listener)
 }
 
 #[track_caller]

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -23,6 +23,13 @@ pub use leptos_use::UseLocalesOptions;
 #[derive(Debug, Clone, Copy)]
 struct AnyLocale(&'static str);
 
+/// Snapshot of the locale found in the cookie when the context was initialized,
+/// provided as a context value so consumers (e.g. the router) can tell whether
+/// the user has an explicitly stored locale preference. `None` when the `cookie`
+/// feature is disabled or no cookie was set.
+#[derive(Debug, Clone, Copy)]
+struct CookieLocale<L>(Option<L>);
+
 /// This context is the heart of the i18n system:
 ///
 /// It servers as a signal to the current locale and enable reactivity to locale change.
@@ -75,6 +82,20 @@ impl<L: Locale, S: Scope<L>> I18nContext<L, S> {
         {
             self.locale_signal.get_untracked()
         }
+    }
+
+    /// Return the locale that was read from the cookie when this context was
+    /// initialized, if any.
+    ///
+    /// This reflects an explicitly stored user preference (as opposed to a
+    /// locale guessed from the `Accept-Language` header or the `navigator`
+    /// API). It is a snapshot taken at initialization, not a reactive value.
+    /// Returns `None` when the `cookie` feature is disabled or no cookie was
+    /// set.
+    #[inline]
+    #[track_caller]
+    pub fn cookie_locale(self) -> Option<L> {
+        use_context::<CookieLocale<L>>().and_then(|c| c.0)
     }
 
     /// Return the keys for the current locale subscribing to any changes
@@ -184,9 +205,13 @@ const COOKIE_PREFERED_LANG: &str = "i18n_pref_locale";
 
 #[track_caller]
 fn init_context_inner<L: Locale>(
+    cookie_locale: Option<L>,
     set_lang_cookie: WriteSignal<Option<L>>,
     initial_locale: Memo<L>,
 ) -> I18nContext<L> {
+    // Expose the cookie locale snapshot so consumers like the router can tell
+    // whether the user has an explicitly stored preference.
+    provide_context(CookieLocale(cookie_locale));
     #[cfg(feature = "unified_contexts")]
     let locale_signal = {
         let init_loc = AnyLocale(initial_locale.get_untracked().as_str());
@@ -269,10 +294,10 @@ pub fn init_i18n_context_with_options<L: Locale>(options: I18nContextOptions<L>)
         (lang_cookie.into(), set_lang_cookie)
     };
 
-    let initial_locale =
-        fetch_locale::fetch_locale(lang_cookie.get_untracked(), ssr_lang_header_getter);
+    let cookie_locale = lang_cookie.get_untracked();
+    let initial_locale = fetch_locale::fetch_locale(cookie_locale, ssr_lang_header_getter);
 
-    init_context_inner::<L>(set_lang_cookie, initial_locale)
+    init_context_inner::<L>(cookie_locale, set_lang_cookie, initial_locale)
 }
 
 /// Initialize a `I18nContext` without providing it.
@@ -351,6 +376,8 @@ fn init_subcontext_with_options<L: Locale>(
 
     let parent_locale = signal_maybe_once_then(parent_locale, fetch_locale_memo);
 
+    let cookie_locale = lang_cookie.get_untracked();
+
     let initial_locale_listener = Memo::new(move |prev_locale| {
         let initial_locale = initial_locale.get();
         let cookie = lang_cookie.get_untracked();
@@ -364,7 +391,7 @@ fn init_subcontext_with_options<L: Locale>(
         }
     });
 
-    init_context_inner::<L>(set_lang_cookie, initial_locale_listener)
+    init_context_inner::<L>(cookie_locale, set_lang_cookie, initial_locale_listener)
 }
 
 #[track_caller]

--- a/leptos_i18n_router/Cargo.toml
+++ b/leptos_i18n_router/Cargo.toml
@@ -14,8 +14,15 @@ readme = "../README.md"
 leptos_i18n = { workspace = true }
 leptos = { workspace = true, default-features = false }
 leptos_router = { workspace = true, default-features = false }
+leptos_actix = { workspace = true, default-features = false, optional = true }
+leptos_axum = { workspace = true, default-features = false, optional = true }
+actix_http = { workspace = true, default-features = false, optional = true }
+axum_http = { workspace = true, default-features = false, optional = true }
 
 [features]
+# default = ["axum"]
+axum = ["ssr", "leptos_i18n/axum", "dep:leptos_axum", "dep:axum_http"]
+actix = ["ssr", "leptos_i18n/actix", "dep:leptos_actix", "dep:actix_http"]
 ssr = ["leptos/ssr", "leptos_router/ssr", "leptos_i18n/ssr"]
 
 

--- a/leptos_i18n_router/src/components.rs
+++ b/leptos_i18n_router/src/components.rs
@@ -34,8 +34,13 @@ where
     Chil: MatchNestedRoutes + Send + Clone + 'static,
     L: Locale,
 {
-    let routes =
-        crate::routing::i18n_routing::<L, View, Chil>(base_path, children, ssr, view, prefix_default);
+    let routes = crate::routing::i18n_routing::<L, View, Chil>(
+        base_path,
+        children,
+        ssr,
+        view,
+        prefix_default,
+    );
     #[cfg(erase_components)]
     return routes.into_any_nested_route();
     #[cfg(not(erase_components))]

--- a/leptos_i18n_router/src/components.rs
+++ b/leptos_i18n_router/src/components.rs
@@ -5,6 +5,20 @@ use leptos_router::any_nested_route::IntoAnyNestedRoute;
 use leptos_router::{ChooseView, MatchNestedRoutes, SsrMode, components::RouteChildren};
 use std::marker::PhantomData;
 
+/// Whether the default locale gets a URL prefix like the others.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
+pub enum PrefixDefault {
+    /// Default locale is served unprefixed (`/path`).
+    /// Prefixed path for the default locale (`/{def}/path`) redirects to the unprefixed one.
+    /// Redirection sets the 301 status on servers
+    #[default]
+    Never,
+    /// Every locale is prefixed, including the default (`/{def}/path`).
+    /// Unprefixed path redirects to "/{loc}/path", where `loc` is the resolved locale for that client
+    /// Redirection sets the 302 status on servers
+    Always,
+}
+
 #[component(transparent)]
 pub fn I18nRoute<L, View, Chil>(
     /// The base path of this application.
@@ -23,9 +37,8 @@ pub fn I18nRoute<L, View, Chil>(
     ssr: SsrMode,
     #[prop(optional)] _marker: PhantomData<L>,
     /// Whether the default locale is prefixed. Defaults to `PrefixDefault::Never`
-    /// (back-compatible with current behavior).
-    #[prop(default = crate::PrefixDefault::Never)]
-    prefix_default: crate::PrefixDefault,
+    #[prop(optional)]
+    prefix_default: PrefixDefault,
     /// `children` may be empty or include nested routes.
     children: RouteChildren<Chil>,
 ) -> impl MatchNestedRoutes + Clone
@@ -34,8 +47,13 @@ where
     Chil: MatchNestedRoutes + Send + Clone + 'static,
     L: Locale,
 {
-    let routes =
-        crate::routing::i18n_routing::<L, View, Chil>(base_path, children, ssr, view, prefix_default);
+    let routes = crate::routing::i18n_routing::<L, View, Chil>(
+        base_path,
+        children,
+        ssr,
+        view,
+        prefix_default,
+    );
     #[cfg(erase_components)]
     return routes.into_any_nested_route();
     #[cfg(not(erase_components))]

--- a/leptos_i18n_router/src/components.rs
+++ b/leptos_i18n_router/src/components.rs
@@ -34,13 +34,8 @@ where
     Chil: MatchNestedRoutes + Send + Clone + 'static,
     L: Locale,
 {
-    let routes = crate::routing::i18n_routing::<L, View, Chil>(
-        base_path,
-        children,
-        ssr,
-        view,
-        prefix_default,
-    );
+    let routes =
+        crate::routing::i18n_routing::<L, View, Chil>(base_path, children, ssr, view, prefix_default);
     #[cfg(erase_components)]
     return routes.into_any_nested_route();
     #[cfg(not(erase_components))]

--- a/leptos_i18n_router/src/components.rs
+++ b/leptos_i18n_router/src/components.rs
@@ -22,6 +22,10 @@ pub fn I18nRoute<L, View, Chil>(
     #[prop(optional)]
     ssr: SsrMode,
     #[prop(optional)] _marker: PhantomData<L>,
+    /// Whether the default locale is prefixed. Defaults to `PrefixDefault::Never`
+    /// (back-compatible with current behavior).
+    #[prop(default = crate::PrefixDefault::Never)]
+    prefix_default: crate::PrefixDefault,
     /// `children` may be empty or include nested routes.
     children: RouteChildren<Chil>,
 ) -> impl MatchNestedRoutes + Clone
@@ -30,7 +34,8 @@ where
     Chil: MatchNestedRoutes + Send + Clone + 'static,
     L: Locale,
 {
-    let routes = crate::routing::i18n_routing::<L, View, Chil>(base_path, children, ssr, view);
+    let routes =
+        crate::routing::i18n_routing::<L, View, Chil>(base_path, children, ssr, view, prefix_default);
     #[cfg(erase_components)]
     return routes.into_any_nested_route();
     #[cfg(not(erase_components))]

--- a/leptos_i18n_router/src/lib.rs
+++ b/leptos_i18n_router/src/lib.rs
@@ -8,6 +8,9 @@ mod routing;
 
 pub use components::{I18nRoute, PrefixDefault};
 
+#[cfg(all(feature = "axum", feature = "actix"))]
+compile_error!("Both `axum` and `actix` features are enabled, please enable only one of them.");
+
 /// Create a localized path (one or more static segments) based on a locale.
 ///
 /// ```rust, ignore

--- a/leptos_i18n_router/src/lib.rs
+++ b/leptos_i18n_router/src/lib.rs
@@ -8,6 +8,16 @@ mod routing;
 
 pub use components::I18nRoute;
 
+/// Whether the default locale gets a URL prefix like the others.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PrefixDefault {
+    /// Default locale is served unprefixed (`/path`). Current behavior.
+    #[default]
+    Never,
+    /// Every locale is prefixed, including the default (`/fr/path`).
+    Always,
+}
+
 /// Create a localized path (one or more static segments) based on a locale.
 ///
 /// ```rust, ignore

--- a/leptos_i18n_router/src/lib.rs
+++ b/leptos_i18n_router/src/lib.rs
@@ -6,17 +6,7 @@
 mod components;
 mod routing;
 
-pub use components::I18nRoute;
-
-/// Whether the default locale gets a URL prefix like the others.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum PrefixDefault {
-    /// Default locale is served unprefixed (`/path`). Current behavior.
-    #[default]
-    Never,
-    /// Every locale is prefixed, including the default (`/fr/path`).
-    Always,
-}
+pub use components::{I18nRoute, PrefixDefault};
 
 /// Create a localized path (one or more static segments) based on a locale.
 ///

--- a/leptos_i18n_router/src/lib.rs
+++ b/leptos_i18n_router/src/lib.rs
@@ -15,19 +15,7 @@ pub enum PrefixDefault {
     #[default]
     Never,
     /// Every locale is prefixed, including the default (`/fr/path`).
-    ///
-    /// An unprefixed request is redirected to the resolved locale's prefixed
-    /// URL, regardless of how that locale was resolved.
     Always,
-    /// Every locale is prefixed, but the unprefixed apex (and other unprefixed
-    /// paths) are *rendered* rather than redirected — letting you show a
-    /// language splash screen — **unless** the user has an explicit locale
-    /// cookie, in which case they are redirected to that locale's prefix.
-    ///
-    /// In other words: a first-time visitor with no cookie stays on the
-    /// unprefixed URL (show them a chooser); a returning visitor with a cookie
-    /// is sent to `/{their_locale}/…`.
-    AlwaysSplash,
 }
 
 /// Create a localized path (one or more static segments) based on a locale.

--- a/leptos_i18n_router/src/lib.rs
+++ b/leptos_i18n_router/src/lib.rs
@@ -15,7 +15,19 @@ pub enum PrefixDefault {
     #[default]
     Never,
     /// Every locale is prefixed, including the default (`/fr/path`).
+    ///
+    /// An unprefixed request is redirected to the resolved locale's prefixed
+    /// URL, regardless of how that locale was resolved.
     Always,
+    /// Every locale is prefixed, but the unprefixed apex (and other unprefixed
+    /// paths) are *rendered* rather than redirected — letting you show a
+    /// language splash screen — **unless** the user has an explicit locale
+    /// cookie, in which case they are redirected to that locale's prefix.
+    ///
+    /// In other words: a first-time visitor with no cookie stays on the
+    /// unprefixed URL (show them a chooser); a returning visitor with a cookie
+    /// is sent to `/{their_locale}/…`.
+    AlwaysSplash,
 }
 
 /// Create a localized path (one or more static segments) based on a locale.

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -315,19 +315,16 @@ fn correct_locale_prefix_effect<L: Locale>(
 ) -> impl Fn(Option<()>) + 'static {
     let location = use_location();
     let navigate = use_navigate();
-    let cookie_locale = i18n.cookie_locale();
     move |_| {
         let path_locale = location
             .pathname
             .with(|path| get_locale_from_path::<L>(path, base_path));
         let current_locale = i18n.get_locale_untracked();
 
-        // Splash mode: a cookie-less visitor on an unprefixed URL stays put (we
-        // render the splash) instead of being navigated to a guessed locale.
-        if prefix_default == PrefixDefault::AlwaysSplash
-            && path_locale.is_none()
-            && cookie_locale.is_none()
-        {
+        // Splash mode: we never navigate away from an unprefixed URL on the
+        // client. The redirect for a returning visitor (cookie set) is done
+        // server-side in `maybe_redirect`.
+        if prefix_default == PrefixDefault::AlwaysSplash && path_locale.is_none() {
             return;
         }
 

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -197,7 +197,7 @@ fn get_new_path<L: Locale>(
     let mut new_path = location.pathname.with_untracked(|path_name| {
         let mut path_builder = PathBuilder::default();
         path_builder.push(base_path);
-        if new_locale != L::default() || prefix_default != PrefixDefault::Never {
+        if new_locale != L::default() || prefix_default == PrefixDefault::Always {
             path_builder.push(new_locale.as_str());
         }
         if let Some(path_rest) = path_name.strip_prefix(base_path) {
@@ -240,8 +240,6 @@ fn get_new_path<L: Locale>(
             new_path.push_str(search);
         }
     });
-
-    #[cfg(not(feature = "ssr"))]
     location.hash.with_untracked(|hash| {
         if !hash.is_empty() {
             // Remove leading '#' if present
@@ -323,13 +321,6 @@ fn correct_locale_prefix_effect<L: Locale>(
             .with(|path| get_locale_from_path::<L>(path, base_path));
         let current_locale = i18n.get_locale_untracked();
 
-        // Splash mode: we never navigate away from an unprefixed URL on the
-        // client. The redirect for a returning visitor (cookie set) is done
-        // server-side in `maybe_redirect`.
-        if prefix_default == PrefixDefault::AlwaysSplash && path_locale.is_none() {
-            return;
-        }
-
         if current_locale == path_locale.unwrap_or_default() {
             return;
         }
@@ -394,7 +385,6 @@ fn check_history_change<L: Locale>(
 
 fn maybe_redirect<L: Locale>(
     previously_resolved_locale: L,
-    cookie_locale: Option<L>,
     base_path: &str,
     segments: &RouteSegments<L>,
     prefix_default: PrefixDefault,
@@ -403,17 +393,10 @@ fn maybe_redirect<L: Locale>(
     if cfg!(not(feature = "ssr")) {
         return None;
     }
-    let should_redirect = match prefix_default {
-        // A default-locale request is already at its canonical unprefixed URL,
-        // so no redirect is needed; non-default locales get redirected.
-        PrefixDefault::Never => previously_resolved_locale != L::default(),
-        // Every unprefixed request is redirected to its prefixed form.
-        PrefixDefault::Always => true,
-        // Only redirect when the user has an explicit cookie preference;
-        // otherwise render the unprefixed view (e.g. a language splash screen).
-        PrefixDefault::AlwaysSplash => cookie_locale.is_some(),
-    };
-    if !should_redirect {
+    // Under `Never`, a default-locale request is already at its canonical
+    // unprefixed URL, so no redirect is needed. Under `Always`, an unprefixed
+    // default-locale request must be redirected to its prefixed form.
+    if prefix_default == PrefixDefault::Never && previously_resolved_locale == L::default() {
         return None;
     }
     let new_path = get_new_path(
@@ -462,7 +445,6 @@ where
     let i18n = use_i18n_context::<L>();
 
     let previously_resolved_locale = i18n.get_locale_untracked();
-    let cookie_locale = i18n.cookie_locale();
 
     // By precedence if there is a locale prefix in the URL it takes priority.
     // if there is none, use the one computed beforehand.
@@ -471,13 +453,7 @@ where
         i18n.set_locale(locale);
         None
     } else {
-        maybe_redirect(
-            previously_resolved_locale,
-            cookie_locale,
-            base_path,
-            &segments,
-            prefix_default,
-        )
+        maybe_redirect(previously_resolved_locale, base_path, &segments, prefix_default)
     };
 
     // This variable is there to sync history changes, because we step out of the Leptos routes reactivity we don't get forward and backward history changes triggers
@@ -727,12 +703,8 @@ where
         });
         // Under `Always`, the default locale is served prefixed like every other
         // locale (already generated below), so we must NOT also emit an unprefixed
-        // route for it — that would create duplicate-content URLs and unprefixed
-        // requests are redirected anyway.
-        // Under `Never` and `AlwaysSplash` the unprefixed routes are kept: `Never`
-        // serves the default locale there, and `AlwaysSplash` renders them (e.g. a
-        // language splash) for cookie-less visitors instead of redirecting.
-        let emit_default_locale_routes = self.prefix_default != PrefixDefault::Always;
+        // route for it — that would create duplicate-content URLs.
+        let emit_default_locale_routes = self.prefix_default == PrefixDefault::Never;
         let default_locale_routes = std::iter::once_with(move || {
             set_current_route_locale(L::default());
             MatchNestedRoutes::generate_routes(&self.route)

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -240,6 +240,8 @@ fn get_new_path<L: Locale>(
             new_path.push_str(search);
         }
     });
+
+    #[cfg(not(feature = "ssr"))]
     location.hash.with_untracked(|hash| {
         if !hash.is_empty() {
             // Remove leading '#' if present

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -543,10 +543,19 @@ fn redirect(path: String, permanent_redirect: bool) {
     fn redirect_via_comp(path: String) {
         let props = leptos::component::component_props_builder(&Redirect)
             .path(path)
+            .options(NavigateOptions {
+                replace: true,
+                ..Default::default()
+            })
             .build();
         Redirect(props)
     }
-    if permanent_redirect && cfg!(any(feature = "actix", feature = "axum")) {
+    if permanent_redirect
+        && cfg!(any(
+            all(feature = "actix", not(feature = "axum")),
+            all(feature = "axum", not(feature = "actix"))
+        ))
+    {
         #[cfg(all(feature = "axum", not(feature = "actix")))]
         {
             if let Some(res) = use_context::<leptos_axum::ResponseOptions>() {

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -197,7 +197,7 @@ fn get_new_path<L: Locale>(
     let mut new_path = location.pathname.with_untracked(|path_name| {
         let mut path_builder = PathBuilder::default();
         path_builder.push(base_path);
-        if new_locale != L::default() || prefix_default == PrefixDefault::Always {
+        if new_locale != L::default() || prefix_default != PrefixDefault::Never {
             path_builder.push(new_locale.as_str());
         }
         if let Some(path_rest) = path_name.strip_prefix(base_path) {
@@ -315,11 +315,21 @@ fn correct_locale_prefix_effect<L: Locale>(
 ) -> impl Fn(Option<()>) + 'static {
     let location = use_location();
     let navigate = use_navigate();
+    let cookie_locale = i18n.cookie_locale();
     move |_| {
         let path_locale = location
             .pathname
             .with(|path| get_locale_from_path::<L>(path, base_path));
         let current_locale = i18n.get_locale_untracked();
+
+        // Splash mode: a cookie-less visitor on an unprefixed URL stays put (we
+        // render the splash) instead of being navigated to a guessed locale.
+        if prefix_default == PrefixDefault::AlwaysSplash
+            && path_locale.is_none()
+            && cookie_locale.is_none()
+        {
+            return;
+        }
 
         if current_locale == path_locale.unwrap_or_default() {
             return;
@@ -385,6 +395,7 @@ fn check_history_change<L: Locale>(
 
 fn maybe_redirect<L: Locale>(
     previously_resolved_locale: L,
+    cookie_locale: Option<L>,
     base_path: &str,
     segments: &RouteSegments<L>,
     prefix_default: PrefixDefault,
@@ -393,10 +404,17 @@ fn maybe_redirect<L: Locale>(
     if cfg!(not(feature = "ssr")) {
         return None;
     }
-    // Under `Never`, a default-locale request is already at its canonical
-    // unprefixed URL, so no redirect is needed. Under `Always`, an unprefixed
-    // default-locale request must be redirected to its prefixed form.
-    if prefix_default == PrefixDefault::Never && previously_resolved_locale == L::default() {
+    let should_redirect = match prefix_default {
+        // A default-locale request is already at its canonical unprefixed URL,
+        // so no redirect is needed; non-default locales get redirected.
+        PrefixDefault::Never => previously_resolved_locale != L::default(),
+        // Every unprefixed request is redirected to its prefixed form.
+        PrefixDefault::Always => true,
+        // Only redirect when the user has an explicit cookie preference;
+        // otherwise render the unprefixed view (e.g. a language splash screen).
+        PrefixDefault::AlwaysSplash => cookie_locale.is_some(),
+    };
+    if !should_redirect {
         return None;
     }
     let new_path = get_new_path(
@@ -445,6 +463,7 @@ where
     let i18n = use_i18n_context::<L>();
 
     let previously_resolved_locale = i18n.get_locale_untracked();
+    let cookie_locale = i18n.cookie_locale();
 
     // By precedence if there is a locale prefix in the URL it takes priority.
     // if there is none, use the one computed beforehand.
@@ -453,7 +472,13 @@ where
         i18n.set_locale(locale);
         None
     } else {
-        maybe_redirect(previously_resolved_locale, base_path, &segments, prefix_default)
+        maybe_redirect(
+            previously_resolved_locale,
+            cookie_locale,
+            base_path,
+            &segments,
+            prefix_default,
+        )
     };
 
     // This variable is there to sync history changes, because we step out of the Leptos routes reactivity we don't get forward and backward history changes triggers
@@ -703,8 +728,12 @@ where
         });
         // Under `Always`, the default locale is served prefixed like every other
         // locale (already generated below), so we must NOT also emit an unprefixed
-        // route for it — that would create duplicate-content URLs.
-        let emit_default_locale_routes = self.prefix_default == PrefixDefault::Never;
+        // route for it — that would create duplicate-content URLs and unprefixed
+        // requests are redirected anyway.
+        // Under `Never` and `AlwaysSplash` the unprefixed routes are kept: `Never`
+        // serves the default locale there, and `AlwaysSplash` renders them (e.g. a
+        // language splash) for cookie-less visitors instead of redirecting.
+        let emit_default_locale_routes = self.prefix_default != PrefixDefault::Always;
         let default_locale_routes = std::iter::once_with(move || {
             set_current_route_locale(L::default());
             MatchNestedRoutes::generate_routes(&self.route)

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -19,6 +19,8 @@ use leptos_router::{
 
 use leptos_i18n::{I18nContext, Locale, use_i18n_context};
 
+use crate::PrefixDefault;
+
 // this whole file is a hack into `leptos_router`, it absolutely should'nt be used like that, but eh I'm a professional (or not.)
 
 #[derive(Debug)]
@@ -190,11 +192,12 @@ fn get_new_path<L: Locale>(
     new_locale: L,
     locale: Option<L>,
     segments: &RouteSegments<L>,
+    prefix_default: PrefixDefault,
 ) -> String {
     let mut new_path = location.pathname.with_untracked(|path_name| {
         let mut path_builder = PathBuilder::default();
         path_builder.push(base_path);
-        if new_locale != L::default() {
+        if new_locale != L::default() || prefix_default == PrefixDefault::Always {
             path_builder.push(new_locale.as_str());
         }
         if let Some(path_rest) = path_name.strip_prefix(base_path) {
@@ -254,6 +257,7 @@ fn update_path_effect<L: Locale>(
     base_path: &'static str,
     history_changed_locale: Rc<Cell<Option<L>>>,
     segments: Arc<RouteSegments<L>>,
+    prefix_default: PrefixDefault,
 ) -> impl Fn(Option<L>) -> L + 'static {
     let location = use_location();
     let navigate = use_navigate();
@@ -274,7 +278,14 @@ fn update_path_effect<L: Locale>(
             return new_locale;
         }
 
-        let new_path = get_new_path(&location, base_path, new_locale, Some(prev_loc), &segments);
+        let new_path = get_new_path(
+            &location,
+            base_path,
+            new_locale,
+            Some(prev_loc),
+            &segments,
+            prefix_default,
+        );
 
         let navigate = navigate.clone();
 
@@ -300,6 +311,7 @@ fn correct_locale_prefix_effect<L: Locale>(
     base_path: &'static str,
     segments: Arc<RouteSegments<L>>,
     history_changed: Rc<Cell<bool>>,
+    prefix_default: PrefixDefault,
 ) -> impl Fn(Option<()>) + 'static {
     let location = use_location();
     let navigate = use_navigate();
@@ -320,7 +332,14 @@ fn correct_locale_prefix_effect<L: Locale>(
             path_locale.unwrap_or(current_locale)
         };
 
-        let new_path = get_new_path(&location, base_path, new_locale, path_locale, &segments);
+        let new_path = get_new_path(
+            &location,
+            base_path,
+            new_locale,
+            path_locale,
+            &segments,
+            prefix_default,
+        );
 
         let navigate = navigate.clone();
 
@@ -368,9 +387,16 @@ fn maybe_redirect<L: Locale>(
     previously_resolved_locale: L,
     base_path: &str,
     segments: &RouteSegments<L>,
+    prefix_default: PrefixDefault,
 ) -> Option<String> {
     let location = use_location();
-    if cfg!(not(feature = "ssr")) || previously_resolved_locale == L::default() {
+    if cfg!(not(feature = "ssr")) {
+        return None;
+    }
+    // Under `Never`, a default-locale request is already at its canonical
+    // unprefixed URL, so no redirect is needed. Under `Always`, an unprefixed
+    // default-locale request must be redirected to its prefixed form.
+    if prefix_default == PrefixDefault::Never && previously_resolved_locale == L::default() {
         return None;
     }
     let new_path = get_new_path(
@@ -379,6 +405,7 @@ fn maybe_redirect<L: Locale>(
         previously_resolved_locale,
         None,
         segments,
+        prefix_default,
     );
     Some(new_path)
 }
@@ -409,6 +436,7 @@ fn view_wrapper<L, View>(
     route_locale: Option<L>,
     base_path: &'static str,
     segments: Arc<RouteSegments<L>>,
+    prefix_default: PrefixDefault,
 ) -> Either<View, impl ChooseView>
 where
     L: Locale,
@@ -425,7 +453,7 @@ where
         i18n.set_locale(locale);
         None
     } else {
-        maybe_redirect(previously_resolved_locale, base_path, &segments)
+        maybe_redirect(previously_resolved_locale, base_path, &segments, prefix_default)
     };
 
     // This variable is there to sync history changes, because we step out of the Leptos routes reactivity we don't get forward and backward history changes triggers
@@ -441,6 +469,7 @@ where
         base_path,
         sync.clone(),
         segments.clone(),
+        prefix_default,
     ));
 
     // listen for history changes
@@ -457,6 +486,7 @@ where
         base_path,
         segments,
         history_changed,
+        prefix_default,
     ));
 
     match redir {
@@ -474,6 +504,7 @@ pub fn i18n_routing<L: Locale, View, Chil>(
     children: RouteChildren<Chil>,
     ssr_mode: SsrMode,
     view: View,
+    prefix_default: PrefixDefault,
 ) -> impl MatchNestedRoutes + Clone
 where
     View: ChooseView + Clone,
@@ -486,7 +517,7 @@ where
 
     let segments = generate_routes_for_each_locale::<L, _, _>(&base_route);
 
-    I18nNestedRoute::new(base_path, base_route, Arc::new(segments))
+    I18nNestedRoute::new(base_path, base_route, Arc::new(segments), prefix_default)
 }
 
 type RouteSegments<L> = HashMap<L, Vec<Vec<PathSegment>>>;
@@ -496,6 +527,7 @@ struct I18nNestedRoute<L, View, Chil> {
     route: BaseRoute<View, Chil>,
     base_path: &'static str,
     segments: Arc<RouteSegments<L>>,
+    prefix_default: PrefixDefault,
 }
 
 impl<L, View, Chil> I18nNestedRoute<L, View, Chil> {
@@ -503,11 +535,13 @@ impl<L, View, Chil> I18nNestedRoute<L, View, Chil> {
         base_path: &'static str,
         route: BaseRoute<View, Chil>,
         segments: Arc<RouteSegments<L>>,
+        prefix_default: PrefixDefault,
     ) -> Self {
         Self {
             route,
             base_path,
             segments,
+            prefix_default,
         }
     }
 }
@@ -557,6 +591,7 @@ where
     matched: String,
     inner_match: <BaseRoute<View, Chil> as MatchNestedRoutes>::Match,
     segments: Arc<RouteSegments<L>>,
+    prefix_default: PrefixDefault,
 }
 
 impl<L, View, Chil> MatchParams for I18nRouteMatch<L, View, Chil>
@@ -595,6 +630,7 @@ where
                 self.locale,
                 self.base_path,
                 self.segments.clone(),
+                self.prefix_default,
             )
         };
         (ViewWrapper(new_view), child)
@@ -635,6 +671,7 @@ where
                             inner_match,
                             base_path: self.base_path,
                             segments: self.segments.clone(),
+                            prefix_default: self.prefix_default,
                         };
                         Some((Some((route_match_id, route_match)), remaining))
                     })
@@ -649,6 +686,7 @@ where
                         inner_match,
                         base_path: self.base_path,
                         segments: self.segments.clone(),
+                        prefix_default: self.prefix_default,
                     };
                     (Some((route_match_id, route_match)), remaining)
                 })
@@ -663,7 +701,11 @@ where
             reset_current_route_locale();
             None
         });
-        let default_locale_routes = std::iter::once_with(|| {
+        // Under `Always`, the default locale is served prefixed like every other
+        // locale (already generated below), so we must NOT also emit an unprefixed
+        // route for it — that would create duplicate-content URLs.
+        let emit_default_locale_routes = self.prefix_default == PrefixDefault::Never;
+        let default_locale_routes = std::iter::once_with(move || {
             set_current_route_locale(L::default());
             MatchNestedRoutes::generate_routes(&self.route)
                 .into_iter()
@@ -673,6 +715,7 @@ where
                     generated_route
                 })
         })
+        .filter(move |_| emit_default_locale_routes)
         .flatten();
         L::get_all()
             .iter()

--- a/leptos_i18n_router/src/routing.rs
+++ b/leptos_i18n_router/src/routing.rs
@@ -201,15 +201,24 @@ fn get_new_path<L: Locale>(
             path_builder.push(new_locale.as_str());
         }
         if let Some(path_rest) = path_name.strip_prefix(base_path) {
-            let path_rest = match locale {
-                None => path_rest,
-                Some(l) => {
-                    if let Some(path_rest) = path_rest.strip_prefix(l.as_str()) {
-                        path_rest
-                    } else {
-                        path_rest // Should happen only if l == L::default()
-                    }
+            let l = locale.unwrap_or_default();
+            let locale_prix_stripped = path_rest.strip_prefix(l.as_str()).and_then(|path| {
+                if path.is_empty() {
+                    Some("")
+                } else {
+                    path.strip_prefix('/')
                 }
+            });
+            let path_rest = if let Some(path_rest) = locale_prix_stripped {
+                path_rest
+            } else if l == L::default() {
+                path_rest // Should happen only if l == L::default()
+            } else {
+                todo!(
+                    "expected the path to have a locale prefix of \"{}/..\" but got: \"{}\"",
+                    l.as_str(),
+                    path_rest
+                )
             };
 
             let old_locale_segments = segments.get(&locale.unwrap_or_default());
@@ -240,6 +249,7 @@ fn get_new_path<L: Locale>(
             new_path.push_str(search);
         }
     });
+
     location.hash.with_untracked(|hash| {
         if !hash.is_empty() {
             // Remove leading '#' if present
@@ -248,6 +258,7 @@ fn get_new_path<L: Locale>(
             new_path.push_str(hash);
         }
     });
+
     new_path
 }
 
@@ -388,17 +399,36 @@ fn maybe_redirect<L: Locale>(
     base_path: &str,
     segments: &RouteSegments<L>,
     prefix_default: PrefixDefault,
-) -> Option<String> {
-    let location = use_location();
+) -> Option<(String, bool)> {
     if cfg!(not(feature = "ssr")) {
         return None;
     }
-    // Under `Never`, a default-locale request is already at its canonical
-    // unprefixed URL, so no redirect is needed. Under `Always`, an unprefixed
-    // default-locale request must be redirected to its prefixed form.
-    if prefix_default == PrefixDefault::Never && previously_resolved_locale == L::default() {
-        return None;
+
+    let location = use_location();
+
+    let is_default = previously_resolved_locale == L::default();
+
+    // check the current default locale prefix to see if we need to redirect
+    if is_default {
+        let has_prefix = location.pathname.with_untracked(|path_name| {
+            let Some(rest) = path_name.strip_prefix(base_path) else {
+                return false;
+            };
+            let Some(rest) = rest.strip_prefix(previously_resolved_locale.as_str()) else {
+                return false;
+            };
+            rest.is_empty() || rest.starts_with('/')
+        });
+
+        if matches!(
+            (has_prefix, prefix_default),
+            // if already has a prefix and is ::Always, or if no prefix and is ::Never, we don't need to redirect
+            (true, PrefixDefault::Always) | (false, PrefixDefault::Never)
+        ) {
+            return None;
+        }
     }
+
     let new_path = get_new_path(
         &location,
         base_path,
@@ -407,7 +437,11 @@ fn maybe_redirect<L: Locale>(
         segments,
         prefix_default,
     );
-    Some(new_path)
+    Some((
+        new_path,
+        // permanently move "/{def}/.." to "/.." with prefix_default to never
+        is_default && prefix_default == PrefixDefault::Never,
+    ))
 }
 
 #[derive(Clone)]
@@ -449,11 +483,18 @@ where
     // By precedence if there is a locale prefix in the URL it takes priority.
     // if there is none, use the one computed beforehand.
 
-    let redir = if let Some(locale) = route_locale {
+    let redir = if let Some(locale) = route_locale
+        && locale != L::default()
+    {
         i18n.set_locale(locale);
         None
     } else {
-        maybe_redirect(previously_resolved_locale, base_path, &segments, prefix_default)
+        maybe_redirect(
+            previously_resolved_locale,
+            base_path,
+            &segments,
+            prefix_default,
+        )
     };
 
     // This variable is there to sync history changes, because we step out of the Leptos routes reactivity we don't get forward and backward history changes triggers
@@ -491,10 +532,45 @@ where
 
     match redir {
         None => Either::Left(view),
-        Some(path) => {
-            let view = move || view! { <Redirect path=path.clone() /> };
-            Either::Right(view)
+        Some((path, permanent)) => {
+            redirect(path.clone(), permanent);
+            Either::Right(())
         }
+    }
+}
+
+fn redirect(path: String, permanent_redirect: bool) {
+    fn redirect_via_comp(path: String) {
+        let props = leptos::component::component_props_builder(&Redirect)
+            .path(path)
+            .build();
+        Redirect(props)
+    }
+    if permanent_redirect && cfg!(any(feature = "actix", feature = "axum")) {
+        #[cfg(all(feature = "axum", not(feature = "actix")))]
+        {
+            if let Some(res) = use_context::<leptos_axum::ResponseOptions>() {
+                let path =
+                    axum_http::HeaderValue::from_str(&path).expect("failed to create header value");
+                res.insert_header(axum_http::header::LOCATION, path);
+                res.set_status(axum_http::StatusCode::MOVED_PERMANENTLY);
+            } else {
+                redirect_via_comp(path);
+            }
+        }
+        #[cfg(all(feature = "actix", not(feature = "axum")))]
+        {
+            if let Some(res) = use_context::<leptos_actix::ResponseOptions>() {
+                let path = actix_http::HeaderValue::from_str(&path)
+                    .expect("failed to create header value");
+                res.insert_header(actix_http::header::LOCATION, path);
+                res.set_status(actix_http::StatusCode::MOVED_PERMANENTLY);
+            } else {
+                redirect_via_comp(path);
+            }
+        }
+    } else {
+        redirect_via_comp(path);
     }
 }
 


### PR DESCRIPTION
Adds a `PrefixDefault` option to `I18nRoute` so the default locale can be
  prefixed like every other locale, plus a cookie-aware splash variant.

  **Commit 1 — `Never` / `Always`.** Today the default locale is hardcoded as
  unprefixed. `PrefixDefault::Always` prefixes it like the rest (`/en`, `/fr`, …)
  and redirects unprefixed requests to avoid duplicate-content URLs.

  **Commit 2 — `AlwaysSplash`.** Implementing the first two made the gap clear:
  neither gives you a fully **language-symmetrical** site. `Never` leaves the
  default unprefixed (asymmetric URLs); `Always` force-redirects the apex, so
  there's nowhere to land a language chooser. `AlwaysSplash` prefixes every
  locale *and* renders the unprefixed apex instead of redirecting it:

  - **locale cookie set** → redirect to `/{cookie_locale}/…`
  - **no cookie** → render the splash (no guessing from `Accept-Language`/navigator)

  To tell an explicit cookie preference from a guessed locale, `leptos_i18n` now
  exposes `I18nContext::cookie_locale()`, which the router reads for the redirect
  decision.

  Fully backward compatible: the prop defaults to `PrefixDefault::Never`.