### PR TITLE
refactor: replace leptos-use with in-crate cookie and Accept-Language…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,17 +565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,12 +1893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,32 +1937,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_split_helpers",
- "web-sys",
-]
-
-[[package]]
-name = "leptos-use"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cded1fffd0646ff028f38552724be36054052a35d293531c8766bbeb25dcc5"
-dependencies = [
- "actix-web",
- "cfg-if",
- "codee",
- "cookie",
- "default-struct-builder",
- "http 0.2.12",
- "http 1.4.0",
- "js-sys",
- "lazy_static",
- "leptos",
- "leptos_actix",
- "leptos_axum",
- "paste",
- "send_wrapper",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -2081,11 +2038,12 @@ dependencies = [
 name = "leptos_i18n"
 version = "0.6.2"
 dependencies = [
+ "actix-web",
  "async-once-cell",
- "codee",
  "default-struct-builder",
  "fixed_decimal",
  "futures",
+ "http 1.4.0",
  "icu_calendar",
  "icu_datetime",
  "icu_decimal",
@@ -2096,7 +2054,8 @@ dependencies = [
  "icu_provider",
  "js-sys",
  "leptos",
- "leptos-use",
+ "leptos_actix",
+ "leptos_axum",
  "leptos_i18n_macro",
  "leptos_meta",
  "serde",
@@ -2105,6 +2064,7 @@ dependencies = [
  "tinystr",
  "typed-builder",
  "wasm-bindgen",
+ "web-sys",
  "writeable",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ leptos_i18n_build = { path = "./leptos_i18n_build", version = "0.6.2", default-f
 leptos = { version = "0.8", default-features = false }
 leptos_router = { version = "0.8", default-features = false }
 leptos_meta = { version = "0.8", default-features = false }
+leptos_axum = { version = "0.8", default-features = false }
+leptos_actix = { version = "0.8", default-features = false }
 
 # icu
 icu = { version = "2.2", default-features = false }
@@ -47,12 +49,10 @@ tinystr = { default-features = false, version = "0.8" }
 default-struct-builder = { default-features = false, version = "0.5" }
 serde_json = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-leptos-use = { default-features = false, version = "0.18" }
 writeable = { default-features = false, version = "0.6" }
 prettyplease = { default-features = false, version = "0.2" }
 serde-wasm-bindgen = { default-features = false, version = "0.6" }
 serde_yaml = { default-features = false, version = "0.9" }
-codee = { default-features = false, version = "0.3" }
 json5 = { default-features = false, version = "1.3" }
 quote = { default-features = false, version = "1.0" }
 toml = { default-features = false, version = "1.1" }
@@ -63,3 +63,6 @@ typed-builder = { default-features = false, version = "0.23" }
 proc-macro2 = { default-features = false, version = "1.0" }
 serde = { default-features = false, version = "1.0" }
 js-sys = { default-features = false, version = "0.3" }
+web-sys = { default-features = false, version = "0.3" }
+http = { default-features = false, version = "1" }
+actix-web = { default-features = false, version = "4" }

--- a/docs/book/src/usage/02_context.md
+++ b/docs/book/src/usage/02_context.md
@@ -122,7 +122,8 @@ The `I18nContextProvider` component accepts multiple props, all optional (except
 - `set_dir_attr_on_html`: whether to set the "dir" attribute on the root `<html>` element (default to true)
 - `enable_cookie`: should set a cookie to keep track of the locale when the page reloads (default to true) (do nothing without the "cookie" feature)
 - `cookie_name`: give a custom name to the cookie (default to the crate default value) (do nothing without the "cookie" feature or if `enable_cookie` is false)
-- `cookie_options`: options for the cookie, the value is of type `leptos_use::UseCookieOptions<Locale>` (default to `Default::default`)
+- `cookie_options`: options for the cookie, the value is of type `leptos_i18n::context::CookieOptions` (default to `Default::default`)
+- `ssr_lang_header_getter`: options for reading the visitor's preferred locales, the value is of type `leptos_i18n::context::UseLocalesOptions` (default to `Default::default`)
 
 ## Note on Island
 
@@ -141,7 +142,7 @@ fn MyI18nProvider(
     cookie_name: Option<&str>,
     children: Children
 ) -> impl IntoView {
-    let my_cookie_options: CookieOptions<Locale> = /* create your options here */;
+    let my_cookie_options: CookieOptions = /* create your options here */;
     let ssr_lang_header_getter: UseLocalesOptions = /* create your options here */;
     let i18n = init_i18n_context_with_options::<Locale>(
         enable_cookie,

--- a/leptos_i18n/Cargo.toml
+++ b/leptos_i18n/Cargo.toml
@@ -11,14 +11,19 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos-use = { default-features = false, features = [
-  "use_locales",
-  "use_cookie",
-], workspace = true }
 leptos_i18n_macro = { workspace = true }
 leptos = { workspace = true, default-features = false }
 leptos_meta = { workspace = true, default-features = false }
-codee = { workspace = true, default-features = true }
+leptos_axum = { workspace = true, optional = true }
+leptos_actix = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
+actix-web = { workspace = true, optional = true }
+web-sys = { workspace = true, features = [
+  "Document",
+  "HtmlDocument",
+  "Navigator",
+  "Window",
+] }
 icu_locale = { workspace = true, default-features = false }
 icu_provider = { workspace = true, optional = true, features = [
   "sync",
@@ -97,8 +102,8 @@ format_currency = [
 
 
 # Target features
-actix = ["ssr", "leptos-use/actix"]
-axum = ["ssr", "leptos-use/axum"]
+actix = ["ssr", "dep:leptos_actix", "dep:actix-web"]
+axum = ["ssr", "dep:leptos_axum", "dep:http"]
 hydrate = [
   "leptos/hydrate",
   "leptos_i18n_macro/hydrate",
@@ -109,7 +114,6 @@ csr = ["leptos/csr", "leptos_i18n_macro/csr"]
 ssr = [
   "leptos/ssr",
   "leptos_meta/ssr",
-  "leptos-use/ssr",
   "leptos_i18n_macro/ssr",
 ]
 islands = ["leptos/islands", "leptos_i18n_macro/islands"]

--- a/leptos_i18n/src/accept_language.rs
+++ b/leptos_i18n/src/accept_language.rs
@@ -1,0 +1,100 @@
+//! The locales the visitor prefers: the `Accept-Language` request header on
+//! the server, `navigator.languages` in the browser.
+
+use default_struct_builder::DefaultBuilder;
+use leptos::prelude::*;
+use std::sync::Arc;
+
+/// Options for reading the visitor's preferred locales.
+#[derive(DefaultBuilder)]
+pub struct UseLocalesOptions {
+    /// Returns the raw value of the `Accept-Language` request header on the server.
+    ///
+    /// The `axum` and `actix` features provide a default that reads the current
+    /// request; without them the default returns `None`.
+    #[cfg_attr(not(feature = "ssr"), allow(dead_code))]
+    ssr_lang_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,
+}
+
+impl Default for UseLocalesOptions {
+    fn default() -> Self {
+        Self {
+            ssr_lang_header_getter: Arc::new(|| {
+                #[cfg(feature = "ssr")]
+                {
+                    crate::server::request_header("accept-language")
+                }
+                #[cfg(not(feature = "ssr"))]
+                {
+                    None
+                }
+            }),
+        }
+    }
+}
+
+/// The visitor's preferred locales, most preferred first.
+///
+/// On the server the value is fixed for the request. In the browser it follows
+/// `navigator.languages` and updates on the `languagechange` event.
+pub(crate) fn accepted_locales(options: UseLocalesOptions) -> Signal<Vec<String>> {
+    #[cfg(feature = "ssr")]
+    {
+        let UseLocalesOptions {
+            ssr_lang_header_getter,
+        } = options;
+        Signal::stored(parse_accept_language(
+            &ssr_lang_header_getter().unwrap_or_default(),
+        ))
+    }
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = options;
+        let (locales, set_locales) = signal(navigator_languages());
+        let handle = window_event_listener_untyped("languagechange", move |_| {
+            set_locales.set(navigator_languages())
+        });
+        on_cleanup(move || handle.remove());
+        locales.into()
+    }
+}
+
+/// The language tags of an `Accept-Language` value in header order, without
+/// their quality weights.
+#[cfg(feature = "ssr")]
+fn parse_accept_language(header: &str) -> Vec<String> {
+    header
+        .split(',')
+        .map(|entry| {
+            entry
+                .split_once(';')
+                .map_or(entry, |(tag, _weight)| tag)
+                .trim()
+                .to_owned()
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "ssr"))]
+fn navigator_languages() -> Vec<String> {
+    window()
+        .navigator()
+        .languages()
+        .iter()
+        .filter_map(|language| language.as_string())
+        .collect()
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accept_language_keeps_header_order_without_weights() {
+        assert_eq!(
+            parse_accept_language("fr-CH, fr;q=0.9, en;q=0.8, *;q=0.5"),
+            ["fr-CH", "fr", "en", "*"]
+        );
+        assert_eq!(parse_accept_language(""), [""]);
+    }
+}

--- a/leptos_i18n/src/context.rs
+++ b/leptos_i18n/src/context.rs
@@ -1,6 +1,5 @@
 //! This module contains the `I18nContext` and helpers for it.
 
-use codee::string::FromToStringCodec;
 use core::marker::PhantomData;
 use leptos::{
     children,
@@ -8,16 +7,19 @@ use leptos::{
     tachys::{html::directive::IntoDirective, reactive_graph::OwnedView},
 };
 use leptos_meta::{Html, provide_meta_context};
-use leptos_use::UseCookieOptions;
 use std::borrow::Cow;
 
 use crate::{
     Scope,
+    cookie::use_locale_cookie,
     fetch_locale::{self, signal_maybe_once_then},
     locale_traits::*,
 };
 
-pub use leptos_use::UseLocalesOptions;
+pub use crate::{
+    accept_language::UseLocalesOptions,
+    cookie::{CookieOptions, SameSite},
+};
 
 #[cfg(feature = "unified_contexts")]
 #[derive(Debug, Clone, Copy)]
@@ -171,13 +173,6 @@ impl<L: Locale, S: Scope<L>> IntoDirective<(leptos::tachys::renderer::types::Ele
     }
 }
 
-/// Cookies options for functions initializing or providing a `I18nContext`
-pub type CookieOptions<L> = UseCookieOptions<
-    L,
-    <FromToStringCodec as codee::Encoder<L>>::Error,
-    <FromToStringCodec as codee::Decoder<L>>::Error,
->;
-
 pub(crate) const ENABLE_COOKIE: bool = cfg!(feature = "cookie");
 
 const COOKIE_PREFERED_LANG: &str = "i18n_pref_locale";
@@ -227,22 +222,19 @@ fn init_context_inner<L: Locale>(
 
 /// Options to init of provide a `I18nContext`
 #[derive(default_struct_builder::DefaultBuilder)]
-pub struct I18nContextOptions<'a, L>
-where
-    L: Locale,
-{
+pub struct I18nContextOptions<'a> {
     /// Should set a cookie to keep track of the locale when page reload (default to true) (do nothing without the "cookie" feature)
     pub enable_cookie: bool,
     /// Give a custom name to the cookie (default to the crate default value) (do nothing without the "cookie" feature or if `enable_cookie` is false)
     #[builder(into)]
     pub cookie_name: Cow<'a, str>,
-    /// Options for the cookie, the value is of type `leptos_use::UseCookieOptions<Locale>` (default to `Default::default`)
-    pub cookie_options: CookieOptions<L>,
-    /// Options to pass to `leptos_use::use_locales`.
+    /// Options for the cookie (default to `Default::default`)
+    pub cookie_options: CookieOptions,
+    /// Options for reading the visitor's preferred locales.
     pub ssr_lang_header_getter: UseLocalesOptions,
 }
 
-impl<L: Locale> Default for I18nContextOptions<'_, L> {
+impl Default for I18nContextOptions<'_> {
     fn default() -> Self {
         I18nContextOptions {
             enable_cookie: ENABLE_COOKIE,
@@ -255,7 +247,7 @@ impl<L: Locale> Default for I18nContextOptions<'_, L> {
 
 /// Same as `init_i18n_context` but with some cookies options.
 #[track_caller]
-pub fn init_i18n_context_with_options<L: Locale>(options: I18nContextOptions<L>) -> I18nContext<L> {
+pub fn init_i18n_context_with_options<L: Locale>(options: I18nContextOptions) -> I18nContext<L> {
     let I18nContextOptions {
         enable_cookie,
         cookie_name,
@@ -263,7 +255,7 @@ pub fn init_i18n_context_with_options<L: Locale>(options: I18nContextOptions<L>)
         ssr_lang_header_getter,
     } = options;
     let (lang_cookie, set_lang_cookie) = if ENABLE_COOKIE && enable_cookie {
-        leptos_use::use_cookie_with_options::<L, FromToStringCodec>(&cookie_name, cookie_options)
+        use_locale_cookie(&cookie_name, cookie_options)
     } else {
         let (lang_cookie, set_lang_cookie) = signal(None);
         (lang_cookie.into(), set_lang_cookie)
@@ -300,7 +292,7 @@ pub fn provide_i18n_context<L: Locale>() -> I18nContext<L> {
 #[doc(hidden)]
 #[track_caller]
 pub fn provide_i18n_context_with_options_inner<L: Locale>(
-    options: I18nContextOptions<L>,
+    options: I18nContextOptions,
 ) -> I18nContext<L> {
     provide_meta_context();
     I18nContext::from_context().unwrap_or_else(move || {
@@ -316,9 +308,7 @@ pub fn provide_i18n_context_with_options_inner<L: Locale>(
     note = "It is now preferred to use the <I18nContextProvider> component in the generated i18n module."
 )]
 #[track_caller]
-pub fn provide_i18n_context_with_options<L: Locale>(
-    options: I18nContextOptions<L>,
-) -> I18nContext<L> {
+pub fn provide_i18n_context_with_options<L: Locale>(options: I18nContextOptions) -> I18nContext<L> {
     provide_i18n_context_with_options_inner(options)
 }
 
@@ -330,14 +320,11 @@ pub fn provide_i18n_context_with_options<L: Locale>(
 fn init_subcontext_with_options<L: Locale>(
     initial_locale: Signal<Option<L>>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: CookieOptions<L>,
+    cookie_options: CookieOptions,
     ssr_lang_header_getter: Option<UseLocalesOptions>,
 ) -> I18nContext<L> {
     let (lang_cookie, set_lang_cookie) = match cookie_name {
-        Some(cookie_name) if ENABLE_COOKIE => leptos_use::use_cookie_with_options::<
-            L,
-            FromToStringCodec,
-        >(&cookie_name, cookie_options),
+        Some(cookie_name) if ENABLE_COOKIE => use_locale_cookie(&cookie_name, cookie_options),
         _ => {
             let (lang_cookie, set_lang_cookie) = signal(None);
             (lang_cookie.into(), set_lang_cookie)
@@ -388,7 +375,7 @@ fn derive_initial_locale_signal<L: Locale>(initial_locale: Option<Signal<L>>) ->
 pub fn init_i18n_subcontext_with_options<L: Locale>(
     initial_locale: Option<Signal<L>>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
+    cookie_options: Option<CookieOptions>,
     ssr_lang_header_getter: Option<UseLocalesOptions>,
 ) -> I18nContext<L> {
     let initial_locale = derive_initial_locale_signal(initial_locale);
@@ -453,7 +440,7 @@ pub fn i18n_sub_context_provider_inner<L: Locale, Chil: IntoView>(
     children: TypedChildren<Chil>,
     initial_locale: Option<Signal<L>>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
+    cookie_options: Option<CookieOptions>,
     ssr_lang_header_getter: Option<UseLocalesOptions>,
 ) -> impl IntoView {
     let ctx = init_i18n_subcontext_with_options::<L>(
@@ -533,7 +520,7 @@ fn provide_i18n_context_component_inner<L: Locale, Chil: IntoView>(
     set_dir_attr_on_html: Option<bool>,
     enable_cookie: Option<bool>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
+    cookie_options: Option<CookieOptions>,
     ssr_lang_header_getter: Option<UseLocalesOptions>,
     children: impl FnOnce() -> Chil,
 ) -> impl IntoView {
@@ -542,13 +529,13 @@ fn provide_i18n_context_component_inner<L: Locale, Chil: IntoView>(
     #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
     let reg_ctx = crate::fetch_translations::RegisterCtx::<L>::provide_context();
     let options = fill_options!(
-        I18nContextOptions::<L>::default(),
+        I18nContextOptions::default(),
         enable_cookie,
         cookie_name,
         cookie_options,
         ssr_lang_header_getter
     );
-    let i18n = provide_i18n_context_with_options_inner(options);
+    let i18n = provide_i18n_context_with_options_inner::<L>(options);
     let children = children();
     #[cfg(all(feature = "dynamic_load", feature = "ssr"))]
     let embed_translations = move || embed_translations_fn(reg_ctx.clone());
@@ -576,11 +563,11 @@ pub fn provide_i18n_context_component<L: Locale, Chil: IntoView>(
     set_dir_attr_on_html: Option<bool>,
     enable_cookie: Option<bool>,
     cookie_name: Option<Cow<str>>,
-    cookie_options: Option<CookieOptions<L>>,
+    cookie_options: Option<CookieOptions>,
     ssr_lang_header_getter: Option<UseLocalesOptions>,
     children: TypedChildren<Chil>,
 ) -> impl IntoView {
-    provide_i18n_context_component_inner(
+    provide_i18n_context_component_inner::<L, _>(
         set_lang_attr_on_html,
         set_dir_attr_on_html,
         enable_cookie,

--- a/leptos_i18n/src/cookie.rs
+++ b/leptos_i18n/src/cookie.rs
@@ -1,0 +1,241 @@
+//! The cookie that remembers the visitor's locale across page loads.
+
+use default_struct_builder::DefaultBuilder;
+use leptos::prelude::*;
+use std::sync::Arc;
+
+use crate::Locale;
+
+/// The [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
+/// attribute of the locale cookie.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SameSite {
+    /// The cookie is only sent with requests from the cookie's own site.
+    Strict,
+    /// The cookie is also sent when the visitor navigates to the site from elsewhere.
+    Lax,
+    /// The cookie is sent with every request, which browsers only allow with `Secure`.
+    None,
+}
+
+impl SameSite {
+    const fn as_str(self) -> &'static str {
+        match self {
+            SameSite::Strict => "Strict",
+            SameSite::Lax => "Lax",
+            SameSite::None => "None",
+        }
+    }
+}
+
+/// Options for the locale cookie.
+///
+/// By default the cookie lasts for the browser session and carries no
+/// `Domain`, `Path`, `SameSite`, `Secure` or `HttpOnly` attribute.
+#[derive(DefaultBuilder)]
+pub struct CookieOptions {
+    /// The [`Max-Age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#max-agenumber)
+    /// attribute in seconds. Default: `None`, the cookie lasts for the browser session.
+    #[builder(into)]
+    max_age: Option<i64>,
+    /// Whether to set the [`HttpOnly`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)
+    /// attribute. Default: `false`. A browser cannot read or write such a cookie,
+    /// so the locale then only reaches the client through the server-rendered page.
+    http_only: bool,
+    /// Whether to set the [`Secure`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure)
+    /// attribute. Default: `false`.
+    secure: bool,
+    /// The [`Domain`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value)
+    /// attribute. Default: `None`, the cookie applies to the current host only.
+    #[builder(into)]
+    domain: Option<String>,
+    /// The [`Path`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value)
+    /// attribute. Default: `None`, the browser derives it from the current URL.
+    #[builder(into)]
+    path: Option<String>,
+    /// The [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
+    /// attribute. Default: `None`, the attribute is not set.
+    #[builder(into)]
+    same_site: Option<SameSite>,
+    /// Returns the raw value of the `Cookie` request header on the server.
+    ///
+    /// The `axum` and `actix` features provide a default that reads the current
+    /// request; without them the default returns `None`.
+    #[cfg_attr(not(feature = "ssr"), allow(dead_code))]
+    ssr_cookies_header_getter: Arc<dyn Fn() -> Option<String> + Send + Sync>,
+    /// Appends a `Set-Cookie` header with the given value to the response on the server.
+    ///
+    /// The `axum` and `actix` features provide a default that writes to the
+    /// current response; without them the default does nothing.
+    #[cfg_attr(not(feature = "ssr"), allow(dead_code))]
+    ssr_set_cookie: Arc<dyn Fn(&str) + Send + Sync>,
+}
+
+impl Default for CookieOptions {
+    fn default() -> Self {
+        Self {
+            max_age: None,
+            http_only: false,
+            secure: false,
+            domain: None,
+            path: None,
+            same_site: None,
+            ssr_cookies_header_getter: Arc::new(|| {
+                #[cfg(feature = "ssr")]
+                {
+                    crate::server::request_header("cookie")
+                }
+                #[cfg(not(feature = "ssr"))]
+                {
+                    None
+                }
+            }),
+            ssr_set_cookie: Arc::new(|header| {
+                #[cfg(feature = "ssr")]
+                {
+                    crate::server::append_set_cookie(header);
+                }
+                #[cfg(not(feature = "ssr"))]
+                {
+                    let _ = header;
+                }
+            }),
+        }
+    }
+}
+
+/// The locale stored in the cookie `name`, and a writer that keeps the cookie
+/// in sync with the locale written to it.
+///
+/// On the server the cookie the request carried is sent back through a
+/// `Set-Cookie` response header, so a `max_age` counts from the last render;
+/// the locale resolved for a first visit is stored by the browser after
+/// hydration. In the browser the cookie is written through `document.cookie`
+/// after every change.
+pub(crate) fn use_locale_cookie<L: Locale>(
+    name: &str,
+    options: CookieOptions,
+) -> (Signal<Option<L>>, WriteSignal<Option<L>>) {
+    let name = name.to_owned();
+    let initial = read_cookie(&name, &options).and_then(|value| L::from_str(&value).ok());
+
+    #[cfg(feature = "ssr")]
+    if let Some(locale) = &initial {
+        write_cookie(&name, Some(locale.as_str()), &options);
+    }
+
+    let (cookie, set_cookie) = signal(initial);
+
+    #[cfg(not(feature = "ssr"))]
+    Effect::new(move |_| {
+        let value = cookie.get().map(|locale| locale.as_str());
+        if read_cookie(&name, &options).as_deref() != value {
+            write_cookie(&name, value, &options);
+        }
+    });
+
+    (cookie.into(), set_cookie)
+}
+
+/// The raw value of the cookie `name`, from the request on the server and
+/// from `document.cookie` in the browser.
+fn read_cookie(name: &str, options: &CookieOptions) -> Option<String> {
+    #[cfg(feature = "ssr")]
+    let header = (options.ssr_cookies_header_getter)();
+    #[cfg(not(feature = "ssr"))]
+    let header = {
+        let _ = options;
+        html_document().cookie().ok()
+    };
+    cookie_value(&header?, name)
+}
+
+/// The value of the cookie `name` in a `Cookie` header or `document.cookie` string.
+fn cookie_value(header: &str, name: &str) -> Option<String> {
+    header
+        .split(';')
+        .filter_map(|pair| pair.trim().split_once('='))
+        .find(|(key, _value)| *key == name)
+        .map(|(_key, value)| value.to_owned())
+}
+
+fn write_cookie(name: &str, value: Option<&str>, options: &CookieOptions) {
+    let header = set_cookie_header(name, value, options);
+    #[cfg(feature = "ssr")]
+    (options.ssr_set_cookie)(&header);
+    #[cfg(not(feature = "ssr"))]
+    {
+        let _ = html_document().set_cookie(&header);
+    }
+}
+
+/// The `Set-Cookie` value that stores `value` in the cookie `name`, or
+/// expires the cookie when `value` is `None`.
+fn set_cookie_header(name: &str, value: Option<&str>, options: &CookieOptions) -> String {
+    let mut header = format!("{name}={}", value.unwrap_or_default());
+    match (value, options.max_age) {
+        (None, _) => header.push_str("; Max-Age=0"),
+        (Some(_), Some(max_age)) => header.push_str(&format!("; Max-Age={max_age}")),
+        (Some(_), None) => {}
+    }
+    if let Some(domain) = &options.domain {
+        header.push_str(&format!("; Domain={domain}"));
+    }
+    if let Some(path) = &options.path {
+        header.push_str(&format!("; Path={path}"));
+    }
+    if let Some(same_site) = options.same_site {
+        header.push_str(&format!("; SameSite={}", same_site.as_str()));
+    }
+    if options.secure {
+        header.push_str("; Secure");
+    }
+    if options.http_only {
+        header.push_str("; HttpOnly");
+    }
+    header
+}
+
+#[cfg(not(feature = "ssr"))]
+fn html_document() -> web_sys::HtmlDocument {
+    use wasm_bindgen::JsCast;
+    document().unchecked_into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_cookie_header_carries_every_configured_attribute() {
+        let options = CookieOptions::default()
+            .max_age(3600)
+            .domain("example.com")
+            .path("/")
+            .same_site(SameSite::Lax)
+            .secure(true)
+            .http_only(true);
+        assert_eq!(
+            set_cookie_header("locale", Some("fr"), &options),
+            "locale=fr; Max-Age=3600; Domain=example.com; Path=/; SameSite=Lax; Secure; HttpOnly"
+        );
+    }
+
+    #[test]
+    fn set_cookie_header_expires_a_removed_cookie() {
+        let options = CookieOptions::default().max_age(3600).path("/");
+        assert_eq!(
+            set_cookie_header("locale", None, &options),
+            "locale=; Max-Age=0; Path=/"
+        );
+    }
+
+    #[test]
+    fn cookie_value_finds_the_named_pair_among_others() {
+        let header = " theme=dark; locale=fr ;token=a=b";
+        assert_eq!(cookie_value(header, "locale").as_deref(), Some("fr"));
+        assert_eq!(cookie_value(header, "token").as_deref(), Some("a=b"));
+        assert_eq!(cookie_value(header, "missing"), None);
+        assert_eq!(cookie_value("", "locale"), None);
+    }
+}

--- a/leptos_i18n/src/fetch_locale.rs
+++ b/leptos_i18n/src/fetch_locale.rs
@@ -1,10 +1,12 @@
 use leptos::prelude::*;
-use leptos_use::UseLocalesOptions;
 
-use crate::Locale;
+use crate::{
+    Locale,
+    accept_language::{UseLocalesOptions, accepted_locales},
+};
 
 pub fn fetch_locale<L: Locale>(current_cookie: Option<L>, options: UseLocalesOptions) -> Memo<L> {
-    let accepted_locales = leptos_use::use_locales_with_options(options);
+    let accepted_locales = accepted_locales(options);
     let accepted_locale =
         Memo::new(move |_| accepted_locales.with(|accepted| L::find_locale(accepted)));
 
@@ -18,8 +20,7 @@ pub fn fetch_locale<L: Locale>(current_cookie: Option<L>, options: UseLocalesOpt
 }
 
 pub fn get_accepted_locale<L: Locale>(options: UseLocalesOptions) -> L {
-    leptos_use::use_locales_with_options(options)
-        .with_untracked(|accepted| L::find_locale(accepted))
+    accepted_locales(options).with_untracked(|accepted| L::find_locale(accepted))
 }
 
 pub fn resolve_locale<L: Locale>(current_cookie: Option<L>, options: UseLocalesOptions) -> L {

--- a/leptos_i18n/src/lib.rs
+++ b/leptos_i18n/src/lib.rs
@@ -116,7 +116,9 @@
 //! }
 //! ```
 
+mod accept_language;
 pub mod context;
+mod cookie;
 pub mod display;
 mod fetch_locale;
 mod fetch_translations;
@@ -126,6 +128,8 @@ mod locale_traits;
 mod macro_helpers;
 mod macros;
 mod scopes;
+#[cfg(feature = "ssr")]
+mod server;
 
 pub use macro_helpers::formatting;
 

--- a/leptos_i18n/src/locale.rs
+++ b/leptos_i18n/src/locale.rs
@@ -1,16 +1,16 @@
 //! Contain utilities for locales
 
-use codee::string::FromToStringCodec;
 use leptos::prelude::*;
 
 use crate::{
     Locale,
     context::{ENABLE_COOKIE, I18nContextOptions},
+    cookie::use_locale_cookie,
     fetch_locale,
 };
 
 /// Same as `resolve_locale` but with some cookies options.
-pub fn resolve_locale_with_options<L: Locale>(options: I18nContextOptions<L>) -> L {
+pub fn resolve_locale_with_options<L: Locale>(options: I18nContextOptions) -> L {
     let I18nContextOptions {
         enable_cookie,
         cookie_name,
@@ -18,7 +18,7 @@ pub fn resolve_locale_with_options<L: Locale>(options: I18nContextOptions<L>) ->
         ssr_lang_header_getter,
     } = options;
     let (lang_cookie, _) = if ENABLE_COOKIE && enable_cookie {
-        leptos_use::use_cookie_with_options::<L, FromToStringCodec>(&cookie_name, cookie_options)
+        use_locale_cookie(&cookie_name, cookie_options)
     } else {
         let (lang_cookie, set_lang_cookie) = signal(None);
         (lang_cookie.into(), set_lang_cookie)

--- a/leptos_i18n/src/server.rs
+++ b/leptos_i18n/src/server.rs
@@ -1,0 +1,67 @@
+//! Access to the current request and response on the server.
+//!
+//! The server integrations expose both through the reactive context; the
+//! `axum` and `actix` features select which one is read.
+
+#[cfg(all(feature = "axum", feature = "actix"))]
+compile_error!("only one of the features \"axum\" and \"actix\" can be enabled at a time");
+
+/// The value of the request header `name`, when the enabled integration
+/// provides the current request in the reactive context and the value is ASCII.
+pub(crate) fn request_header(name: &str) -> Option<String> {
+    #[cfg(feature = "axum")]
+    {
+        leptos::prelude::use_context::<http::request::Parts>()
+            .and_then(|parts| parts.headers.get(name)?.to_str().ok().map(str::to_owned))
+    }
+    #[cfg(feature = "actix")]
+    {
+        leptos::prelude::use_context::<leptos_actix::Request>().and_then(|request| {
+            request
+                .headers()
+                .get(name)?
+                .to_str()
+                .ok()
+                .map(str::to_owned)
+        })
+    }
+    #[cfg(not(any(feature = "axum", feature = "actix")))]
+    {
+        leptos::logging::warn!(
+            "leptos_i18n cannot read the `{name}` request header: enable the `axum` or `actix` \
+             feature, or provide the value through the context options"
+        );
+        None
+    }
+}
+
+/// Appends a `Set-Cookie` header with the given value to the current response,
+/// when the enabled integration provides the response options in the reactive context.
+pub(crate) fn append_set_cookie(header: &str) {
+    #[cfg(feature = "axum")]
+    {
+        if let (Some(response), Ok(value)) = (
+            leptos::prelude::use_context::<leptos_axum::ResponseOptions>(),
+            http::HeaderValue::from_str(header),
+        ) {
+            response.append_header(http::header::SET_COOKIE, value);
+        }
+    }
+    #[cfg(feature = "actix")]
+    {
+        use actix_web::http::header::{HeaderValue, SET_COOKIE};
+        if let (Some(response), Ok(value)) = (
+            leptos::prelude::use_context::<leptos_actix::ResponseOptions>(),
+            HeaderValue::from_str(header),
+        ) {
+            response.append_header(SET_COOKIE, value);
+        }
+    }
+    #[cfg(not(any(feature = "axum", feature = "actix")))]
+    {
+        leptos::logging::warn!(
+            "leptos_i18n cannot set the locale cookie `{header}`: enable the `axum` or `actix` \
+             feature, or provide `ssr_set_cookie` through the cookie options"
+        );
+    }
+}

--- a/leptos_i18n_codegen/src/load_locales/mod.rs
+++ b/leptos_i18n_codegen/src/load_locales/mod.rs
@@ -177,10 +177,10 @@ pub fn load_locales(
                 /// Specify a name for the cookie, default to the library default.
                 #[prop(optional, into)]
                 cookie_name: Option<Cow<'static, str>>,
-                /// Options for the cookie, see `leptos_use::UseCookieOptions`.
+                /// Options for the cookie, see `leptos_i18n::context::CookieOptions`.
                 #[prop(optional)]
-                cookie_options: Option<CookieOptions<#enum_ident>>,
-                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                cookie_options: Option<CookieOptions>,
+                /// Options for reading the visitor's preferred locales, see `leptos_i18n::context::UseLocalesOptions`.
                 #[prop(optional)]
                 ssr_lang_header_getter: Option<UseLocalesOptions>,
                 children: TypedChildren<Chil>
@@ -210,10 +210,10 @@ pub fn load_locales(
                 /// If set save the locale in a cookie of the given name (does nothing without the `cookie` feature).
                 #[prop(optional, into)]
                 cookie_name: Option<Cow<'static, str>>,
-                /// Options for the cookie, see `leptos_use::UseCookieOptions`.
+                /// Options for the cookie, see `leptos_i18n::context::CookieOptions`.
                 #[prop(optional)]
-                cookie_options: Option<CookieOptions<#enum_ident>>,
-                /// Options for getting the Accept-Language header, see `leptos_use::UseLocalesOptions`.
+                cookie_options: Option<CookieOptions>,
+                /// Options for reading the visitor's preferred locales, see `leptos_i18n::context::UseLocalesOptions`.
                 #[prop(optional)]
                 ssr_lang_header_getter: Option<UseLocalesOptions>,
             ) -> impl IntoView {


### PR DESCRIPTION
… handling

leptos_i18n only used leptos-use for use_cookie and use_locales, which pulled leptos-use, codee, cookie and lazy_static into every consumer. Three small modules now cover the same ground: reading Accept-Language on the server and navigator.languages in the browser, reading and writing the locale cookie, and accessing the axum or actix request and response.

fix #336