### PR TITLE
add fallible context accessors

### DIFF
--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -43,6 +43,26 @@ pub fn Foo() -> impl IntoView {
 }
 ```
 
+## Access the Context Without a Provider
+
+`use_i18n` panics if no context has been provided. If a component can be rendered outside of any `I18nContextProvider`, such as a shared loading placeholder or an error screen, use `try_use_i18n` instead: it returns `Option<I18nContext<Locale>>` and lets you fallback instead of panicking.
+
+```rust,ignore
+use crate::i18n::*;
+use leptos::prelude::*;
+
+#[component]
+pub fn Loading() -> impl IntoView {
+    let Some(i18n) = try_use_i18n() else {
+        return view! { <p>"Loading..."</p> }.into_any();
+    };
+
+    view! { <p>{t!(i18n, loading)}</p> }.into_any()
+}
+```
+
+A scoped counterpart exists: `try_use_i18n_scoped::<MyScope>()`.
+
 ## Access the Current Locale
 
 With the context, you can access the current locale with the `get_locale` method:

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -485,7 +485,17 @@ pub fn i18n_sub_context_provider_island<L: Locale>(
 #[inline]
 #[track_caller]
 pub fn use_i18n_context<L: Locale>() -> I18nContext<L> {
-    I18nContext::from_context().expect("I18n context is missing")
+    try_use_i18n_context().expect("I18n context is missing")
+}
+
+/// Return the `I18nContext` previously set, or `None` if it is missing.
+///
+/// This is the fallible counterpart to `use_i18n_context`, for components that can be
+/// rendered outside of any provider and want to fallback instead of panicking.
+#[inline]
+#[track_caller]
+pub fn try_use_i18n_context<L: Locale>() -> Option<I18nContext<L>> {
+    I18nContext::from_context()
 }
 
 /// Return the `I18nContext` previously set.
@@ -498,6 +508,17 @@ pub fn use_i18n_context<L: Locale>() -> I18nContext<L> {
 #[track_caller]
 pub fn use_i18n_with_scope<L: Locale, S: Scope<L>>() -> I18nContext<L, S> {
     use_i18n_context::<L>().scope()
+}
+
+/// Return the `I18nContext` previously set, or `None` if it is missing.
+///
+/// Is scoped to the given scope.
+///
+/// This is the fallible counterpart to `use_i18n_with_scope`, for components that can be
+/// rendered outside of any provider and want to fallback instead of panicking.
+#[track_caller]
+pub fn try_use_i18n_with_scope<L: Locale, S: Scope<L>>() -> Option<I18nContext<L, S>> {
+    try_use_i18n_context::<L>().map(I18nContext::scope)
 }
 
 #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
@@ -660,5 +681,76 @@ impl<L: Locale, S: Scope<L>> Fn<(L,)> for I18nContext<L, S> {
     #[inline]
     extern "rust-call" fn call(&self, (locale,): (L,)) -> Self::Output {
         self.set_locale(locale)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    leptos_i18n_macro::declare_locales! {
+        path: crate,
+        default: "en",
+        locales: ["en", "fr"],
+        en: {
+            sk: {
+                ssk: "test en",
+            },
+        },
+        fr: {
+            sk: {
+                ssk: "test fr",
+            },
+        },
+    }
+
+    use super::{I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context};
+    use core::marker::PhantomData;
+    use i18n::Locale;
+    use leptos::prelude::*;
+
+    type SkScope = leptos_i18n_macro::define_scope!(i18n, sk);
+
+    fn make_context() -> I18nContext<Locale> {
+        #[cfg(feature = "unified_contexts")]
+        let locale_signal = {
+            use crate::Locale as _;
+            RwSignal::new(super::AnyLocale(Locale::fr.as_str()))
+        };
+        #[cfg(not(feature = "unified_contexts"))]
+        let locale_signal = RwSignal::new(Locale::fr);
+
+        I18nContext {
+            locale_signal,
+            locale_marker: PhantomData,
+            scope_marker: PhantomData,
+        }
+    }
+
+    #[test]
+    fn try_use_context_without_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            assert!(try_use_i18n_context::<Locale>().is_none());
+            assert!(try_use_i18n_with_scope::<Locale, SkScope>().is_none());
+            assert!(i18n::try_use_i18n().is_none());
+            assert!(i18n::try_use_i18n_scoped::<SkScope>().is_none());
+        });
+    }
+
+    #[test]
+    fn try_use_context_with_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            I18nContext::provide(make_context());
+
+            let ctx = try_use_i18n_context::<Locale>().expect("context should be found");
+            assert_eq!(ctx.get_locale_untracked(), Locale::fr);
+            assert_eq!(
+                use_i18n_context::<Locale>().get_locale_untracked(),
+                Locale::fr
+            );
+
+            let scoped = i18n::try_use_i18n_scoped::<SkScope>().expect("context should be found");
+            assert_eq!(scoped.get_locale_untracked(), Locale::fr);
+        });
     }
 }

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -131,7 +131,10 @@ pub use macro_helpers::formatting;
 
 pub use locale_traits::{Direction, Locale, LocaleKeys};
 
-pub use context::{I18nContext, use_i18n_context, use_i18n_with_scope};
+pub use context::{
+    I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context,
+    use_i18n_with_scope,
+};
 
 #[allow(deprecated)]
 pub use context::provide_i18n_context;

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -252,10 +252,24 @@ pub fn load_locales(
                 l_i18n_crate::use_i18n_context()
             }
 
+            /// Same as `use_i18n` but return `None` if no context has been provided instead of panicking.
+            #[inline]
+            #[track_caller]
+            pub fn try_use_i18n() -> Option<l_i18n_crate::I18nContext<#enum_ident>> {
+                l_i18n_crate::try_use_i18n_context()
+            }
+
             #[inline]
             #[track_caller]
             pub fn use_i18n_scoped<S: l_i18n_crate::Scope<#enum_ident>>() -> l_i18n_crate::I18nContext<#enum_ident, S> {
                 l_i18n_crate::use_i18n_with_scope()
+            }
+
+            /// Same as `use_i18n_scoped` but return `None` if no context has been provided instead of panicking.
+            #[inline]
+            #[track_caller]
+            pub fn try_use_i18n_scoped<S: l_i18n_crate::Scope<#enum_ident>>() -> Option<l_i18n_crate::I18nContext<#enum_ident, S>> {
+                l_i18n_crate::try_use_i18n_with_scope()
             }
 
             #[deprecated(

--- a/tests/json/src/context.rs
+++ b/tests/json/src/context.rs
@@ -1,0 +1,13 @@
+use crate::i18n::*;
+
+#[test]
+fn try_use_i18n_without_provider() {
+    assert!(try_use_i18n().is_none());
+}
+
+#[test]
+fn try_use_i18n_scoped_without_provider() {
+    type SubkeysScope = define_scope!(crate::i18n, subkeys);
+
+    assert!(try_use_i18n_scoped::<SubkeysScope>().is_none());
+}

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -4,6 +4,7 @@
 include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
 
 mod components;
+mod context;
 mod defaulted;
 mod foreign;
 mod formatting;


### PR DESCRIPTION
Closes #328.

## Problem

`use_i18n` panics when no provider is mounted, since it resolves to
`I18nContext::from_context().expect("I18n context is missing")`. That makes it impossible to
render shared components outside of an `I18nContextProvider` — loading placeholders, error
screens — and there was no public way to check whether a provider exists first:
`from_context` is `pub(crate)`, and under `unified_contexts` the context stores a private
`AnyLocale` type, so `use_context` cannot be called with public types either.

## Approach

This takes option 1 from the issue (a public fallible accessor) rather than making
`from_context` public, so the `unified_contexts` `AnyLocale` signal type stays private.

Added to `leptos_i18n`:

- `try_use_i18n_context::<L>() -> Option<I18nContext<L>>`
- `try_use_i18n_with_scope::<L, S>() -> Option<I18nContext<L, S>>`

And in the generated `i18n` module:

- `try_use_i18n() -> Option<I18nContext<Locale>>`
- `try_use_i18n_scoped::<S>() -> Option<I18nContext<Locale, S>>`

`use_i18n_context` now routes through `try_use_i18n_context().expect(...)`, so there is a single
code path and the panicking behaviour is unchanged.

```rust
#[component]
pub fn Loading() -> impl IntoView {
    let Some(i18n) = try_use_i18n() else {
        return view! { <p>"Loading..."</p> }.into_any();
    };

    view! { <p>{t!(i18n, loading)}</p> }.into_any()
}
```

The scoped variants are there to mirror the existing `use_i18n_with_scope` / `use_i18n_scoped`
pair — happy to drop them if you prefer a narrower surface, since
`try_use_i18n().map(|i18n| i18n.scope::<S>())` covers that case.

Also documented in the book, under a new "Access the Context Without a Provider" section in
`docs/book/src/usage/02_context.md`.

## Tests

- `leptos_i18n/src/context.rs` — unit tests over the missing-context and present-context cases,
  including the scoped accessors, using `declare_locales!`.
- `tests/json/src/context.rs` — checks the build-script codegen path exposes `try_use_i18n` and
  `try_use_i18n_scoped`.

Both new unit tests were confirmed to fail when the provide / no-provide setup is inverted, then
restored, so they do gate.

## Verification

Run locally and green: `cargo fmt --check`, `cargo clippy --workspace --all-targets`,
`cargo test -p leptos_i18n`, and the five `tests/*` suites CI runs.

`cargo-all-features` was not available locally, so instead of the full matrix, clippy and tests
were run over the feature combinations this change touches: `unified_contexts`, `islands`, `csr`,
`hydrate`, `dynamic_load`, `unified_contexts,islands` and `dynamic_load,unified_contexts`. The
`nightly` combinations were not exercised locally — CI covers those.
