### PR TITLE
fix(runtime): correct locale negotiation for bare language tags and stop formatter cache poisoning

### DIFF
--- a/leptos_i18n/src/langid.rs
+++ b/leptos_i18n/src/langid.rs
@@ -50,11 +50,9 @@ pub fn filter_matches<L: Locale>(requested: &[LanguageIdentifier], available: &[
 
     for req in requested.iter().cloned() {
         macro_rules! test_strategy {
-            ($self_as_range:expr) => {{
-                let mut match_found = false;
+            ($self_as_range:expr, $other_as_range:expr) => {{
                 available_locales.retain(|locale| {
-                    if lang_id_matches(locale.as_langid(), &req, $self_as_range, false) {
-                        match_found = true;
+                    if lang_id_matches(locale.as_langid(), &req, $self_as_range, $other_as_range) {
                         supported_locales.push(*locale);
                         return false;
                     }
@@ -64,16 +62,23 @@ pub fn filter_matches<L: Locale>(requested: &[LanguageIdentifier], available: &[
         }
 
         // 1) Try to find a simple (case-insensitive) string match for the request.
-        test_strategy!(false);
+        test_strategy!(false, false);
 
         // 2) Try to match against the available locales treated as ranges.
-        test_strategy!(true);
+        test_strategy!(true, false);
 
         // Per Unicode TR35, 4.4 Locale Matching, we don't add likely subtags to
         // requested locales, so we'll skip it from the rest of the steps.
         if req.language.is_unknown() {
             continue;
         }
+
+        // 3) Try to match against the requested locale treated as a range.
+        //
+        // Without this step a request for a bare language ("de") never matches a
+        // region qualified available locale ("de-DE"), and silently falls back to
+        // the default locale.
+        test_strategy!(true, true);
     }
 
     supported_locales
@@ -125,14 +130,30 @@ mod test {
     fn test_hirarchy() {
         const LOCALES: &[Locale] = &[Locale::de, Locale::en_US, Locale::de_DE, Locale::de_CH];
 
+        // an exact match comes first, then the regional variants of that language
         let res = filter_matches(&[langid!("de")], LOCALES);
-        assert_eq!(res, [Locale::de]);
+        assert_eq!(res, [Locale::de, Locale::de_DE, Locale::de_CH]);
 
         let res = filter_matches(&[langid!("de-DE")], LOCALES);
         assert_eq!(res, [Locale::de_DE, Locale::de]);
 
         let res = filter_matches(&[langid!("de-CH")], LOCALES);
         assert_eq!(res, [Locale::de_CH, Locale::de]);
+    }
+
+    #[test]
+    fn test_bare_language_matches_regional_locale() {
+        // A browser sending "de" must be served "de-DE" if that is the only
+        // german locale declared by the app, instead of falling back to the default.
+        let res = filter_matches(&[langid!("de")], &[Locale::en, Locale::de_DE]);
+        assert_eq!(res, [Locale::de_DE]);
+
+        let res = find_match(&[langid!("de")], &[Locale::en, Locale::de_DE]);
+        assert_eq!(res, Locale::de_DE);
+
+        // Same for a request carrying a script but no region.
+        let res = find_match(&[langid!("fr")], &[Locale::en, Locale::fr_FR]);
+        assert_eq!(res, Locale::fr_FR);
     }
 
     #[test]

--- a/leptos_i18n/src/macro_helpers/formatting/mod.rs
+++ b/leptos_i18n/src/macro_helpers/formatting/mod.rs
@@ -239,7 +239,7 @@ pub(crate) mod inner {
     use icu_locale::Locale as IcuLocale;
     use std::{
         collections::HashMap,
-        sync::{OnceLock, RwLock},
+        sync::{OnceLock, PoisonError, RwLock},
     };
 
     #[cfg(feature = "format_datetime")]
@@ -269,7 +269,13 @@ pub(crate) mod inner {
             T: Default,
         {
             let mutex = self.0.get_or_init(Default::default);
-            let mut guard = mutex.write().unwrap();
+            // Formatter construction can panic (a data provider missing a marker or a
+            // locale), and it does so while this guard is held, which poisons the lock.
+            // The cache stays consistent in that case, as `HashMap`'s entry API inserts
+            // nothing when the `or_insert_with` closure unwinds, so the poison flag is
+            // ignored: one failing formatter must not turn every later formatting call,
+            // for any locale and any formatter kind, into a `PoisonError` panic.
+            let mut guard = mutex.write().unwrap_or_else(PoisonError::into_inner);
             f(&mut guard)
         }
     }
@@ -317,6 +323,39 @@ pub(crate) mod inner {
             formatters.provider =
                 super::data_provider::BakedDataProvider(Some(Box::new(data_provider)));
         });
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::{HashMap, StaticLock};
+
+        // A formatter that fails to be built panics inside `with_mut`, i.e. while the
+        // write guard is held. Every later use of the cache must still work, whatever
+        // the locale or the formatter kind.
+        #[test]
+        fn cache_survives_a_failing_formatter_creation() {
+            static CACHE: StaticLock<HashMap<&'static str, usize>> = StaticLock::new();
+
+            CACHE.with_mut(|cache| cache.insert("en", 1));
+
+            let panicked = std::panic::catch_unwind(|| {
+                CACHE.with_mut(|cache| {
+                    cache
+                        .entry("de")
+                        .or_insert_with(|| panic!("A DecimalFormatter"));
+                })
+            });
+            assert!(panicked.is_err());
+
+            // Would panic with a `PoisonError` if the poison flag was propagated.
+            let (en, de_entries) = CACHE.with_mut(|cache| (cache.get("en").copied(), cache.len()));
+            assert_eq!(en, Some(1));
+            // the entry API inserted nothing for the key that failed
+            assert_eq!(de_entries, 1);
+
+            CACHE.with_mut(|cache| cache.insert("de", 2));
+            assert_eq!(CACHE.with_mut(|cache| cache.get("de").copied()), Some(2));
+        }
     }
 }
 


### PR DESCRIPTION
### `langid`: bare language requests never matched region-qualified locales

`filter_matches` implemented only the first two steps of the Unicode TR35 "Filtering" negotiation (exact match, and available-locale-as-range). The third step — treating the *requested* locale as a range — was missing, so `lang_id_matches` was never called with `other_as_range = true`.

A browser sending a bare language tag (the common `Accept-Language` / `navigator.languages` form) matched nothing when the app only declares region-qualified locales, and `find_match` silently fell back to the default:

```rust
filter_matches(&[langid!("de")], &[Locale::en, Locale::de_DE]);
// before: []   after: [de_DE]
```

This affected every cookie-less resolution — `Locale::find_locale` on both SSR and CSR. The new step runs after the `req.language.is_unknown()` guard, so `und-*` still doesn't match everything.

### `formatting`: one failing formatter poisoned the process-wide cache

All formatters and plural rules live in a single `OnceLock<RwLock<Formatters>>`. On a cache miss, `StaticLock::with_mut` built the ICU formatter with `.expect(..)` *while holding the write guard*. Formatter construction failing is recoverable and realistic (a custom baked provider missing a marker or locale under `default-features = false`), but the panic unwound through the live guard and poisoned the lock — and `with_mut` then did `.write().unwrap()`. From that point every formatting call in the process panicked with `PoisonError`, for every locale and formatter kind, including ones whose data was present. On SSR, one request's missing-data error became a permanent formatting outage.

`with_mut` now ignores the poison flag (`unwrap_or_else(PoisonError::into_inner)`). The cache is left consistent by such a panic — `HashMap`'s entry API inserts nothing when the `or_insert_with` closure unwinds — so the failure stays contained to the call that caused it.