### PR TITLE
fix(macro): two `leptos_i18n_macro` bugs

### DIFF
--- a/leptos_i18n_macro/src/load_locales/declare_locales.rs
+++ b/leptos_i18n_macro/src/load_locales/declare_locales.rs
@@ -16,28 +16,43 @@ use leptos_i18n_parser::{
     },
     utils::{Key, KeyPath, Loc, ParseContext},
 };
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use syn::{
-    Ident, Lit, LitStr, Token, parse::ParseBuffer, parse_macro_input, punctuated::Punctuated,
-    token::Comma,
-};
+use syn::{Ident, Lit, LitStr, Token, parse::ParseBuffer, punctuated::Punctuated, token::Comma};
 
 pub fn declare_locales(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    declare_locales_inner(tokens.into()).into()
+}
+
+fn to_compile_error<T: Display>(err: T) -> TokenStream {
+    let err = err.to_string();
+    quote::quote!(compile_error!(#err);)
+}
+
+fn declare_locales_inner(tokens: TokenStream) -> TokenStream {
     let ParsedInput {
         cfg_file,
         locales,
         crate_path,
         foreign_keys_paths,
         interpolate_display,
-    } = parse_macro_input!(tokens as ParsedInput);
+    } = match syn::parse2::<ParsedInput>(tokens) {
+        Ok(input) => input,
+        Err(err) => return err.into_compile_error(),
+    };
     let diag = Diagnostics::new();
 
     let mut cfg: Config = cfg_file.into();
 
     cfg.options = ParseOptions::default().interpolate_display(interpolate_display);
 
-    let builder_keys = make_builder_keys(locales, &cfg, foreign_keys_paths, &diag).unwrap();
+    // validation errors are regular user errors (missing foreign key, subkeys
+    // missmatch, ...), report them like `load_locales!` does instead of
+    // aborting the compiler with a proc macro panic.
+    let builder_keys = match make_builder_keys(locales, &cfg, foreign_keys_paths, &diag) {
+        Ok(builder_keys) => builder_keys,
+        Err(err) => return to_compile_error(err),
+    };
 
     let parsed_locales = ParsedLocales {
         cfg,
@@ -49,11 +64,8 @@ pub fn declare_locales(tokens: proc_macro::TokenStream) -> proc_macro::TokenStre
     let result =
         leptos_i18n_codegen::gen_code(&parsed_locales, Some(&crate_path), true, None, true);
     match result {
-        Ok(ts) => ts.into(),
-        Err(err) => {
-            let err = err.to_string();
-            quote::quote!(compile_error!(#err);).into()
-        }
+        Ok(ts) => ts,
+        Err(err) => to_compile_error(err),
     }
 }
 
@@ -499,5 +511,51 @@ impl<'a, 'de> ParseRanges<'a, 'de> for RangeParseBuffer<'de> {
         seed: Self::Seed,
     ) -> Self::Result<()> {
         parse_range_pairs(&self.0, ranges, seed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quote::quote;
+
+    fn expand_err(tokens: TokenStream) -> String {
+        let expanded = declare_locales_inner(tokens).to_string();
+        assert!(
+            expanded.contains("compile_error"),
+            "expected a compile error, got: {expanded}"
+        );
+        expanded
+    }
+
+    #[test]
+    fn validation_errors_are_reported_as_compile_errors() {
+        let expanded = expand_err(quote! {
+            path: crate,
+            default: "en",
+            locales: ["en"],
+            en: {
+                key: "$t(missing_key)",
+            },
+        });
+        assert!(
+            expanded.contains("Invalid foreign key"),
+            "unexpected error: {expanded}"
+        );
+    }
+
+    #[test]
+    fn subkeys_missmatch_is_reported_as_compile_error() {
+        expand_err(quote! {
+            path: crate,
+            default: "en",
+            locales: ["en", "fr"],
+            en: {
+                key: { sub: "en" },
+            },
+            fr: {
+                key: "fr",
+            },
+        });
     }
 }

--- a/leptos_i18n_macro/src/t_plural/mod.rs
+++ b/leptos_i18n_macro/src/t_plural/mod.rs
@@ -49,9 +49,11 @@ pub fn t_plural_inner(
     let get_locale = input_type.get_locale(&ctx);
 
     let match_arms = forms.iter().map(|(form, block)| quote!(#form => #block));
+    // the trailing comma has to be part of the optional arm, otherwise a missing
+    // fallback leaves a dangling `,` in the generated match.
     let fallback = fallback.map(|(expr, span)| {
         let fb = quote_spanned! { span => _ };
-        quote!(#fb => #expr)
+        quote!(#fb => #expr,)
     });
 
     let ts = quote! {
@@ -59,7 +61,7 @@ pub fn t_plural_inner(
             #(
                 #match_arms,
             )*
-            #fallback,
+            #fallback
         }
     };
 

--- a/tests/json/src/t_plural.rs
+++ b/tests/json/src/t_plural.rs
@@ -55,3 +55,32 @@ fn ordinal_plural() {
     let fr = td_plural_ordinal!(Locale::fr, count = count, one => "one", two => "two", few => "few", _ => "other");
     assert_eq!(fr, "other");
 }
+
+#[test]
+fn exhaustive_plural_no_fallback() {
+    let count = move || 1;
+    let en = td_plural!(
+        Locale::en,
+        count = count,
+        zero => "zero",
+        one => "one",
+        two => "two",
+        few => "few",
+        many => "many",
+        other => "other"
+    );
+    assert_eq!(en, "one");
+
+    let count = move || 2;
+    let en = td_plural!(
+        Locale::en,
+        count = count,
+        zero => "zero",
+        one => "one",
+        two => "two",
+        few => "few",
+        many => "many",
+        other => "other"
+    );
+    assert_eq!(en, "other");
+}


### PR DESCRIPTION
## `t_plural!` emits a dangling comma when there is no fallback

`t_plural!` and its variants (`td_plural!`, `tu_plural!`, the `_ordinal` ones)
generate invalid Rust when the invocation has no `_` arm — a legitimate input,
since the six plural categories cover every case:

```rust
let count = move || 1;
let en = td_plural!(
    Locale::en,
    count = count,
    zero => "zero", one => "one", two => "two",
    few => "few", many => "many", other => "other"
);
```

```text
error: expected pattern, found `,`
  = note: this error originates in the macro `td_plural`
```

The fallback arm is an `Option<TokenStream>`, but the comma after it was emitted
unconditionally, so the match ended with `PluralCategory::Other => "other" , , }`.
The parser accepts input without a fallback, so the call was accepted and then
failed with a syntax error pointing at the user's invocation.

The trailing comma is now part of the optional arm. Covered by a new test in
`tests/json`.

## `declare_locales!` panics instead of reporting validation errors

Any semantic error in `declare_locales!` input aborts the compiler with a proc
macro panic and a `Debug`-formatted internal error, instead of the located
message the parser already builds:

```rust
leptos_i18n_macro::declare_locales! {
    default: "en",
    locales: ["en"],
    en: { key: "$t(missing_key)" },
}
```

```text
error: proc macro panicked
  = help: message: called `Result::unwrap()` on an `Err` value: MissingForeignKey { ... }
```

`declare_locales` turned parse errors and codegen errors into `compile_error!`
but `.unwrap()`ed the whole validation stage (`make_builder_keys`: foreign key
resolution, subkeys missmatch checks, plural merging, …), all reachable from
ordinary input. Users were told to open an issue for their own typo.

The macro body moves to a `proc_macro2::TokenStream`-based inner function so all
three stages share one `Err -> compile_error!` conversion, and so the expansion
can be unit tested. The example above now reports:

```text
error: Invalid foreign key "missing_key" at key "key" in locale "en", key don't exist.
```