### PR TITLE
fix(codegen): fix five codegen bugs that panic or emit invalid Rust

### DIFF
--- a/leptos_i18n_codegen/src/load_locales/interpolate.rs
+++ b/leptos_i18n_codegen/src/load_locales/interpolate.rs
@@ -9,7 +9,7 @@ use leptos_i18n_parser::{
     },
     utils::{Key, KeyPath, UnwrapAt},
 };
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 
 use super::parsed_value;
@@ -288,9 +288,11 @@ impl Interpolation {
             })
             .collect::<Vec<_>>();
 
-        let builder_name = format!("{key}_builder");
+        // `Key` implements `IdentFragment` with its sanitized ident, `Display` yields the raw
+        // name, which can contain `-` and is not a valid ident.
+        let ident = format_ident!("{}_builder", key);
 
-        let ident = syn::Ident::new(&builder_name, Span::call_site());
+        let builder_name = ident.to_string();
 
         let dummy_ident = format_ident!("{}_dummy", ident);
 

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, ops::Not};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Not,
+};
 
 pub mod interpolate;
 pub mod locale;
@@ -712,6 +715,56 @@ fn create_scopes_module_inner(
         })
 }
 
+/// Keys are distinguished by their raw name, but two distinct names can sanitize to the same Rust
+/// identifier: `"a-b"` and `"a_b"` both give `a_b`. Generating an accessor for each of them would
+/// emit duplicate definitions in the same `impl` block, failing the user build with a `E0592`
+/// pointing inside generated code.
+///
+/// Report the offending keys instead, along with the ones to skip so the duplicate definitions
+/// don't bury the actual error.
+fn check_ident_collisions<'a, T>(
+    keys: &'a BTreeMap<Key, T>,
+    key_path: &KeyPath,
+) -> (TokenStream, BTreeSet<&'a Key>) {
+    let mut by_ident: BTreeMap<&syn::Ident, Vec<&Key>> = BTreeMap::new();
+
+    for key in keys.keys() {
+        by_ident.entry(&key.ident).or_default().push(key);
+    }
+
+    let mut errors = TokenStream::new();
+    let mut skipped = BTreeSet::new();
+
+    for (ident, keys) in by_ident {
+        let [first, others @ ..] = &keys[..] else {
+            continue;
+        };
+        if others.is_empty() {
+            continue;
+        }
+
+        skipped.extend(others);
+
+        let path = key_path.to_string();
+        let at = if path.is_empty() {
+            String::new()
+        } else {
+            format!(" at \"{path}\"")
+        };
+        let names = std::iter::once(first)
+            .chain(others)
+            .map(|key| key.name.as_ref())
+            .collect::<Vec<_>>()
+            .join("\", \"");
+        let msg = format!(
+            "conflicting keys{at}: \"{names}\" all resolve to the Rust identifier \"{ident}\", rename them so that they don't conflict.",
+        );
+        errors.extend(quote!(core::compile_error!(#msg);));
+    }
+
+    (errors, skipped)
+}
+
 fn create_locale_type_inner<const IS_TOP: bool>(
     type_ident: &syn::Ident,
     parent_ident: Option<&syn::Ident>,
@@ -728,8 +781,11 @@ fn create_locale_type_inner<const IS_TOP: bool>(
 ) -> TokenStream {
     let translations_key = Key::new(TRANSLATIONS_KEY).unwrap_at("TRANSLATIONS_KEY");
 
+    let (ident_collisions, skipped_keys) = check_ident_collisions(keys, key_path);
+
     let literal_keys = keys
         .iter()
+        .filter(|(key, _)| !skipped_keys.contains(key))
         .filter_map(|(key, value)| match value {
             LocaleValue::Value {
                 value: InterpolOrLit::Lit(t),
@@ -866,6 +922,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
 
     let subkeys = keys
         .iter()
+        .filter(|(key, _)| !skipped_keys.contains(key))
         .filter_map(|(key, value)| match value {
             LocaleValue::Subkeys { locales, keys } => {
                 Some(Subkeys::new(key.clone(), key_path, locales, keys, gen_docs))
@@ -927,6 +984,7 @@ fn create_locale_type_inner<const IS_TOP: bool>(
 
     let builders = keys
         .iter()
+        .filter(|(key, _)| !skipped_keys.contains(key))
         .filter_map(|(key, value)| match value {
             LocaleValue::Value {
                 value: InterpolOrLit::Interpol(keys),
@@ -1216,6 +1274,8 @@ fn create_locale_type_inner<const IS_TOP: bool>(
     };
 
     quote! {
+        #ident_collisions
+
         #docs
         #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
         #[allow(non_camel_case_types, non_snake_case)]
@@ -1298,8 +1358,11 @@ fn create_namespaces_types(
         quote! {}
     };
 
+    let (ident_collisions, skipped_keys) = check_ident_collisions(keys, &KeyPath::new(None));
+
     let namespaces = namespaces
         .iter()
+        .filter(|ns| !skipped_keys.contains(&ns.key))
         .map(|ns| {
             let namespace_module_ident = create_namespace_mod_ident(&ns.key.ident);
             let docs = if gen_docs {
@@ -1445,6 +1508,8 @@ fn create_namespaces_types(
     };
 
     quote! {
+        #ident_collisions
+
         #[doc(hidden)]
         pub mod namespaces {
             use super::{#enum_ident, l_i18n_crate};

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -1589,7 +1589,7 @@ fn create_namespaces_types(
                     #(
                         #deserialize_match_arms,
                     )*
-                    _ => Err(<D::Error as leptos_i18n::reexports::serde::de::Error>::custom(format!("invalid translation unit id: {s}")))
+                    _ => Err(<D::Error as l_i18n_crate::reexports::serde::de::Error>::custom(format!("invalid translation unit id: {s}")))
                 }
             }
         }

--- a/leptos_i18n_codegen/src/load_locales/parsed_value.rs
+++ b/leptos_i18n_codegen/src/load_locales/parsed_value.rs
@@ -46,6 +46,21 @@ pub enum Literal<'a> {
     Bool(bool),
 }
 
+/// `f64` literals are built with `proc_macro2::Literal::f64_suffixed`, which asserts the value is
+/// finite, but formats supporting non-finite floats (`.nan` and `.inf` in YAML, `NaN` and
+/// `Infinity` in JSON5) can produce them. Emit the associated constants for those.
+fn float_to_token_stream(value: f64) -> TokenStream {
+    if value.is_nan() {
+        quote!(f64::NAN)
+    } else if value == f64::INFINITY {
+        quote!(f64::INFINITY)
+    } else if value == f64::NEG_INFINITY {
+        quote!(f64::NEG_INFINITY)
+    } else {
+        ToTokens::to_token_stream(&value)
+    }
+}
+
 impl Literal<'_> {
     fn to_token_stream(&self, strings_count: usize) -> TokenStream {
         match self {
@@ -64,7 +79,7 @@ impl Literal<'_> {
             }
             Literal::Signed(v) => ToTokens::to_token_stream(v),
             Literal::Unsigned(v) => ToTokens::to_token_stream(v),
-            Literal::Float(v) => ToTokens::to_token_stream(v),
+            Literal::Float(v) => float_to_token_stream(*v),
             Literal::Bool(v) => ToTokens::to_token_stream(v),
         }
     }

--- a/leptos_i18n_codegen/src/load_locales/ranges.rs
+++ b/leptos_i18n_codegen/src/load_locales/ranges.rs
@@ -1,4 +1,4 @@
-use std::ops::Bound;
+use std::{fmt::Display, ops::Bound};
 
 use leptos_i18n_parser::{
     parse_locales::{
@@ -63,7 +63,138 @@ impl ToTokens for RangeType {
     }
 }
 
-fn to_tokens_integers_string<T: RangeNumber>(
+/// Integers specific operations, needed to check that a set of ranges covers the whole domain of
+/// the type. `RangeNumber` alone doesn't expose the bounds nor a way to step through values.
+trait IntegerRangeNumber: RangeNumber + Ord + Display {
+    const MIN: Self;
+    const MAX: Self;
+
+    fn checked_pred(self) -> Option<Self>;
+    fn checked_succ(self) -> Option<Self>;
+}
+
+macro_rules! impl_integer_range_number {
+    ($($num_type:ty)*) => {
+        $(
+            impl IntegerRangeNumber for $num_type {
+                const MIN: Self = <$num_type>::MIN;
+                const MAX: Self = <$num_type>::MAX;
+
+                fn checked_pred(self) -> Option<Self> {
+                    self.checked_sub(1)
+                }
+
+                fn checked_succ(self) -> Option<Self> {
+                    self.checked_add(1)
+                }
+            }
+        )*
+    };
+}
+
+impl_integer_range_number!(i8 i16 i32 i64 u8 u16 u32 u64);
+
+/// Push the values matched by `range` as inclusive intervals.
+fn push_covered_intervals<T: IntegerRangeNumber>(range: &Range<T>, covered: &mut Vec<(T, T)>) {
+    match range {
+        Range::Exact(value) => covered.push((*value, *value)),
+        Range::Bounds { start, end } => {
+            let start = start.unwrap_or(T::MIN);
+            let end = match end {
+                Bound::Included(end) => Some(*end),
+                // `x..MIN` matches nothing.
+                Bound::Excluded(end) => end.checked_pred(),
+                Bound::Unbounded => Some(T::MAX),
+            };
+            if let Some(end) = end
+                && start <= end
+            {
+                covered.push((start, end));
+            }
+        }
+        Range::Multiple(ranges) => {
+            for range in ranges {
+                push_covered_intervals(range, covered);
+            }
+        }
+        Range::Fallback => covered.push((T::MIN, T::MAX)),
+    }
+}
+
+/// Compute the inclusive intervals of `T` left unmatched by `ranges`.
+///
+/// Only a fallback is mandatory for floats (`RangeType::should_have_fallback`), so integer ranges
+/// can leave holes in the domain of the count. The generated `match` would then be
+/// non-exhaustive, failing the user build with a `E0004` pointing inside generated code, so the
+/// holes are computed here to report them properly.
+fn uncovered_intervals<T: IntegerRangeNumber>(ranges: &[(Range<T>, ParsedValue)]) -> Vec<(T, T)> {
+    let mut covered = Vec::with_capacity(ranges.len());
+
+    for (range, _) in ranges {
+        push_covered_intervals(range, &mut covered);
+    }
+
+    covered.sort_unstable_by_key(|(start, _)| *start);
+
+    let mut uncovered = Vec::new();
+    // smallest value not covered by the intervals seen so far, `None` means the domain is
+    // exhausted.
+    let mut cursor = Some(T::MIN);
+
+    for (start, end) in covered {
+        let Some(current) = cursor else {
+            break;
+        };
+        if start > current {
+            // `start > current >= T::MIN` so `start` has a predecessor.
+            uncovered.push((
+                current,
+                start.checked_pred().unwrap_at("uncovered_intervals_1"),
+            ));
+        }
+        if end >= current {
+            cursor = end.checked_succ();
+        }
+    }
+
+    if let Some(current) = cursor {
+        uncovered.push((current, T::MAX));
+    }
+
+    uncovered
+}
+
+/// A `_` arm reporting the values not covered by `ranges`, if any.
+fn missing_ranges_arm<T: IntegerRangeNumber>(
+    ranges: &[(Range<T>, ParsedValue)],
+) -> Option<TokenStream> {
+    let uncovered = uncovered_intervals(ranges);
+
+    if uncovered.is_empty() {
+        return None;
+    }
+
+    let missing = uncovered
+        .iter()
+        .map(|(start, end)| {
+            if start == end {
+                format!("{start}")
+            } else {
+                format!("{start}..={end}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let msg = format!(
+        "ranges don't cover every possible value of `{}`, missing: {missing}. Add a \"_\" fallback range or widen the existing ones.",
+        T::TYPE
+    );
+
+    Some(quote!(_ => core::compile_error!(#msg)))
+}
+
+fn to_tokens_integers_string<T: IntegerRangeNumber>(
     ranges: &[(Range<T>, ParsedValue)],
     count_key: &Key,
     strings_count: usize,
@@ -74,12 +205,15 @@ fn to_tokens_integers_string<T: RangeNumber>(
         quote!(#range => #value)
     });
 
+    let missing_ranges_arm = missing_ranges_arm(ranges);
+
     quote! {
         {
             match *#count_key {
                 #(
                     #match_arms,
                 )*
+                #missing_ranges_arm
             }
         }
     }
@@ -111,7 +245,7 @@ fn to_tokens_floats_string<T: RangeNumber>(
     }
 }
 
-fn to_tokens_integers<T: RangeNumber>(
+fn to_tokens_integers<T: IntegerRangeNumber>(
     ranges: &[(Range<T>, ParsedValue)],
     count_key: &Key,
     strings_count: usize,
@@ -140,12 +274,15 @@ fn to_tokens_integers<T: RangeNumber>(
             .map(|key| quote!(let #key = core::clone::Clone::clone(&#key);));
         quote!(#(#keys)*)
     });
+    let missing_ranges_arm = missing_ranges_arm(ranges);
+
     let match_statement = quote! {
         {
             match #count_key() {
                 #(
                     #match_arms,
                 )*
+                #missing_ranges_arm
             }
         }
     };
@@ -318,5 +455,49 @@ fn range_to_token_stream<T: RangeNumber>(range: &Range<T>) -> proc_macro2::Token
                 quote!()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ranges<T: IntegerRangeNumber>(
+        ranges: impl IntoIterator<Item = &'static str>,
+    ) -> Vec<(Range<T>, ParsedValue)> {
+        ranges
+            .into_iter()
+            .map(|range| (Range::new(range).unwrap(), ParsedValue::Default))
+            .collect()
+    }
+
+    #[test]
+    fn full_domain_is_covered() {
+        assert!(uncovered_intervals(&ranges::<i32>(["..0", "0", "1.."])).is_empty());
+        assert!(uncovered_intervals(&ranges::<u8>(["..=127", "128.."])).is_empty());
+        assert!(uncovered_intervals(&ranges::<i8>(["_"])).is_empty());
+        assert!(uncovered_intervals(&ranges::<u8>(["0..=255"])).is_empty());
+        // overlapping ranges
+        assert!(uncovered_intervals(&ranges::<u8>(["..=200", "100.."])).is_empty());
+        // out of order ranges
+        assert!(uncovered_intervals(&ranges::<u8>(["128..", "..=127"])).is_empty());
+        // "|" separated ranges
+        assert!(uncovered_intervals(&ranges::<u8>(["0..=127 | 128..=255"])).is_empty());
+    }
+
+    #[test]
+    fn holes_are_found() {
+        assert_eq!(
+            uncovered_intervals(&ranges::<u8>(["0", "1..=3"])),
+            [(4, 255)]
+        );
+        assert_eq!(
+            uncovered_intervals(&ranges::<i8>(["0", "1..=3"])),
+            [(-128, -1), (4, 127)]
+        );
+        assert_eq!(uncovered_intervals(&ranges::<u8>(["1.."])), [(0, 0)]);
+        assert_eq!(uncovered_intervals(&ranges::<u8>([])), [(0, 255)]);
+        // exclusive end
+        assert_eq!(uncovered_intervals(&ranges::<u8>(["..255"])), [(255, 255)]);
     }
 }

--- a/leptos_i18n_codegen/tests/codegen.rs
+++ b/leptos_i18n_codegen/tests/codegen.rs
@@ -253,3 +253,31 @@ fn non_finite_floats() {
     assert!(code.contains("f64 :: NEG_INFINITY"), "{code}");
     assert!(code.contains("1.5f64"), "{code}");
 }
+
+/// Generated code must only reference the runtime crate through the `l_i18n_crate` alias, the
+/// crate can be renamed or behind a reexport.
+#[test]
+fn no_hardcoded_crate_path() {
+    let cargo = r#"
+[package]
+name = "test"
+
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en"]
+namespaces = ["common"]
+"#;
+    let dir = fixture(
+        "no_hardcoded_crate_path",
+        cargo,
+        &[("locales/en/common.json", r#"{ "hello": "world" }"#)],
+    );
+
+    let code = gen_with(dir, Some("my_renamed_crate"), FileFormat::Json);
+
+    assert!(
+        code.contains("use my_renamed_crate as l_i18n_crate"),
+        "{code}"
+    );
+    assert!(!code.contains("leptos_i18n :: reexports"), "{code}");
+}

--- a/leptos_i18n_codegen/tests/codegen.rs
+++ b/leptos_i18n_codegen/tests/codegen.rs
@@ -153,3 +153,82 @@ fn non_colliding_keys_are_not_reported() {
 
     assert!(!code.contains("compile_error"), "{code}");
 }
+
+/// Extract the brace balanced block following `start`.
+fn block_after(code: &str, start: &str) -> String {
+    let start = code
+        .find(start)
+        .expect("pattern not found in generated code");
+    let block_start = code[start..].find('{').expect("no block found") + start;
+    let mut depth = 0usize;
+    for (i, c) in code[block_start..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return code[block_start..=block_start + i].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced block in generated code");
+}
+
+/// Only floats are required to have a fallback, so integer ranges can leave holes in the domain of
+/// the count, which would generate a non exhaustive `match` (`E0004`).
+#[test]
+fn non_exhaustive_integer_ranges_are_reported() {
+    let dir = fixture(
+        "non_exhaustive_integer_ranges_are_reported",
+        BASE_CARGO,
+        &[(
+            "locales/en.json",
+            r#"{ "r": [["zero", 0], ["some", "1..=3"]] }"#,
+        )],
+    );
+
+    let code = gen_for(dir);
+    let block = block_after(&code, "match var_count ()");
+
+    assert!(block.contains("_ => core :: compile_error !"), "{block}");
+    assert!(
+        block.contains("missing: -2147483648..=-1, 4..=2147483647"),
+        "{block}"
+    );
+}
+
+#[test]
+fn exhaustive_integer_ranges_have_no_wildcard_arm() {
+    let dir = fixture(
+        "exhaustive_integer_ranges_have_no_wildcard_arm",
+        BASE_CARGO,
+        &[(
+            "locales/en.json",
+            r#"{ "r": [["neg", "..0"], ["zero", 0], ["pos", "1.."]] }"#,
+        )],
+    );
+
+    let code = gen_for(dir);
+    let block = block_after(&code, "match var_count ()");
+
+    // an unneeded wildcard arm would trigger `unreachable_patterns` in the user crate.
+    assert!(!block.contains("_ =>"), "{block}");
+}
+
+#[test]
+fn integer_ranges_with_fallback_have_no_error_arm() {
+    let dir = fixture(
+        "integer_ranges_with_fallback_have_no_error_arm",
+        BASE_CARGO,
+        &[(
+            "locales/en.json",
+            r#"{ "r": [["zero", 0], ["some", "1..=3"], ["other", "_"]] }"#,
+        )],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(!code.contains("compile_error"), "{code}");
+}

--- a/leptos_i18n_codegen/tests/codegen.rs
+++ b/leptos_i18n_codegen/tests/codegen.rs
@@ -80,3 +80,76 @@ fn kebab_case_key_without_interpolation() {
 
     assert!(code.contains("pub const fn my_key (self)"));
 }
+
+/// `"a-b"` and `"a_b"` are two distinct keys resolving to the same ident, generating an accessor
+/// for both would emit duplicate methods (`E0592`).
+#[test]
+fn colliding_keys_are_reported() {
+    let dir = fixture(
+        "colliding_keys_are_reported",
+        BASE_CARGO,
+        &[("locales/en.json", r#"{ "a-b": "x", "a_b": "y" }"#)],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(code.contains("conflicting keys"), "{code}");
+    assert!(code.contains("\\\"a-b\\\", \\\"a_b\\\""), "{code}");
+    // the duplicated accessor is skipped so the collision is the only reported error.
+    assert_eq!(code.matches("pub const fn a_b (self)").count(), 1, "{code}");
+}
+
+#[test]
+fn colliding_subkeys_are_reported() {
+    let dir = fixture(
+        "colliding_subkeys_are_reported",
+        BASE_CARGO,
+        &[(
+            "locales/en.json",
+            r#"{ "sub": { "a-b": "x", "a_b": "y" } }"#,
+        )],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(code.contains("conflicting keys at \\\"sub\\\""), "{code}");
+}
+
+#[test]
+fn colliding_namespaces_are_reported() {
+    let cargo = r#"
+[package]
+name = "test"
+
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en"]
+namespaces = ["a-b", "a_b"]
+"#;
+    let dir = fixture(
+        "colliding_namespaces_are_reported",
+        cargo,
+        &[
+            ("locales/en/a-b.json", r#"{ "hello": "world" }"#),
+            ("locales/en/a_b.json", r#"{ "hello": "world" }"#),
+        ],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(code.contains("conflicting keys"), "{code}");
+    assert_eq!(code.matches("pub fn a_b (self)").count(), 1, "{code}");
+}
+
+#[test]
+fn non_colliding_keys_are_not_reported() {
+    let dir = fixture(
+        "non_colliding_keys_are_not_reported",
+        BASE_CARGO,
+        &[("locales/en.json", r#"{ "a-b": "x", "c_d": "y" }"#)],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(!code.contains("compile_error"), "{code}");
+}

--- a/leptos_i18n_codegen/tests/codegen.rs
+++ b/leptos_i18n_codegen/tests/codegen.rs
@@ -232,3 +232,24 @@ fn integer_ranges_with_fallback_have_no_error_arm() {
 
     assert!(!code.contains("compile_error"), "{code}");
 }
+
+/// `proc_macro2` asserts float literals are finite, but YAML and JSON5 can express `NaN` and
+/// infinities.
+#[test]
+fn non_finite_floats() {
+    let dir = fixture(
+        "non_finite_floats",
+        BASE_CARGO,
+        &[(
+            "locales/en.yaml",
+            "nan: .nan\ninf: .inf\nneg_inf: -.inf\nfinite: 1.5\n",
+        )],
+    );
+
+    let code = gen_with(dir, None, FileFormat::Yaml);
+
+    assert!(code.contains("f64 :: NAN"), "{code}");
+    assert!(code.contains("f64 :: INFINITY"), "{code}");
+    assert!(code.contains("f64 :: NEG_INFINITY"), "{code}");
+    assert!(code.contains("1.5f64"), "{code}");
+}

--- a/leptos_i18n_codegen/tests/codegen.rs
+++ b/leptos_i18n_codegen/tests/codegen.rs
@@ -1,0 +1,82 @@
+// `dynamic_load` changes the shape of the generated accessors and needs a translations URI to be
+// configured, the assertions below are written against the default codegen.
+#![cfg(not(feature = "dynamic_load"))]
+
+//! Regression tests for the code generation.
+//!
+//! Each test writes a locale fixture to disk, parses it exactly like the `load_locales!` macro
+//! does and inspects the generated token stream.
+
+use std::path::{Path, PathBuf};
+
+use leptos_i18n_parser::parse_locales::{
+    cfg_file::ConfigFile,
+    options::{Config, FileFormat, ParseOptions},
+    parse_locales,
+};
+
+const BASE_CARGO: &str = r#"
+[package]
+name = "test"
+
+[package.metadata.leptos-i18n]
+default = "en"
+locales = ["en"]
+"#;
+
+fn fixture(name: &str, cargo: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("Cargo.toml"), cargo).unwrap();
+    for (path, content) in files {
+        let path = dir.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+    dir
+}
+
+fn gen_for(dir: PathBuf) -> String {
+    gen_with(dir, None, FileFormat::Json)
+}
+
+fn gen_with(dir: PathBuf, crate_path: Option<&str>, file_format: FileFormat) -> String {
+    let mut manifest_dir = dir;
+    let cfg_file = ConfigFile::new(&mut manifest_dir).unwrap();
+    let mut cfg: Config = cfg_file.into();
+    cfg.options = ParseOptions::default().file_format(file_format);
+    let parsed = parse_locales(Some(manifest_dir), cfg).unwrap();
+    let crate_path = crate_path.map(|path| syn::parse_str::<syn::Path>(path).unwrap());
+    leptos_i18n_codegen::gen_code(&parsed, crate_path.as_ref(), true, None, true)
+        .unwrap()
+        .to_string()
+}
+
+/// `Key` keeps the raw name for display and a sanitized ident for codegen, the builder type must
+/// be named after the ident, `-` is not valid in an ident.
+#[test]
+fn kebab_case_key_with_interpolation() {
+    let dir = fixture(
+        "kebab_case_key_with_interpolation",
+        BASE_CARGO,
+        &[("locales/en.json", r#"{ "my-key": "hello {{ count }}" }"#)],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(code.contains("struct my_key_builder"));
+}
+
+#[test]
+fn kebab_case_key_without_interpolation() {
+    let dir = fixture(
+        "kebab_case_key_without_interpolation",
+        BASE_CARGO,
+        &[("locales/en.json", r#"{ "my-key": "hello" }"#)],
+    );
+
+    let code = gen_for(dir);
+
+    assert!(code.contains("pub const fn my_key (self)"));
+}


### PR DESCRIPTION
### `b5b7afd` — kebab-case keys with interpolations panic

`Interpolation::new` built the builder ident by formatting the key with
`Display` (raw name, dashes included) instead of the sanitized ident every
other site uses. `{ "my-key": "hello {{ count }}" }` panics with
`"my-key_builder" is not a valid Ident`. The plain-string case worked because
no builder is created.

### `da3b53b` — keys colliding on the same Rust identifier

`"a-b"` and `"a_b"` both sanitize to `a_b`, so codegen emitted two
`pub const fn a_b` in the same impl and the user got `E0592: duplicate
definitions` with no hint about the culprits. Colliding keys are now grouped
and reported through `compile_error!` naming every raw key, and duplicates are
skipped so they don't bury the error. Covers root keys, subkeys and namespaces.

### `5346785` — integer ranges leaving holes in the count domain

Only float ranges require a fallback, so `[["zero", 0], ["some", "1..=3"]]`
produced a non-exhaustive `match` over an `i32` (`E0004`). The uncovered
intervals are now computed and, when non-empty, a `_` arm carries a
`compile_error!` listing them. Ranges already covering the domain still emit no
wildcard, to avoid `unreachable_patterns` downstream.

### `4050b10` — non-finite float literals

YAML and JSON5 can express `.nan` / `.inf`, and quoting those through
`ToTokens` hits `assertion failed: f.is_finite()` in `proc-macro2`. Those values
now emit `f64::NAN` / `f64::INFINITY` / `f64::NEG_INFINITY`; finite values are
unchanged.

### `eb4381a` — hardcoded crate name in the namespaces `Deserialize` impl

The impl referenced `leptos_i18n` literally instead of the `l_i18n_crate` alias
every other generated path uses, so a custom `crate_path` (renamed dependency,
`declare_locales!(path: …)`) failed with `E0433` in namespaces mode.