### PR TITLE
add falling back context accessors

### DIFF
--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -63,6 +63,22 @@ pub fn Loading() -> impl IntoView {
 
 A scoped counterpart exists: `try_use_i18n_scoped::<MyScope>()`.
 
+If you would rather fallback to a locale than branch on an `Option`, use `use_i18n_or`, which takes the locale to fallback on, or `use_i18n_or_else`, which only computes that locale if no context is found:
+
+```rust,ignore
+use crate::i18n::*;
+use leptos::prelude::*;
+
+#[component]
+pub fn Loading() -> impl IntoView {
+    let i18n = use_i18n_or(Locale::en);
+
+    view! { <p>{t!(i18n, loading)}</p> }
+}
+```
+
+The fallback context is standalone: it is not provided to the children of the component, it is not backed by a cookie, and it does not sync with any other context, so calling `set_locale` on it only affects that one instance. It is a plain signal, so it is created anew on every call that does not find a context.
+
 ## Access the Current Locale
 
 With the context, you can access the current locale with the `get_locale` method:

--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -43,6 +43,26 @@ pub fn Foo() -> impl IntoView {
 }
 ```
 
+## Access the Context Without a Provider
+
+`use_i18n` panics if no context has been provided. If a component can be rendered outside of any `I18nContextProvider`, such as a shared loading placeholder or an error screen, use `try_use_i18n` instead: it returns `Option<I18nContext<Locale>>` and lets you fallback instead of panicking.
+
+```rust,ignore
+use crate::i18n::*;
+use leptos::prelude::*;
+
+#[component]
+pub fn Loading() -> impl IntoView {
+    let Some(i18n) = try_use_i18n() else {
+        return view! { <p>"Loading..."</p> }.into_any();
+    };
+
+    view! { <p>{t!(i18n, loading)}</p> }.into_any()
+}
+```
+
+A scoped counterpart exists: `try_use_i18n_scoped::<MyScope>()`.
+
 ## Access the Current Locale
 
 With the context, you can access the current locale with the `get_locale` method:

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -485,7 +485,17 @@ pub fn i18n_sub_context_provider_island<L: Locale>(
 #[inline]
 #[track_caller]
 pub fn use_i18n_context<L: Locale>() -> I18nContext<L> {
-    I18nContext::from_context().expect("I18n context is missing")
+    try_use_i18n_context().expect("I18n context is missing")
+}
+
+/// Return the `I18nContext` previously set, or `None` if it is missing.
+///
+/// This is the fallible counterpart to `use_i18n_context`, for components that can be
+/// rendered outside of any provider and want to fallback instead of panicking.
+#[inline]
+#[track_caller]
+pub fn try_use_i18n_context<L: Locale>() -> Option<I18nContext<L>> {
+    I18nContext::from_context()
 }
 
 /// Return the `I18nContext` previously set.
@@ -498,6 +508,17 @@ pub fn use_i18n_context<L: Locale>() -> I18nContext<L> {
 #[track_caller]
 pub fn use_i18n_with_scope<L: Locale, S: Scope<L>>() -> I18nContext<L, S> {
     use_i18n_context::<L>().scope()
+}
+
+/// Return the `I18nContext` previously set, or `None` if it is missing.
+///
+/// Is scoped to the given scope.
+///
+/// This is the fallible counterpart to `use_i18n_with_scope`, for components that can be
+/// rendered outside of any provider and want to fallback instead of panicking.
+#[track_caller]
+pub fn try_use_i18n_with_scope<L: Locale, S: Scope<L>>() -> Option<I18nContext<L, S>> {
+    try_use_i18n_context::<L>().map(I18nContext::scope)
 }
 
 #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
@@ -660,5 +681,76 @@ impl<L: Locale, S: Scope<L>> Fn<(L,)> for I18nContext<L, S> {
     #[inline]
     extern "rust-call" fn call(&self, (locale,): (L,)) -> Self::Output {
         self.set_locale(locale)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    leptos_i18n_macro::declare_locales! {
+        path: crate,
+        default: "en",
+        locales: ["en", "fr"],
+        en: {
+            sk: {
+                ssk: "test en",
+            },
+        },
+        fr: {
+            sk: {
+                ssk: "test fr",
+            },
+        },
+    }
+
+    use super::{I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context};
+    use core::marker::PhantomData;
+    use i18n::Locale;
+    use leptos::prelude::*;
+
+    type SkScope = leptos_i18n_macro::define_scope!(i18n, sk);
+
+    fn make_context() -> I18nContext<Locale> {
+        #[cfg(feature = "unified_contexts")]
+        let locale_signal = {
+            use crate::Locale as _;
+            RwSignal::new(super::AnyLocale(Locale::fr.as_str()))
+        };
+        #[cfg(not(feature = "unified_contexts"))]
+        let locale_signal = RwSignal::new(Locale::fr);
+
+        I18nContext {
+            locale_signal,
+            locale_marker: PhantomData,
+            scope_marker: PhantomData,
+        }
+    }
+
+    #[test]
+    fn try_use_context_without_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            assert!(try_use_i18n_context::<Locale>().is_none());
+            assert!(try_use_i18n_with_scope::<Locale, SkScope>().is_none());
+            assert!(i18n::try_use_i18n().is_none());
+            assert!(i18n::try_use_i18n_scoped::<SkScope>().is_none());
+        });
+    }
+
+    #[test]
+    fn try_use_context_with_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            I18nContext::provide(make_context());
+
+            let ctx = try_use_i18n_context::<Locale>().expect("context should be found");
+            assert_eq!(ctx.get_locale_untracked(), Locale::fr);
+            assert_eq!(
+                use_i18n_context::<Locale>().get_locale_untracked(),
+                Locale::fr
+            );
+
+            let scoped = i18n::try_use_i18n_scoped::<SkScope>().expect("context should be found");
+            assert_eq!(scoped.get_locale_untracked(), Locale::fr);
+        });
     }
 }

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -221,6 +221,22 @@ fn init_context_inner<L: Locale>(
     }
 }
 
+/// Create a standalone `I18nContext` for the given locale.
+///
+/// It is not tied to any provider: no cookie, no locale resolution, no effects.
+fn detached_context<L: Locale>(locale: L) -> I18nContext<L> {
+    #[cfg(feature = "unified_contexts")]
+    let locale_signal = RwSignal::new(AnyLocale(locale.as_str()));
+    #[cfg(not(feature = "unified_contexts"))]
+    let locale_signal = RwSignal::new(locale);
+
+    I18nContext {
+        locale_signal,
+        locale_marker: PhantomData,
+        scope_marker: PhantomData,
+    }
+}
+
 // *********************************************
 // * CONTEXT
 // *********************************************
@@ -498,6 +514,31 @@ pub fn try_use_i18n_context<L: Locale>() -> Option<I18nContext<L>> {
     I18nContext::from_context()
 }
 
+/// Return the `I18nContext` previously set, or a standalone one for the given locale if it is
+/// missing.
+///
+/// The fallback context is detached: it is not provided to children, is not backed by a cookie and
+/// does not sync with any other context, so `set_locale` on it only affects that instance.
+/// It allocates a signal on each call where no context is found.
+#[inline]
+#[track_caller]
+pub fn use_i18n_context_or<L: Locale>(locale: L) -> I18nContext<L> {
+    try_use_i18n_context().unwrap_or_else(|| detached_context(locale))
+}
+
+/// Return the `I18nContext` previously set, or a standalone one for the locale returned by `f` if
+/// it is missing.
+///
+/// `f` is only called when no context is found.
+/// The fallback context is detached: it is not provided to children, is not backed by a cookie and
+/// does not sync with any other context, so `set_locale` on it only affects that instance.
+/// It allocates a signal on each call where no context is found.
+#[inline]
+#[track_caller]
+pub fn use_i18n_context_or_else<L: Locale>(f: impl FnOnce() -> L) -> I18nContext<L> {
+    try_use_i18n_context().unwrap_or_else(|| detached_context(f()))
+}
+
 /// Return the `I18nContext` previously set.
 ///
 /// Is scoped to the given scope.
@@ -702,28 +743,15 @@ mod test {
         },
     }
 
-    use super::{I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context};
-    use core::marker::PhantomData;
+    use super::{
+        I18nContext, detached_context, try_use_i18n_context, try_use_i18n_with_scope,
+        use_i18n_context, use_i18n_context_or, use_i18n_context_or_else,
+    };
+    use core::cell::Cell;
     use i18n::Locale;
     use leptos::prelude::*;
 
     type SkScope = leptos_i18n_macro::define_scope!(i18n, sk);
-
-    fn make_context() -> I18nContext<Locale> {
-        #[cfg(feature = "unified_contexts")]
-        let locale_signal = {
-            use crate::Locale as _;
-            RwSignal::new(super::AnyLocale(Locale::fr.as_str()))
-        };
-        #[cfg(not(feature = "unified_contexts"))]
-        let locale_signal = RwSignal::new(Locale::fr);
-
-        I18nContext {
-            locale_signal,
-            locale_marker: PhantomData,
-            scope_marker: PhantomData,
-        }
-    }
 
     #[test]
     fn try_use_context_without_provider() {
@@ -740,7 +768,7 @@ mod test {
     fn try_use_context_with_provider() {
         let owner = Owner::new();
         owner.with(|| {
-            I18nContext::provide(make_context());
+            I18nContext::provide(detached_context(Locale::fr));
 
             let ctx = try_use_i18n_context::<Locale>().expect("context should be found");
             assert_eq!(ctx.get_locale_untracked(), Locale::fr);
@@ -751,6 +779,79 @@ mod test {
 
             let scoped = i18n::try_use_i18n_scoped::<SkScope>().expect("context should be found");
             assert_eq!(scoped.get_locale_untracked(), Locale::fr);
+        });
+    }
+
+    #[test]
+    fn use_context_or_without_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let ctx = use_i18n_context_or(Locale::fr);
+            assert_eq!(ctx.get_locale_untracked(), Locale::fr);
+            assert_eq!(
+                i18n::use_i18n_or(Locale::fr).get_locale_untracked(),
+                Locale::fr
+            );
+
+            let called = Cell::new(false);
+            let ctx = use_i18n_context_or_else(|| {
+                called.set(true);
+                Locale::fr
+            });
+            assert_eq!(ctx.get_locale_untracked(), Locale::fr);
+            assert!(called.get(), "the fallback should be called");
+
+            assert_eq!(
+                i18n::use_i18n_or_else(|| Locale::fr).get_locale_untracked(),
+                Locale::fr
+            );
+        });
+    }
+
+    #[test]
+    fn use_context_or_with_provider() {
+        let owner = Owner::new();
+        owner.with(|| {
+            I18nContext::provide(detached_context(Locale::fr));
+
+            // the provided context wins, the fallback locale is ignored
+            assert_eq!(
+                use_i18n_context_or(Locale::en).get_locale_untracked(),
+                Locale::fr
+            );
+            assert_eq!(
+                i18n::use_i18n_or(Locale::en).get_locale_untracked(),
+                Locale::fr
+            );
+
+            let called = Cell::new(false);
+            let ctx = use_i18n_context_or_else(|| {
+                called.set(true);
+                Locale::en
+            });
+            assert_eq!(ctx.get_locale_untracked(), Locale::fr);
+            assert!(!called.get(), "the fallback should not be called");
+
+            assert_eq!(
+                i18n::use_i18n_or_else(|| Locale::en).get_locale_untracked(),
+                Locale::fr
+            );
+        });
+    }
+
+    #[test]
+    fn fallback_context_is_detached() {
+        let owner = Owner::new();
+        owner.with(|| {
+            let ctx = use_i18n_context_or(Locale::en);
+            ctx.set_locale_untracked(Locale::fr);
+
+            // the fallback is standalone: setting its locale provides nothing to the tree
+            assert!(try_use_i18n_context::<Locale>().is_none());
+            assert_eq!(
+                use_i18n_context_or(Locale::en).get_locale_untracked(),
+                Locale::en
+            );
         });
     }
 }

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -131,7 +131,10 @@ pub use macro_helpers::formatting;
 
 pub use locale_traits::{Direction, Locale, LocaleKeys};
 
-pub use context::{I18nContext, use_i18n_context, use_i18n_with_scope};
+pub use context::{
+    I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context,
+    use_i18n_with_scope,
+};
 
 #[allow(deprecated)]
 pub use context::provide_i18n_context;

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -133,7 +133,7 @@ pub use locale_traits::{Direction, Locale, LocaleKeys};
 
 pub use context::{
     I18nContext, try_use_i18n_context, try_use_i18n_with_scope, use_i18n_context,
-    use_i18n_with_scope,
+    use_i18n_context_or, use_i18n_context_or_else, use_i18n_with_scope,
 };
 
 #[allow(deprecated)]

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -259,6 +259,20 @@ pub fn load_locales(
                 l_i18n_crate::try_use_i18n_context()
             }
 
+            /// Same as `use_i18n` but return a standalone context for the given locale if no context has been provided instead of panicking.
+            #[inline]
+            #[track_caller]
+            pub fn use_i18n_or(locale: #enum_ident) -> l_i18n_crate::I18nContext<#enum_ident> {
+                l_i18n_crate::use_i18n_context_or(locale)
+            }
+
+            /// Same as `use_i18n_or` but the fallback locale is only computed if no context has been provided.
+            #[inline]
+            #[track_caller]
+            pub fn use_i18n_or_else(f: impl FnOnce() -> #enum_ident) -> l_i18n_crate::I18nContext<#enum_ident> {
+                l_i18n_crate::use_i18n_context_or_else(f)
+            }
+
             #[inline]
             #[track_caller]
             pub fn use_i18n_scoped<S: l_i18n_crate::Scope<#enum_ident>>() -> l_i18n_crate::I18nContext<#enum_ident, S> {

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -252,10 +252,24 @@ pub fn load_locales(
                 l_i18n_crate::use_i18n_context()
             }
 
+            /// Same as `use_i18n` but return `None` if no context has been provided instead of panicking.
+            #[inline]
+            #[track_caller]
+            pub fn try_use_i18n() -> Option<l_i18n_crate::I18nContext<#enum_ident>> {
+                l_i18n_crate::try_use_i18n_context()
+            }
+
             #[inline]
             #[track_caller]
             pub fn use_i18n_scoped<S: l_i18n_crate::Scope<#enum_ident>>() -> l_i18n_crate::I18nContext<#enum_ident, S> {
                 l_i18n_crate::use_i18n_with_scope()
+            }
+
+            /// Same as `use_i18n_scoped` but return `None` if no context has been provided instead of panicking.
+            #[inline]
+            #[track_caller]
+            pub fn try_use_i18n_scoped<S: l_i18n_crate::Scope<#enum_ident>>() -> Option<l_i18n_crate::I18nContext<#enum_ident, S>> {
+                l_i18n_crate::try_use_i18n_with_scope()
             }
 
             #[deprecated(

--- a/tests/json/src/context.rs
+++ b/tests/json/src/context.rs
@@ -1,4 +1,5 @@
 use crate::i18n::*;
+use tests_common::*;
 
 #[test]
 fn try_use_i18n_without_provider() {
@@ -10,4 +11,17 @@ fn try_use_i18n_scoped_without_provider() {
     type SubkeysScope = define_scope!(crate::i18n, subkeys);
 
     assert!(try_use_i18n_scoped::<SubkeysScope>().is_none());
+}
+
+#[test]
+fn use_i18n_or_without_provider() {
+    let i18n = use_i18n_or(Locale::fr);
+    assert_eq!(i18n.get_locale_untracked(), Locale::fr);
+    assert_eq_rendered!(t!(i18n, click_to_change_lang), "Cliquez pour changez de langue");
+}
+
+#[test]
+fn use_i18n_or_else_without_provider() {
+    let i18n = use_i18n_or_else(|| Locale::fr);
+    assert_eq!(i18n.get_locale_untracked(), Locale::fr);
 }

--- a/tests/json/src/context.rs
+++ b/tests/json/src/context.rs
@@ -1,0 +1,13 @@
+use crate::i18n::*;
+
+#[test]
+fn try_use_i18n_without_provider() {
+    assert!(try_use_i18n().is_none());
+}
+
+#[test]
+fn try_use_i18n_scoped_without_provider() {
+    type SubkeysScope = define_scope!(crate::i18n, subkeys);
+
+    assert!(try_use_i18n_scoped::<SubkeysScope>().is_none());
+}

--- a/tests/json/src/lib.rs
+++ b/tests/json/src/lib.rs
@@ -4,6 +4,7 @@
 include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
 
 mod components;
+mod context;
 mod defaulted;
 mod foreign;
 mod formatting;


### PR DESCRIPTION
> **Stacked on #331** — it branches off that PR's branch, so the diff here contains #331's commit
> until that one merges. Only the second commit, `add falling back context accessors`, is new.
> Please review #331 first.

## Problem

#331 adds `try_use_i18n`, which returns an `Option`. That is the right primitive, but at a call
site it forces a branch *and* a change of macro — `t!(i18n, key)` in one arm, `td!(Locale::en, key)`
in the other:

```rust
let Some(i18n) = try_use_i18n() else {
    return view! { <p>{td!(Locale::en, loading)}</p> }.into_any();
};
view! { <p>{t!(i18n, loading)}</p> }.into_any()
```

## Approach

Add a pair that falls back to a locale, so one `t!` call site works either way:

```rust
let i18n = use_i18n_or(Locale::en);
view! { <p>{t!(i18n, loading)}</p> }
```

In `leptos_i18n`:

- `use_i18n_context_or::<L>(locale: L) -> I18nContext<L>`
- `use_i18n_context_or_else::<L>(f: impl FnOnce() -> L) -> I18nContext<L>`

In the generated `i18n` module: `use_i18n_or(locale)` and `use_i18n_or_else(f)`.

### Naming

No `try_` prefix, so the family mirrors `Option`: `try_` marks the fallible operation returning an
`Option`, `_or` / `_or_else` mark the infallible ones taking a fallback, the way `unwrap_or` relates
to `unwrap`.

```
use_i18n_context()           -> I18nContext<L>          // panics
try_use_i18n_context()       -> Option<I18nContext<L>>
use_i18n_context_or(..)      -> I18nContext<L>
use_i18n_context_or_else(..) -> I18nContext<L>
```

### The fallback context

The argument is a locale rather than a context, because there is no cheap way to build an
`I18nContext` — every public constructor goes through `init_context_inner`, which creates two
effects and resolves cookie/locale through `leptos_use`. So this adds a private `detached_context`
helper: a bare `RwSignal` over the locale, no effects, no cookie, not provided to children.

That means the fallback is standalone — `set_locale` on it only affects that instance, and a call
that finds no context allocates a signal each time. Both are documented on the functions and in the
book.

`detached_context` also replaces the hand-rolled test helper #331 added, which was the same code.

No scoped `_or` variants: `use_i18n_context_or(locale).scope::<S>()` covers it and four more
functions did not seem worth it — happy to add them if you would rather have the symmetry.

## Tests

`leptos_i18n/src/context.rs`: fallback used when no context exists; provided context wins and the
fallback locale is ignored when one does; `_or_else` closure is *not* called in that case; and the
fallback really is detached. `tests/json/src/context.rs` covers the build-script codegen path,
including rendering `t!` off the fallback with no provider anywhere.

Each new assertion was confirmed to go red against a deliberately broken implementation (fallback
winning over a provided context, and eager evaluation of the `_or_else` closure) before being
restored.

## Verification

Green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets`,
`cargo test -p leptos_i18n`, and the five `tests/*` suites CI runs.

`cargo-all-features` is not installed here, so in place of the full matrix, clippy and tests were
run over the combinations this touches — `unified_contexts`, `islands`, `csr`, `hydrate`,
`dynamic_load`, `unified_contexts,islands`, `dynamic_load,unified_contexts`. `unified_contexts`
matters most, since `detached_context` has a `cfg` branch on it. The `nightly` combinations were
not run locally.
