### PR TITLE
fix(build): three bugs in `leptos_i18n_build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "leptos_i18n_parser",
  "prettyplease",
  "proc-macro2",
+ "serde_json",
  "syn",
 ]
 

--- a/leptos_i18n_build/Cargo.toml
+++ b/leptos_i18n_build/Cargo.toml
@@ -35,6 +35,9 @@ prettyplease = { features = [
 ], optional = true, workspace = true, default-features = true }
 syn = { workspace = true, default-features = true }
 
+[dev-dependencies]
+serde_json = { workspace = true, default-features = true }
+
 [features]
 default = []
 islands = ["leptos_i18n_codegen/islands"]

--- a/leptos_i18n_build/src/datamarker.rs
+++ b/leptos_i18n_build/src/datamarker.rs
@@ -1,10 +1,12 @@
 use icu_provider::{DataMarker, DataMarkerInfo};
-use leptos_i18n_parser::formatters::{self, FormatterToTokens, VarBounds};
-use leptos_i18n_parser::parse_locales::locale::{
-    BuildersKeysInner, InterpolOrLit, LocaleValue, RangeOrPlural,
+use leptos_i18n_parser::{
+    formatters::{self, FormatterToTokens, VarBounds},
+    parse_locales::locale::{BuildersKeysInner, InterpolOrLit, LocaleValue, RangeOrPlural},
 };
-use std::any::{Any, TypeId};
-use std::collections::HashSet;
+use std::{
+    any::{Any, TypeId},
+    collections::HashSet,
+};
 
 /// This enum represent the different `Formatters` and options your translations could be using.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -96,7 +98,7 @@ impl FormatterOptions {
     /// Return a `Vec<DataMarkerInfo>` needed to use the given option.
     pub fn into_data_markers(self) -> Vec<DataMarkerInfo> {
         match self {
-            FormatterOptions::Plurals => icu::calendar::provider::MARKERS.to_vec(),
+            FormatterOptions::Plurals => icu::plurals::provider::MARKERS.to_vec(),
             FormatterOptions::FormatDateTime => [
                 icu::datetime::provider::MARKERS,
                 icu::plurals::provider::MARKERS,
@@ -115,6 +117,56 @@ impl FormatterOptions {
             .iter()
             .flat_map(|m| m.to_vec())
             .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every option must at least bake the data of the ICU component it stands for,
+    /// otherwise the generated provider compiles but fails at runtime with a
+    /// missing data error.
+    #[test]
+    fn options_bake_the_data_of_their_own_component() {
+        let contains = |option: FormatterOptions, markers: &[DataMarkerInfo]| {
+            let baked = option.into_data_markers();
+            markers.iter().all(|marker| baked.contains(marker))
+        };
+
+        assert!(contains(
+            FormatterOptions::Plurals,
+            icu::plurals::provider::MARKERS
+        ));
+        assert!(contains(
+            FormatterOptions::FormatDateTime,
+            icu::datetime::provider::MARKERS
+        ));
+        assert!(contains(
+            FormatterOptions::FormatList,
+            icu::list::provider::MARKERS
+        ));
+        assert!(contains(
+            FormatterOptions::FormatNums,
+            icu::decimal::provider::MARKERS
+        ));
+        assert!(contains(
+            FormatterOptions::FormatCurrency,
+            icu::decimal::provider::MARKERS
+        ));
+    }
+
+    /// `Plurals` used to be mapped to the calendar markers, which baked Japanese
+    /// calendar and week data while leaving the plural rules out entirely.
+    #[test]
+    fn plurals_does_not_bake_calendar_data() {
+        let baked = FormatterOptions::Plurals.into_data_markers();
+        for marker in icu::calendar::provider::MARKERS {
+            assert!(
+                !baked.contains(marker),
+                "`FormatterOptions::Plurals` should not pull in calendar data"
+            );
         }
     }
 }

--- a/leptos_i18n_build/src/lib.rs
+++ b/leptos_i18n_build/src/lib.rs
@@ -434,16 +434,110 @@ impl<'a> LocaleTranslations<'a> {
     }
 }
 
+/// Write `s` as a JSON string, surrounding quotes included.
+///
+/// `str`'s `Debug` impl looks close enough but is not a JSON serializer:
+/// it escapes control characters as `\u{7f}` and nul as `\0`, neither of which
+/// JSON accepts, and it escapes a leading combining mark the same way.
+fn write_json_str(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
+    f.write_char('"')?;
+    // Index of the first byte not yet written, everything that needs no escaping
+    // is copied in one go when an escape is met or at the end of the string.
+    let mut copied = 0;
+    for (index, c) in s.char_indices() {
+        let escape = match c {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\u{8}' => "\\b",
+            '\u{c}' => "\\f",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            // Anything above U+001F is allowed as is, JSON only requires the
+            // control characters to be escaped.
+            _ if c >= '\u{20}' => continue,
+            _ => {
+                f.write_str(&s[copied..index])?;
+                write!(f, "\\u{:04x}", c as u32)?;
+                copied = index + c.len_utf8();
+                continue;
+            }
+        };
+        f.write_str(&s[copied..index])?;
+        f.write_str(escape)?;
+        copied = index + c.len_utf8();
+    }
+    f.write_str(&s[copied..])?;
+    f.write_char('"')
+}
+
 impl Display for TranslationsFormatter<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_char('[')?;
         let mut iter = self.strings.iter();
         if let Some(first) = iter.next() {
-            write!(f, "{first:?}")?;
+            write_json_str(f, first)?;
         }
         for s in iter {
-            write!(f, ",{s:?}")?;
+            f.write_char(',')?;
+            write_json_str(f, s)?;
         }
         f.write_char(']')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn format(strings: &[&str]) -> String {
+        let strings: Vec<Rc<str>> = strings.iter().copied().map(Rc::from).collect();
+        TranslationsFormatter { strings: &strings }.to_string()
+    }
+
+    #[test]
+    fn control_characters_use_json_escapes() {
+        assert_eq!(format(&["a\0b"]), r#"["a\u0000b"]"#);
+        assert_eq!(format(&["\u{7}"]), r#"["\u0007"]"#);
+        assert_eq!(format(&["\u{1f}"]), r#"["\u001f"]"#);
+        assert_eq!(format(&["\u{8}\u{c}\n\r\t"]), r#"["\b\f\n\r\t"]"#);
+        assert_eq!(format(&[r#"say "hi"\"#]), r#"["say \"hi\"\\"]"#);
+    }
+
+    #[test]
+    fn printable_characters_are_left_alone() {
+        // U+007F and combining marks are valid JSON string content, but `Debug`
+        // escapes them with the Rust-only `\u{..}` syntax.
+        assert_eq!(format(&["x\u{7f}y"]), "[\"x\u{7f}y\"]");
+        assert_eq!(format(&["\u{301}a"]), "[\"\u{301}a\"]");
+        assert_eq!(format(&["héllo 🎉"]), "[\"héllo 🎉\"]");
+    }
+
+    #[test]
+    fn array_layout() {
+        assert_eq!(format(&[]), "[]");
+        assert_eq!(format(&["a"]), r#"["a"]"#);
+        assert_eq!(format(&["a", "b", "c"]), r#"["a","b","c"]"#);
+    }
+
+    /// The emitted files are fetched and parsed as JSON by the `dynamic_load`
+    /// client, so they have to match what a JSON serializer would produce.
+    #[test]
+    fn matches_serde_json() {
+        let strings = [
+            "",
+            "a\0b",
+            "\u{7}\u{8}\u{c}\n\r\t\u{1f}",
+            "x\u{7f}y",
+            "\u{301}a",
+            r#"quotes " and backslashes \"#,
+            "héllo 🎉",
+        ];
+        let rendered = format(&strings);
+        assert_eq!(rendered, serde_json::to_string(&strings).unwrap());
+        assert_eq!(
+            serde_json::from_str::<Vec<String>>(&rendered).unwrap(),
+            strings
+        );
     }
 }

--- a/leptos_i18n_build/src/lib.rs
+++ b/leptos_i18n_build/src/lib.rs
@@ -210,30 +210,36 @@ impl TranslationsInfos {
     }
 
     /// Same as `generate_data` but can be supplied additionnal ICU `DataMarker`.
+    ///
+    /// # Warning
+    ///
+    /// `mod_directory` is recursively removed before the data is generated,
+    /// see [`generate_data`](Self::generate_data).
     pub fn generate_data_with_data_markers(
         &self,
         mod_directory: PathBuf,
         keys: impl IntoIterator<Item = DataMarkerInfo>,
     ) -> Result<ExportMetadata, DataError> {
-        // This is'nt really needed, but ICU4X wants the directory to be empty
-        // and Rust Analyzer can trigger the build.rs without cleaning the out directory.
-        if mod_directory.exists() {
-            std::fs::remove_dir_all(&mod_directory).unwrap();
-        }
-
+        // `overwrite` makes `BakedExporter::new` recursively remove `mod_directory`,
+        // which ICU4X wants empty and Rust Analyzer can leave behind by triggering
+        // the build.rs without cleaning the out directory.
         let exporter = BakedExporter::new(mod_directory, {
             let mut options = baked_exporter::Options::default();
             options.overwrite = true;
             options.use_internal_fallback = false;
             options
-        })
-        .unwrap();
+        })?;
 
         self.build_datagen_driver_with_data_keys(keys)
             .export(&SourceDataProvider::new(), exporter)
     }
 
     /// Same as `generate_data` but can be supplied additionnal options.
+    ///
+    /// # Warning
+    ///
+    /// `mod_directory` is recursively removed before the data is generated,
+    /// see [`generate_data`](Self::generate_data).
     pub fn generate_data_with_options(
         &self,
         mod_directory: PathBuf,
@@ -243,6 +249,12 @@ impl TranslationsInfos {
     }
 
     /// Generate an ICU datagen at the given mod_directory using the infos from the translations.
+    ///
+    /// # Warning
+    ///
+    /// If `mod_directory` already exists it is **recursively removed** before the
+    /// data is generated, so it must be a directory dedicated to that data,
+    /// typically one under `OUT_DIR`. Anything else stored there is lost.
     pub fn generate_data(&self, mod_directory: PathBuf) -> Result<ExportMetadata, DataError> {
         self.generate_data_with_options(mod_directory, std::iter::empty())
     }

--- a/leptos_i18n_build/tests/fixtures/locales/en.json
+++ b/leptos_i18n_build/tests/fixtures/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "hello": "Hello",
+  "control_chars": "before\u0007after",
+  "del_and_combining": "\u0301x\u007fy"
+}

--- a/leptos_i18n_build/tests/translations_output.rs
+++ b/leptos_i18n_build/tests/translations_output.rs
@@ -1,0 +1,41 @@
+use leptos_i18n_build::{Config, TranslationsInfos};
+use std::path::{Path, PathBuf};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn out_dir(test_name: &str) -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR")).join(test_name);
+    if path.exists() {
+        std::fs::remove_dir_all(&path).unwrap();
+    }
+    path
+}
+
+fn parse_fixtures() -> TranslationsInfos {
+    let cfg = Config::new("en").unwrap();
+    TranslationsInfos::parse_at_dir(fixtures_dir(), cfg).unwrap()
+}
+
+/// The files written by `write_to_dir` are fetched and decoded as JSON by the
+/// `dynamic_load` client, so locale files that are valid JSON have to round
+/// trip into files that are valid JSON too.
+#[test]
+fn written_translations_are_valid_json() {
+    let out = out_dir("written_translations_are_valid_json");
+
+    parse_fixtures()
+        .get_translations()
+        .write_to_dir(&out)
+        .unwrap();
+
+    let written = std::fs::read_to_string(out.join("en.json")).unwrap();
+    let strings: Vec<String> = serde_json::from_str(&written)
+        .unwrap_or_else(|err| panic!("`{written}` is not valid JSON: {err}"));
+
+    // The strings must survive the round trip untouched.
+    assert!(strings.iter().any(|s| s.contains('\u{7}')));
+    assert!(strings.iter().any(|s| s.contains('\u{7f}')));
+    assert!(strings.iter().any(|s| s.contains('\u{301}')));
+}

--- a/leptos_i18n_build/tests/translations_output.rs
+++ b/leptos_i18n_build/tests/translations_output.rs
@@ -39,3 +39,24 @@ fn written_translations_are_valid_json() {
     assert!(strings.iter().any(|s| s.contains('\u{7f}')));
     assert!(strings.iter().any(|s| s.contains('\u{301}')));
 }
+
+/// Datagen returns `Result`, so an unusable output path has to surface as an
+/// error rather than take the whole build script down with a panic.
+#[test]
+fn generate_data_reports_io_errors() {
+    let out = out_dir("generate_data_reports_io_errors");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // A file where a directory is expected: clearing the output path fails.
+    let mod_directory = out.join("baked_data");
+    std::fs::write(&mod_directory, "not a directory").unwrap();
+
+    let err = parse_fixtures()
+        .generate_data(mod_directory)
+        .expect_err("generating into a path that cannot be cleared should fail");
+
+    assert!(
+        matches!(err.kind, icu_provider::DataErrorKind::Io(_)),
+        "expected an IO error, got {err:?}"
+    );
+}


### PR DESCRIPTION
### 1. `FormatterOptions::Plurals` baked calendar data instead of plural rules

`into_data_markers` mapped `Plurals` to `icu::calendar::provider::MARKERS`
(`CalendarJapaneseModernV1`, `CalendarWeekV1`) rather than
`icu::plurals::provider::MARKERS`.

A project using plurals therefore shipped Japanese calendar data and no
plural rules at all, and rendering a plural key panicked in
`get_plural_rules` (`.expect("A PluralRules")`). The `FormatDateTime` arm
does list the plurals markers, which hid the bug for projects that format
dates *and* use plurals.

**Fix:** map `Plurals` to the plurals markers. Also drops the calendar
data that was baked for nothing in every plural project.

### 2. Translations were serialized with Rust `Debug`, not JSON

`TranslationsFormatter` wrote each string via `write!(f, "{s:?}")`.
`Debug` for `str` is not a JSON serializer — it emits `\u{7f}` and `\0`,
which are not JSON escapes:

```
input  ["x\u{7f}y"]  (valid JSON)
output ["x\u{7f}y"]  -> Error("invalid escape", line: 1, column: 9)
```

These files are decoded as JSON by the `dynamic_load` client, so a valid
locale file round-tripped into one that fails to load at runtime.

**Fix:** write through a small JSON string writer applying the real
escaping rules. Includes a differential test asserting byte-identical
output to `serde_json`.

### 3. Datagen IO errors panicked the build script

`generate_data_with_data_markers` returns `Result<_, DataError>` but
`unwrap()`ed on IO problems while clearing the output directory. That
manual cleanup was also redundant — `BakedExporter::new` already clears
the directory and reports failures as a `DataError`.

**Fix:** drop the duplicated removal and propagate the error with `?`, so
the caller decides what to do. Also documented that the `generate_data*`
methods recursively remove `mod_directory`, which was previously silent.